### PR TITLE
feat(create): collapse history pagination to a single opaque cursor

### DIFF
--- a/apps/web/src/app/admin/create/attach-drafts/page.tsx
+++ b/apps/web/src/app/admin/create/attach-drafts/page.tsx
@@ -37,8 +37,7 @@ export default function AdminCreateAttachDraftsPage() {
   const [decisionError, setDecisionError] = useState<string | null>(null);
   const [applyError, setApplyError] = useState<string | null>(null);
   const [historyHasMoreByDraft, setHistoryHasMoreByDraft] = useState<Record<string, boolean>>({});
-  const [historyNextCursorByDraft, setHistoryNextCursorByDraft] = useState<Record<string, string | null>>({});
-  const [historyNextScanCursorByDraft, setHistoryNextScanCursorByDraft] = useState<Record<string, string | null>>({});
+  const [historyCursorByDraft, setHistoryCursorByDraft] = useState<Record<string, string | null>>({});
   const [historyErrorByDraft, setHistoryErrorByDraft] = useState<Record<string, string | null>>({});
 
   useEffect(() => {
@@ -68,17 +67,10 @@ export default function AdminCreateAttachDraftsPage() {
           }
           return next;
         });
-        setHistoryNextCursorByDraft((prev) => {
+        setHistoryCursorByDraft((prev) => {
           const next = { ...prev };
           for (const item of loaded) {
             next[item.draftId] = item.historyNextCursor ?? null;
-          }
-          return next;
-        });
-        setHistoryNextScanCursorByDraft((prev) => {
-          const next = { ...prev };
-          for (const item of loaded) {
-            next[item.draftId] = null;
           }
           return next;
         });
@@ -182,7 +174,7 @@ export default function AdminCreateAttachDraftsPage() {
 
   async function handleLoadMoreHistory(draftId: string) {
     if (historyLoadingDraftId) return;
-    const cursor = historyNextScanCursorByDraft[draftId] ?? historyNextCursorByDraft[draftId] ?? null;
+    const cursor = historyCursorByDraft[draftId] ?? null;
     if (!cursor && !historyHasMoreByDraft[draftId]) return;
     setHistoryLoadingDraftId(draftId);
     setHistoryErrorByDraft((prev) => ({ ...prev, [draftId]: null }));
@@ -222,8 +214,7 @@ export default function AdminCreateAttachDraftsPage() {
         }),
       );
       setHistoryHasMoreByDraft((prev) => ({ ...prev, [draftId]: !!body.hasMore }));
-      setHistoryNextCursorByDraft((prev) => ({ ...prev, [draftId]: body.nextCursor ?? null }));
-      setHistoryNextScanCursorByDraft((prev) => ({ ...prev, [draftId]: body.nextScanCursor ?? null }));
+      setHistoryCursorByDraft((prev) => ({ ...prev, [draftId]: body.nextCursor ?? null }));
     } catch (historyErr: unknown) {
       setHistoryErrorByDraft((prev) => ({
         ...prev,

--- a/apps/web/src/app/api/admin/create/attach-drafts/[draftId]/history/route.ts
+++ b/apps/web/src/app/api/admin/create/attach-drafts/[draftId]/history/route.ts
@@ -36,7 +36,6 @@ export async function GET(
       applyEvents: result.applyEvents,
       hasMore: result.hasMore,
       nextCursor: result.nextCursor,
-      nextScanCursor: result.nextScanCursor,
       type: result.type,
       limit: result.limit,
     });

--- a/apps/web/src/features/create/attachDraftReviewQueue.ts
+++ b/apps/web/src/features/create/attachDraftReviewQueue.ts
@@ -66,13 +66,19 @@ type CreatePrepareAttachDraftHistoryPage = {
   applyEvents: CreatePrepareAttachApplyHistoryEvent[];
   hasMore: boolean;
   nextCursor: string | null;
-  nextScanCursor: string | null;
+};
+
+type HistoryCursorPoint = {
+  createdAt: string;
+  oid: string;
 };
 
 type HistoryCursorPayload = {
+  v: 2;
   draftId: string;
-  createdAt: string;
-  oid: string;
+  type: CreatePrepareAttachHistoryType;
+  accepted: HistoryCursorPoint | null;
+  scan: HistoryCursorPoint | null;
 };
 
 export async function listCreatePrepareAttachDraftQueue(params: {
@@ -113,7 +119,6 @@ export async function listCreatePrepareAttachDraftQueue(params: {
         applyEvents: [],
         hasMore: false,
         nextCursor: null,
-        nextScanCursor: null,
       };
       return {
         ...item,
@@ -172,7 +177,6 @@ export async function getCreatePrepareAttachDraftHistory(params: {
     applyEvents: page.applyEvents,
     hasMore: page.hasMore,
     nextCursor: page.nextCursor,
-    nextScanCursor: page.nextScanCursor,
     cursor: params.cursor ?? null,
     type,
     limit,
@@ -328,7 +332,6 @@ async function loadCreatePrepareAttachDraftHistory(params: {
       applyEvents: [],
       hasMore: false,
       nextCursor: null,
-      nextScanCursor: null,
     });
   }
   if (ids.length === 0) return map;
@@ -369,12 +372,16 @@ export async function getCreatePrepareAttachDraftHistoryPage(params: {
   const History = await createPrepareAttachHistoryEventsCol();
   const type = normalizeHistoryType(params.type);
   const limit = Math.max(1, Math.min(100, Number(params.limit) || 20));
-  let scanCursor = decodeHistoryCursor(params.cursor ?? null, params.draftId);
-  const accepted: Array<{ event: CreatePrepareAttachDraftHistoryEvent; cursor: HistoryCursorPayload }> = [];
+  const decodedCursor = decodeHistoryCursor(params.cursor ?? null, {
+    expectedDraftId: params.draftId,
+    expectedType: type,
+  });
+  let scanCursor = decodedCursor?.scan ?? decodedCursor?.accepted ?? null;
+  const accepted: Array<{ event: CreatePrepareAttachDraftHistoryEvent; cursor: HistoryCursorPoint }> = [];
   const batchSize = Math.max(20, Math.min(120, limit * 2));
   let exhausted = false;
   let safetyRuns = 0;
-  let lastScannedCursor: HistoryCursorPayload | null = null;
+  let lastScannedCursor: HistoryCursorPoint | null = null;
 
   while (accepted.length < limit + 1 && !exhausted && safetyRuns < 24) {
     safetyRuns += 1;
@@ -413,11 +420,18 @@ export async function getCreatePrepareAttachDraftHistoryPage(params: {
   const reviewEvents = events.filter((event): event is CreatePrepareAttachReviewHistoryEvent => event.eventType === "review");
   const applyEvents = events.filter((event): event is CreatePrepareAttachApplyHistoryEvent => event.eventType === "apply");
   const hasMore = accepted.length > limit;
+  const acceptedCursorForNextPage = pageAccepted[pageAccepted.length - 1]?.cursor ?? null;
+  const scanCursorForNextPage = lastScannedCursor ?? acceptedCursorForNextPage;
   const nextCursor =
-    hasMore && pageAccepted.length > 0
-      ? encodeHistoryCursor(pageAccepted[pageAccepted.length - 1]?.cursor ?? null)
+    hasMore && acceptedCursorForNextPage
+      ? encodeHistoryCursor({
+          v: 2,
+          draftId: params.draftId,
+          type,
+          accepted: acceptedCursorForNextPage,
+          scan: scanCursorForNextPage,
+        })
       : null;
-  const nextScanCursor = hasMore ? encodeHistoryCursor(lastScannedCursor) : null;
 
   return {
     events,
@@ -425,7 +439,6 @@ export async function getCreatePrepareAttachDraftHistoryPage(params: {
     applyEvents,
     hasMore,
     nextCursor,
-    nextScanCursor,
   };
 }
 
@@ -526,7 +539,7 @@ function normalizeHistoryDoc(
 function buildHistoryRawFilter(params: {
   draftId: string;
   type: CreatePrepareAttachHistoryType;
-  cursor: HistoryCursorPayload | null;
+  cursor: HistoryCursorPoint | null;
 }) {
   const clauses: Record<string, unknown>[] = [{ draftId: params.draftId }];
   if (params.type === "review") {
@@ -618,7 +631,7 @@ function normalizeEventTimestamp(raw: Record<string, unknown>, ...values: unknow
   return "1970-01-01T00:00:00.000Z";
 }
 
-function getRowCursor(row: CreatePrepareAttachDraftHistoryEventDoc, draftId: string): HistoryCursorPayload | null {
+function getRowCursor(row: CreatePrepareAttachDraftHistoryEventDoc, draftId: string): HistoryCursorPoint | null {
   const raw = row as Record<string, unknown>;
   const createdAt = normalizeEventTimestamp(raw, raw.createdAt, raw.reviewedAt, raw.appliedAt, raw.updatedAt);
   const objectId = parseObjectIdLike(raw._id);
@@ -628,16 +641,20 @@ function getRowCursor(row: CreatePrepareAttachDraftHistoryEventDoc, draftId: str
       `${draftId}|${createdAt}|${String(raw.eventId || "")}|${String(raw.actorUserId || raw.reviewedBy || raw.appliedBy || "")}`,
     );
   if (!ObjectId.isValid(oid)) return null;
-  return { draftId, createdAt, oid };
+  return { createdAt, oid };
 }
 
 function encodeHistoryCursor(payload: HistoryCursorPayload | null) {
   if (!payload) return null;
+  if (!payload.accepted && !payload.scan) return null;
   const raw = JSON.stringify(payload);
   return toBase64Url(raw);
 }
 
-function decodeHistoryCursor(value: string | null, expectedDraftId: string): HistoryCursorPayload | null {
+function decodeHistoryCursor(
+  value: string | null,
+  options: { expectedDraftId: string; expectedType: CreatePrepareAttachHistoryType },
+): HistoryCursorPayload | null {
   if (!value) return null;
   let parsed: unknown;
   try {
@@ -646,20 +663,54 @@ function decodeHistoryCursor(value: string | null, expectedDraftId: string): His
     throw new Error("invalid_history_cursor");
   }
   const obj = parsed as Record<string, unknown>;
-  const draftId = String(obj.draftId || "").trim();
-  const createdAt = String(obj.createdAt || "").trim();
-  const oid = String(obj.oid || "").trim();
+  const version = Number(obj.v || 0);
+  if (version === 2) {
+    const draftId = String(obj.draftId || "").trim();
+    const type = String(obj.type || "").trim();
+    if (!draftId || draftId !== options.expectedDraftId || type !== options.expectedType) {
+      throw new Error("invalid_history_cursor");
+    }
+    const accepted = parseHistoryCursorPoint(obj.accepted);
+    const scan = parseHistoryCursorPoint(obj.scan);
+    if (!accepted && !scan) {
+      throw new Error("invalid_history_cursor");
+    }
+    return {
+      v: 2,
+      draftId,
+      type: options.expectedType,
+      accepted,
+      scan,
+    };
+  }
+
+  // Legacy cursor compatibility: old payload had only draft + position and was effectively "all".
+  const legacyDraftId = String(obj.draftId || "").trim();
+  const legacyPoint = parseHistoryCursorPoint(obj);
   if (
-    !draftId ||
-    draftId !== expectedDraftId ||
-    !createdAt ||
-    Number.isNaN(Date.parse(createdAt)) ||
-    !ObjectId.isValid(oid)
+    !legacyDraftId ||
+    legacyDraftId !== options.expectedDraftId ||
+    options.expectedType !== "all" ||
+    !legacyPoint
   ) {
     throw new Error("invalid_history_cursor");
   }
   return {
-    draftId,
+    v: 2,
+    draftId: legacyDraftId,
+    type: "all",
+    accepted: legacyPoint,
+    scan: legacyPoint,
+  };
+}
+
+function parseHistoryCursorPoint(value: unknown): HistoryCursorPoint | null {
+  if (!value || typeof value !== "object") return null;
+  const obj = value as Record<string, unknown>;
+  const createdAt = String(obj.createdAt || "").trim();
+  const oid = String(obj.oid || "").trim();
+  if (!createdAt || Number.isNaN(Date.parse(createdAt)) || !ObjectId.isValid(oid)) return null;
+  return {
     createdAt,
     oid: new ObjectId(oid).toHexString(),
   };

--- a/apps/web/tests/create-prepare-attach.history-route.test.ts
+++ b/apps/web/tests/create-prepare-attach.history-route.test.ts
@@ -64,7 +64,6 @@ describe("create prepare-attach history route", () => {
       applyEvents: [],
       hasMore: true,
       nextCursor: "cursor-2",
-      nextScanCursor: "scan-2",
       type: "all",
       limit: 20,
     });
@@ -75,16 +74,17 @@ describe("create prepare-attach history route", () => {
     );
 
     expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toMatchObject({
+    const body = await res.json();
+    expect(body).toMatchObject({
       ok: true,
       draft: { draftId: "65f000000000000000000011", version: 3 },
       latestEvent: { eventId: "r1" },
       hasMore: true,
       nextCursor: "cursor-2",
-      nextScanCursor: "scan-2",
       type: "all",
       limit: 20,
     });
+    expect(body.nextScanCursor).toBeUndefined();
   });
 
   it("maps invalid id / not found / forbidden", async () => {

--- a/apps/web/tests/create-prepare-attach.review-history.service.test.ts
+++ b/apps/web/tests/create-prepare-attach.review-history.service.test.ts
@@ -429,7 +429,7 @@ describe("create prepare-attach review/apply history service", () => {
     expect(page1.events).toHaveLength(2);
     expect(page1.hasMore).toBe(true);
     expect(page1.nextCursor).toBeTruthy();
-    expect(page1.nextScanCursor).toBeTruthy();
+    expect((page1 as Record<string, unknown>).nextScanCursor).toBeUndefined();
 
     const page2 = await getCreatePrepareAttachDraftHistory({
       actor: actor as any,
@@ -619,6 +619,51 @@ describe("create prepare-attach review/apply history service", () => {
         draftId: draftIdB,
         type: "all",
         limit: 1,
+        cursor: first.nextCursor,
+      }),
+    ).rejects.toThrow("invalid_history_cursor");
+  });
+
+  it("rejects cursors that are reused with another history type filter", async () => {
+    const draftId = seedDraft({ version: 1 });
+    for (let i = 0; i < 4; i += 1) {
+      mocks.seedHistoryEvent({
+        _id: new ObjectId(`65f0000000000000000004${(10 + i).toString().padStart(2, "0")}`),
+        schemaVersion: "create_prepare_attach_history.v1",
+        eventType: i % 2 === 0 ? "review" : "apply",
+        eventId: `mix-${i}`,
+        draftId,
+        actorUserId: "u-review",
+        previousReviewState: "pending",
+        nextReviewState: "accepted_for_apply",
+        previousApplyState: "not_applied",
+        nextApplyState: i % 2 === 0 ? "not_applied" : "applied",
+        reviewNote: i % 2 === 0 ? `review-${i}` : null,
+        result: i % 2 === 1 ? "applied" : undefined,
+        targetType: i % 2 === 1 ? "claim" : undefined,
+        targetId: i % 2 === 1 ? "claim-1" : undefined,
+        applyNote: null,
+        mutationType: i % 2 === 1 ? "attach_reference_claim" : undefined,
+        errorCode: null,
+        resultCode: i % 2 === 1 ? "apply_success" : "review_state_changed",
+        createdAt: `2026-03-20T17:${String(10 + i).padStart(2, "0")}:00.000Z`,
+      });
+    }
+
+    const first = await getCreatePrepareAttachDraftHistory({
+      actor: actor as any,
+      draftId,
+      type: "all",
+      limit: 2,
+    });
+    expect(first.nextCursor).toBeTruthy();
+
+    await expect(
+      getCreatePrepareAttachDraftHistory({
+        actor: actor as any,
+        draftId,
+        type: "review",
+        limit: 2,
         cursor: first.nextCursor,
       }),
     ).rejects.toThrow("invalid_history_cursor");

--- a/docs/E150/OpenTasks.md
+++ b/docs/E150/OpenTasks.md
@@ -5,7 +5,7 @@
 Diese Datei ist der kanonische Aufgabenstand fuer E150.
 Wenn andere Parts, alte Drift-Prompts oder Zwischen-Notizen abweichen, gewinnt diese Datei.
 
-Stand: 2026-03-20
+Stand: 2026-03-21
 
 ## Leitbild
 
@@ -132,6 +132,7 @@ Status: **Open (Architecture alignment required / 2026-03-20)**
 | Task | Status | Naechster Run | Evidenz/Notiz |
 | --- | --- | --- | --- |
 | PR-AI-CREATE-01 `/create` auf kanonischen Orchestrierungsfluss harmonisieren | In Progress (implementation baseline active / 2026-03-20) | GOV-AI-02 | Freistart-Entry ohne primaeren Modus-Split aktiv; `/api/contributions/analyze` liefert typed `createAnalyze`-Envelope (intake/quality/graph_matching/cta_suggestions, matchType/matchEntityType, noAutoPublish/noSilentMerge); `AnalyzeWorkspace` zeigt Input-Typ/Qualitaet/Matches/CTAs; Parser akzeptiert `preparedText`-Alias; Tests: `apps/web/tests/create-analyze.contract.test.ts`, `apps/web/tests/create-analyze.route.test.ts`, `apps/web/tests/create-mode.page.test.ts`, `apps/web/tests/create-mode.analyze-parse.test.ts` |
+| PR-AI-MATCH-11 Single Opaque History Cursor + lazy queue cleanup | Done (contract/UX polish active / 2026-03-21) | Monitoring/Polish | Produktiver History-Read-Contract fuer Prepare-Attach ist auf einen einzelnen opaquen Cursor reduziert: `GET /api/admin/create/attach-drafts/[draftId]/history` liefert `nextCursor` (kein `nextScanCursor` mehr). Interner Cursor bleibt robust (Scan+Accepted-Position im Payload, draft-/type-gebunden, `invalid_history_cursor` bei Mismatch). Queue-UI nutzt pro Draft nur noch einen Cursor-State fuer lazy "Mehr Verlauf laden". Legacy-Read-Normalisierung bleibt unveraendert aktiv (`normalizedFromLegacy`, `legacyNormalizationReason`); keine neue Auto-Mutation. |
 | Create IA v2: dedizierte Mode-Module (`manual/source/ai`) statt nur Workspace-Parametrisierung | Superseded (legacy intermediate state, no longer target architecture) | GOV-AI-01 | `manual/source/ai` bleibt nur als Legacy-Kompatibilitaets-/Migrationsschicht aktiv (inkl. Alias-Normalisierung + Persistenz), ist aber nicht mehr der kanonische Produktpfad; kanonisch: Freistart + verpflichtende Qualitaetsschicht + Graph-Matching + CTA-Layer |
 | Runden Entry Surface auf produktive Quelle umstellen (statt Seed aus `features/topicRound/data.ts`) | Done (productive source + compatibility matrix active / 2026-03-19) | PR-0039 | `/runden` liest aus produktivem `output_seed`/`anlassraum`-Read-Model (`features/topicRound/entrySource.ts`, `GET /api/runden/entry`); `/demo/runden` ist expliziter Compat-Redirect auf `/runden` (kein Seed-Fallback), inkl. Tests `apps/web/tests/runden-entry.*`, `apps/web/tests/runden-compat.*`, `apps/web/tests/runden-page.acceptance.test.ts` |
 | Backward-Compatibility finalisieren | Done (legacy/demo round entry clarified / 2026-03-19) | PR-0039 | Canonical Round-Entry = `/runden`; alte Demo-Pfade zeigen explizit auf produktiven Einstieg (`apps/web/src/app/demo/runden/page.tsx`, `apps/web/src/app/demo/page.tsx`, `apps/web/src/app/demo/DemoNavClient.tsx`) |
@@ -152,6 +153,39 @@ Status: **Open (Architecture alignment required / 2026-03-20)**
 | Account Dark-Mode Nacharbeit | Open | PR-0047 | Components/Token-Check |
 | Env-Key-Hardening abschliessen | Open | PR-ENV-01 | Runtime-Aliasse |
 | Mongo SRV `ECONNREFUSED` robust abfedern | Open | PR-ENV-02 | DNS/Netz/Config-Fallback |
+
+### Create Prepare-Attach History Contract (Single Opaque Cursor / 2026-03-21)
+
+Produktiver Read-Contract:
+- Endpoint: `GET /api/admin/create/attach-drafts/[draftId]/history`
+- Query:
+  - `type=all|review|apply`
+  - `limit`
+  - `cursor` (opaque)
+- Response:
+  - `events`, `reviewEvents`, `applyEvents`, `latestEvent`
+  - `hasMore`, `nextCursor`
+  - `type`, `limit`, `draft`
+
+Contract-Polish:
+- Extern wird nur noch ein Cursor ausgegeben (`nextCursor`).
+- `nextScanCursor` ist nicht mehr Teil des oeffentlichen API-Contracts.
+- Intern darf der Cursor weiterhin robuste Scan-Semantik tragen (accepted/scan/tie-break), bleibt fuer Clients aber opaque.
+- Cursor sind draft- und filter-gebunden (`type`); Mismatch wird mit `invalid_history_cursor` abgelehnt.
+
+Read-/Legacy-Verhalten:
+- deterministische Sortierung bleibt erhalten (`createdAt` desc, `_id` als tie-break)
+- Legacy-Rows werden weiterhin read-time defensiv normalisiert:
+  - `normalizedFromLegacy`
+  - `legacyNormalizationReason`
+
+Guardrails unveraendert:
+- kein Auto-Apply
+- kein Auto-Merge
+- kein Auto-Publish
+- keine neue Produkt-Mutation
+- Review/Apply bleiben getrennt
+- Stage-2/Stage-3 bleiben unberuehrt
 
 ## Neue Architektur-Tasks (V1 dauerhaft verankert)
 

--- a/docs/E150/Part15.md
+++ b/docs/E150/Part15.md
@@ -1,6 +1,6 @@
 # E150 Master Spec – Part 15: Offene Pfade & Restarbeiten
 
-> Status-Hinweis (2026-03-20): Dieses Part ist eine Spezifikation/Zusammenfassung. Der verbindliche Aufgabenstand liegt in `docs/E150/OpenTasks.md`. Keine neuen Runs aus diesem Part ableiten.
+> Status-Hinweis (2026-03-21): Dieses Part ist eine Spezifikation/Zusammenfassung. Der verbindliche Aufgabenstand liegt in `docs/E150/OpenTasks.md`. Keine neuen Runs aus diesem Part ableiten.
 
 
 ## Zweck
@@ -35,6 +35,21 @@ Dieses Dokument dient als Status-Zusammenfassung der Pfade (Part00–Part15). Es
 - Guardrails unveraendert:
   no auto publish, no silent merge, review-first, approval-first, manual-first.
 - Stage-2/Stage-3 (Self-Host/Souveraenisierung) bleiben unberuehrt und hard-deferred.
+
+## Update (2026-03-21) — PR-AI-MATCH-11 Single Opaque History Cursor
+
+- Der produktive History-Read-Contract fuer Prepare-Attach-Drafts ist vereinfacht:
+  `GET /api/admin/create/attach-drafts/[draftId]/history` liefert fuer Pagination extern nur noch `nextCursor`.
+- `nextScanCursor` ist nicht mehr Teil des externen API-Contracts.
+- Cursor bleiben fuer den Client opaque; intern darf der Cursor weiterhin Scan-/Accepted-Position und Tie-Break-Information tragen.
+- Cursor sind draft- und filter-gebunden (`type=all|review|apply`); Mismatch wird weiter als `invalid_history_cursor` abgewiesen.
+- Lazy History Loading in der Admin-Queue nutzt pro Draft nur noch einen Cursor-State.
+- Read-time Legacy-Normalisierung bleibt unveraendert aktiv:
+  - `normalizedFromLegacy`
+  - `legacyNormalizationReason`
+- Guardrails bleiben unveraendert:
+  kein Auto-Apply, kein Auto-Merge, kein Auto-Publish, keine neue Produkt-Mutation.
+- Stage-2/Stage-3 bleiben unberuehrt und hard-deferred.
 
 ## Update (2026-03-19) — Wave 1 Governance Foundation
 

--- a/docs/E150/Part16.md
+++ b/docs/E150/Part16.md
@@ -1,6 +1,6 @@
 # Part16 - Canonical Orchestration Flow
 
-> Stand: 2026-03-20
+> Stand: 2026-03-21
 > Status: Canonical Architecture Baseline
 > Verbindlicher Task-Backlog: `docs/E150/OpenTasks.md`
 
@@ -284,6 +284,28 @@ Regeln:
 - manual-first
 - provenance-by-default
 - audit trail pro Schritt
+
+## Operational Addendum (2026-03-21) — Single Opaque History Cursor
+
+Create Prepare-Attach History Read:
+- Endpoint: `GET /api/admin/create/attach-drafts/[draftId]/history`
+- Query: `type`, `limit`, `cursor`
+- Response: `events`, `reviewEvents`, `applyEvents`, `latestEvent`, `hasMore`, `nextCursor`, `type`, `limit`, `draft`
+
+Cursor-Regel:
+- Extern ist nur ein Cursor sichtbar (`nextCursor`).
+- Der Cursor bleibt opaque; interne Scan-/Accepted-Informationen duerfen enthalten sein.
+- Cursor sind draft- und filter-gebunden (`type=all|review|apply`), nicht zwischen Drafts/Filtern wiederverwendbar.
+
+Legacy-Verhalten:
+- Read-time Legacy-Normalisierung bleibt unveraendert aktiv (`normalizedFromLegacy`, `legacyNormalizationReason`).
+
+Guardrails bleiben unveraendert:
+- kein Auto-Apply
+- kein Auto-Merge
+- kein Auto-Publish
+- keine neue Produkt-Mutation
+- Stage-2/Stage-3 bleiben unberuehrt
 
 ## Strategischer Leitsatz
 


### PR DESCRIPTION
## Ziel

Vereinfacht den produktiven History-Read-Contract für Prepare-Attach-Drafts auf **einen einzigen opaquen Cursor** und bereinigt den Queue-/UI-State entsprechend, ohne neue Mutation oder Guardrail-Änderung einzuführen.

## Änderungen

- collapse des externen History-Pagination-Contracts auf **nur noch `nextCursor`**
- `nextScanCursor` ist **nicht mehr Teil des öffentlichen API-Contracts**
- interner Cursor bleibt robust und darf weiterhin Scan-/Accepted-Positionen sowie Tie-Break-Infos tragen, bleibt für Clients aber opaque
- Cursor sind **draft- und filter-gebunden** (`type=all|review|apply`)
- Admin-Queue nutzt pro Draft nur noch **einen Cursor-State** für lazy history loading
- History-Route, Service und Tests auf den Single-Cursor-Contract angepasst
- E150-Dokumente auf den neuen Contract aktualisiert

## Explizit

- externer Contract jetzt nur noch `nextCursor`
- `nextScanCursor` ist **nicht mehr public**
- interne Scan-Semantik bleibt im opaquen Cursor erhalten
- Legacy-Normalisierung bleibt erhalten:
  - `normalizedFromLegacy`
  - `legacyNormalizationReason`
- **keine neue Auto-Mutation**
- **kein Auto-Merge**
- **kein Auto-Publish**
- Review/Apply bleiben getrennt
- Stage-2 / Stage-3 bleiben unberührt

## Verification

- `pnpm -C apps/web exec vitest run tests/create-prepare-attach.review-history.service.test.ts tests/create-prepare-attach.history-route.test.ts tests/create-prepare-attach.review-ui.test.tsx tests/create-prepare-attach.review-queue.routes.test.ts tests/create-prepare-attach.apply-route.test.ts`
- `pnpm -C apps/web exec vitest run tests/create-analyze.route.test.ts tests/create-mode.save.route.test.ts tests/create-mode.finalize.route.test.ts`
- `pnpm -C apps/web exec tsc --noEmit -p tsconfig.json`