### PR TITLE
feat(create): add history backfill utility and document cursor contract

### DIFF
--- a/apps/web/scripts/create.history-backfill.ts
+++ b/apps/web/scripts/create.history-backfill.ts
@@ -1,0 +1,70 @@
+import { existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { config } from "dotenv";
+import { fileURLToPath } from "node:url";
+import { closeAll } from "@core/db/triMongo";
+import {
+  parseCreatePrepareAttachHistoryBackfillArgs,
+  runCreatePrepareAttachHistoryBackfill,
+} from "@/features/create/attachDraftHistoryBackfill";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const envCandidates = [
+  resolve(__dirname, "..", ".env.local"),
+  resolve(__dirname, "..", ".env"),
+  resolve(__dirname, "..", "..", ".env.local"),
+  resolve(__dirname, "..", "..", ".env"),
+];
+for (const path of envCandidates) {
+  if (!existsSync(path)) continue;
+  config({ path, override: false });
+  break;
+}
+
+async function main() {
+  const options = parseCreatePrepareAttachHistoryBackfillArgs(process.argv.slice(2));
+  const report = await runCreatePrepareAttachHistoryBackfill({
+    mode: options.mode,
+    previewLimit: options.previewLimit,
+    scanLimit: options.scanLimit,
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
+  console.log(`[history-backfill] mode=${report.mode}`);
+  console.log(
+    `[history-backfill] scanned=${report.totalScanned} canonical=${report.canonical} normalizable=${report.normalizable} unsafe=${report.unsafe} applied=${report.applied} applySkipped=${report.applySkipped}`,
+  );
+  if (report.samples.length > 0) {
+    console.log("[history-backfill] samples:");
+    for (const sample of report.samples) {
+      const reasons = sample.reasons.length > 0 ? sample.reasons.join(",") : "none";
+      console.log(
+        `  row=${sample.rowId ?? "missing"} draft=${sample.draftId ?? "missing"} status=${sample.status} type=${sample.inferredEventType ?? "unknown"} reasons=${reasons}`,
+      );
+    }
+  }
+  const sortedReasons = Object.entries(report.reasonBuckets).sort((left, right) => right[1] - left[1]);
+  if (sortedReasons.length > 0) {
+    console.log("[history-backfill] reasonBuckets:");
+    for (const [reason, count] of sortedReasons) {
+      console.log(`  ${reason}: ${count}`);
+    }
+  }
+}
+
+main()
+  .then(async () => {
+    await closeAll();
+    process.exit(0);
+  })
+  .catch(async (error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    await closeAll().catch(() => undefined);
+    process.exit(1);
+  });

--- a/apps/web/scripts/create.history-backfill.ts
+++ b/apps/web/scripts/create.history-backfill.ts
@@ -2,11 +2,6 @@ import { existsSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { config } from "dotenv";
 import { fileURLToPath } from "node:url";
-import { closeAll } from "@core/db/triMongo";
-import {
-  parseCreatePrepareAttachHistoryBackfillArgs,
-  runCreatePrepareAttachHistoryBackfill,
-} from "@/features/create/attachDraftHistoryBackfill";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -24,6 +19,12 @@ for (const path of envCandidates) {
 }
 
 async function main() {
+  const { closeAll } = await import("@core/db/triMongo");
+  const {
+    parseCreatePrepareAttachHistoryBackfillArgs,
+    runCreatePrepareAttachHistoryBackfill,
+  } = await import("@/features/create/attachDraftHistoryBackfill");
+
   const options = parseCreatePrepareAttachHistoryBackfillArgs(process.argv.slice(2));
   const report = await runCreatePrepareAttachHistoryBackfill({
     mode: options.mode,
@@ -60,11 +61,13 @@ async function main() {
 
 main()
   .then(async () => {
+    const { closeAll } = await import("@core/db/triMongo");
     await closeAll();
     process.exit(0);
   })
   .catch(async (error: unknown) => {
     console.error(error instanceof Error ? error.message : String(error));
+    const { closeAll } = await import("@core/db/triMongo");
     await closeAll().catch(() => undefined);
     process.exit(1);
   });

--- a/apps/web/src/features/create/attachDraftHistoryBackfill.ts
+++ b/apps/web/src/features/create/attachDraftHistoryBackfill.ts
@@ -1,0 +1,610 @@
+import { ObjectId } from "@core/db/triMongo";
+import {
+  CREATE_PREPARE_ATTACH_HISTORY_SCHEMA_VERSION,
+  createApplyHistoryEvent,
+  createReviewHistoryEvent,
+  type CreatePrepareAttachDraftHistoryEvent,
+} from "@/features/create/attachDraftHistory";
+import { createPrepareAttachHistoryEventsCol } from "@/features/create/attachDraftCollections";
+import {
+  isCreatePrepareAttachDraftApplyState,
+  isCreatePrepareAttachDraftReviewDecision,
+  isCreatePrepareAttachDraftReviewState,
+  type CreatePrepareAttachDraftApplyState,
+  type CreatePrepareAttachDraftReviewDecision,
+  type CreatePrepareAttachDraftReviewState,
+  type CreatePrepareAttachTargetType,
+} from "@/features/create/prepareAttachDraft";
+
+export const CREATE_PREPARE_ATTACH_HISTORY_BACKFILL_MODES = ["dry_run", "apply"] as const;
+export type CreatePrepareAttachHistoryBackfillMode =
+  (typeof CREATE_PREPARE_ATTACH_HISTORY_BACKFILL_MODES)[number];
+
+export const CREATE_PREPARE_ATTACH_HISTORY_BACKFILL_DEFAULT_PREVIEW_LIMIT = 8;
+export const CREATE_PREPARE_ATTACH_HISTORY_BACKFILL_MAX_PREVIEW_LIMIT = 30;
+
+export type CreatePrepareAttachHistoryBackfillStatus =
+  | "canonical_already_ok"
+  | "normalizable"
+  | "unsafe_to_backfill";
+
+export type CreatePrepareAttachHistoryBackfillAssessment = {
+  status: CreatePrepareAttachHistoryBackfillStatus;
+  rowId: string | null;
+  draftId: string | null;
+  inferredEventType: "review" | "apply" | null;
+  reasons: string[];
+  normalizedEvent: CreatePrepareAttachDraftHistoryEvent | null;
+};
+
+export type CreatePrepareAttachHistoryBackfillSample = {
+  rowId: string | null;
+  draftId: string | null;
+  status: CreatePrepareAttachHistoryBackfillStatus;
+  inferredEventType: "review" | "apply" | null;
+  reasons: string[];
+};
+
+export type CreatePrepareAttachHistoryBackfillReport = {
+  mode: CreatePrepareAttachHistoryBackfillMode;
+  totalScanned: number;
+  canonical: number;
+  normalizable: number;
+  unsafe: number;
+  applied: number;
+  applySkipped: number;
+  samples: CreatePrepareAttachHistoryBackfillSample[];
+  reasonBuckets: Record<string, number>;
+};
+
+export type CreatePrepareAttachHistoryBackfillCliOptions = {
+  mode: CreatePrepareAttachHistoryBackfillMode;
+  previewLimit: number;
+  scanLimit: number | null;
+  json: boolean;
+};
+
+export function normalizeCreatePrepareAttachHistoryBackfillMode(
+  value: unknown,
+): CreatePrepareAttachHistoryBackfillMode {
+  const normalized = String(value ?? "dry_run").trim().toLowerCase();
+  if (normalized === "dry_run" || normalized === "apply") return normalized;
+  throw new Error("invalid_history_backfill_mode");
+}
+
+export function normalizeCreatePrepareAttachHistoryBackfillPreviewLimit(value: unknown): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return CREATE_PREPARE_ATTACH_HISTORY_BACKFILL_DEFAULT_PREVIEW_LIMIT;
+  const rounded = Math.floor(numeric);
+  return Math.max(1, Math.min(CREATE_PREPARE_ATTACH_HISTORY_BACKFILL_MAX_PREVIEW_LIMIT, rounded));
+}
+
+function normalizeCreatePrepareAttachHistoryBackfillScanLimit(value: unknown): number | null {
+  if (value == null || value === "") return null;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    throw new Error("invalid_history_backfill_scan_limit");
+  }
+  return Math.floor(numeric);
+}
+
+export function parseCreatePrepareAttachHistoryBackfillArgs(
+  argv: string[],
+): CreatePrepareAttachHistoryBackfillCliOptions {
+  let modeInput: string | null = null;
+  let previewLimitInput: string | null = null;
+  let scanLimitInput: string | null = null;
+  let json = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = String(argv[index] || "").trim();
+    if (!arg) continue;
+    if (arg === "--apply") {
+      modeInput = "apply";
+      continue;
+    }
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (arg === "--mode") {
+      modeInput = String(argv[index + 1] ?? "");
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--mode=")) {
+      modeInput = arg.slice("--mode=".length);
+      continue;
+    }
+    if (arg === "--preview-limit") {
+      previewLimitInput = String(argv[index + 1] ?? "");
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--preview-limit=")) {
+      previewLimitInput = arg.slice("--preview-limit=".length);
+      continue;
+    }
+    if (arg === "--scan-limit") {
+      scanLimitInput = String(argv[index + 1] ?? "");
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--scan-limit=")) {
+      scanLimitInput = arg.slice("--scan-limit=".length);
+      continue;
+    }
+    throw new Error("invalid_history_backfill_arg");
+  }
+
+  return {
+    mode: normalizeCreatePrepareAttachHistoryBackfillMode(modeInput ?? "dry_run"),
+    previewLimit: normalizeCreatePrepareAttachHistoryBackfillPreviewLimit(previewLimitInput),
+    scanLimit: normalizeCreatePrepareAttachHistoryBackfillScanLimit(scanLimitInput),
+    json,
+  };
+}
+
+export function classifyCreatePrepareAttachHistoryLegacyRow(
+  row: Record<string, unknown>,
+): CreatePrepareAttachHistoryBackfillAssessment {
+  if (!row || typeof row !== "object") {
+    return {
+      status: "unsafe_to_backfill",
+      rowId: null,
+      draftId: null,
+      inferredEventType: null,
+      reasons: ["invalid_row_object"],
+      normalizedEvent: null,
+    };
+  }
+
+  const raw = row as Record<string, unknown>;
+  const rowId = getRowIdString(raw._id);
+  const draftId = String(raw.draftId || "").trim() || null;
+  const reasons = new Set<string>();
+
+  if (!rowId) {
+    reasons.add("row_id_missing");
+    return {
+      status: "unsafe_to_backfill",
+      rowId,
+      draftId,
+      inferredEventType: null,
+      reasons: Array.from(reasons),
+      normalizedEvent: null,
+    };
+  }
+  if (!draftId) {
+    reasons.add("missing_draft_id");
+    return {
+      status: "unsafe_to_backfill",
+      rowId,
+      draftId,
+      inferredEventType: null,
+      reasons: Array.from(reasons),
+      normalizedEvent: null,
+    };
+  }
+
+  const typeResult = inferBackfillEventType(raw);
+  if (!typeResult.eventType) {
+    reasons.add(typeResult.reasonCode || "event_type_unrecoverable");
+    return {
+      status: "unsafe_to_backfill",
+      rowId,
+      draftId,
+      inferredEventType: null,
+      reasons: Array.from(reasons),
+      normalizedEvent: null,
+    };
+  }
+
+  if (typeResult.inferred) {
+    reasons.add("event_type_inferred");
+  }
+
+  const actor = inferBackfillActor(raw);
+  if (actor.reasonCode) reasons.add(actor.reasonCode);
+
+  const timestamp = inferBackfillTimestamp(raw);
+  if (!timestamp.value) {
+    reasons.add(timestamp.reasonCode || "timestamp_unrecoverable");
+    return {
+      status: "unsafe_to_backfill",
+      rowId,
+      draftId,
+      inferredEventType: typeResult.eventType,
+      reasons: Array.from(reasons),
+      normalizedEvent: null,
+    };
+  }
+  if (timestamp.reasonCode) reasons.add(timestamp.reasonCode);
+
+  if (String(raw.schemaVersion || "") !== CREATE_PREPARE_ATTACH_HISTORY_SCHEMA_VERSION) {
+    reasons.add("schema_version_normalized");
+  }
+
+  const eventIdResult = resolveBackfillEventId(raw, {
+    draftId,
+    actorUserId: actor.actorUserId,
+    createdAt: timestamp.value,
+    eventType: typeResult.eventType,
+  });
+  if (eventIdResult.reasonCode) reasons.add(eventIdResult.reasonCode);
+
+  const normalizedEvent = buildNormalizedHistoryEvent({
+    raw,
+    draftId,
+    eventType: typeResult.eventType,
+    actorUserId: actor.actorUserId,
+    createdAt: timestamp.value,
+    eventId: eventIdResult.eventId,
+    reasons,
+  });
+
+  if (!normalizedEvent) {
+    reasons.add(typeResult.eventType === "review" ? "review_state_unrecoverable" : "apply_result_unrecoverable");
+    return {
+      status: "unsafe_to_backfill",
+      rowId,
+      draftId,
+      inferredEventType: typeResult.eventType,
+      reasons: Array.from(reasons),
+      normalizedEvent: null,
+    };
+  }
+
+  if (isCanonicalHistoryRow(raw, typeResult.eventType)) {
+    return {
+      status: "canonical_already_ok",
+      rowId,
+      draftId,
+      inferredEventType: typeResult.eventType,
+      reasons: [],
+      normalizedEvent: null,
+    };
+  }
+
+  if (reasons.size === 0) {
+    reasons.add("contract_fields_enriched");
+  }
+
+  return {
+    status: "normalizable",
+    rowId,
+    draftId,
+    inferredEventType: typeResult.eventType,
+    reasons: Array.from(reasons),
+    normalizedEvent,
+  };
+}
+
+export async function runCreatePrepareAttachHistoryBackfill(params?: {
+  mode?: CreatePrepareAttachHistoryBackfillMode | string | null;
+  previewLimit?: number | string | null;
+  scanLimit?: number | string | null;
+}): Promise<CreatePrepareAttachHistoryBackfillReport> {
+  const mode = normalizeCreatePrepareAttachHistoryBackfillMode(params?.mode ?? "dry_run");
+  const previewLimit = normalizeCreatePrepareAttachHistoryBackfillPreviewLimit(
+    params?.previewLimit ?? CREATE_PREPARE_ATTACH_HISTORY_BACKFILL_DEFAULT_PREVIEW_LIMIT,
+  );
+  const scanLimit = normalizeCreatePrepareAttachHistoryBackfillScanLimit(params?.scanLimit ?? null);
+
+  const History = await createPrepareAttachHistoryEventsCol();
+  const cursor = History.find({}).sort({ _id: 1 });
+  if (scanLimit) cursor.limit(scanLimit);
+  const rows = await cursor.toArray();
+
+  const report: CreatePrepareAttachHistoryBackfillReport = {
+    mode,
+    totalScanned: 0,
+    canonical: 0,
+    normalizable: 0,
+    unsafe: 0,
+    applied: 0,
+    applySkipped: 0,
+    samples: [],
+    reasonBuckets: {},
+  };
+
+  for (const row of rows as Record<string, unknown>[]) {
+    report.totalScanned += 1;
+    const assessment = classifyCreatePrepareAttachHistoryLegacyRow(row);
+
+    if (assessment.status === "canonical_already_ok") report.canonical += 1;
+    if (assessment.status === "normalizable") report.normalizable += 1;
+    if (assessment.status === "unsafe_to_backfill") report.unsafe += 1;
+
+    for (const reason of assessment.reasons) {
+      report.reasonBuckets[reason] = (report.reasonBuckets[reason] ?? 0) + 1;
+    }
+
+    if (report.samples.length < previewLimit) {
+      report.samples.push({
+        rowId: assessment.rowId,
+        draftId: assessment.draftId,
+        status: assessment.status,
+        inferredEventType: assessment.inferredEventType,
+        reasons: assessment.reasons,
+      });
+    }
+
+    if (mode !== "apply") continue;
+    if (assessment.status !== "normalizable") continue;
+    if (!assessment.normalizedEvent) {
+      report.applySkipped += 1;
+      continue;
+    }
+
+    const filter = buildRowFilter(row);
+    if (!filter) {
+      report.applySkipped += 1;
+      continue;
+    }
+
+    const updateRes = await History.updateOne(filter, {
+      $set: assessment.normalizedEvent as Record<string, unknown>,
+    });
+    if (updateRes.modifiedCount === 1) {
+      report.applied += 1;
+    } else {
+      report.applySkipped += 1;
+    }
+  }
+
+  return report;
+}
+
+function buildRowFilter(row: Record<string, unknown>) {
+  if (!Object.prototype.hasOwnProperty.call(row, "_id")) return null;
+  if ((row as { _id?: unknown })._id == null) return null;
+  return { _id: (row as { _id: unknown })._id };
+}
+
+function buildNormalizedHistoryEvent(params: {
+  raw: Record<string, unknown>;
+  draftId: string;
+  eventType: "review" | "apply";
+  actorUserId: string;
+  createdAt: string;
+  eventId: string;
+  reasons: Set<string>;
+}): CreatePrepareAttachDraftHistoryEvent | null {
+  const reason = params.reasons.size > 0 ? Array.from(params.reasons).join(",") : null;
+  if (params.eventType === "review") {
+    const nextReviewState =
+      parseReviewDecision(params.raw.nextReviewState) ?? parseReviewDecision(params.raw.reviewState);
+    if (!nextReviewState) return null;
+    return createReviewHistoryEvent({
+      draftId: params.draftId,
+      actorUserId: params.actorUserId,
+      previousReviewState: parseReviewState(params.raw.previousReviewState) ?? "pending",
+      nextReviewState,
+      previousApplyState: parseApplyState(params.raw.previousApplyState) ?? "not_applied",
+      nextApplyState: parseApplyState(params.raw.nextApplyState) ?? "not_applied",
+      reviewNote: params.raw.reviewNote == null ? null : String(params.raw.reviewNote),
+      normalizedFromLegacy: true,
+      legacyNormalizationReason: reason,
+      createdAt: params.createdAt,
+      eventId: params.eventId,
+    });
+  }
+
+  const result = inferApplyResult(params.raw);
+  if (!result) return null;
+  const previousReviewState = parseReviewState(params.raw.previousReviewState) ?? parseReviewState(params.raw.reviewState) ?? null;
+  const nextReviewState = parseReviewState(params.raw.nextReviewState) ?? previousReviewState;
+  const previousApplyState = parseApplyState(params.raw.previousApplyState) ?? "not_applied";
+  const nextApplyState =
+    parseApplyState(params.raw.nextApplyState) ??
+    parseApplyState(params.raw.applyState) ??
+    (result === "applied" ? "applied" : "apply_failed");
+  return createApplyHistoryEvent({
+    draftId: params.draftId,
+    actorUserId: params.actorUserId,
+    targetType: parseTargetType(params.raw.targetType),
+    targetId: params.raw.targetId == null ? null : String(params.raw.targetId),
+    result,
+    applyNote: params.raw.applyNote == null ? null : String(params.raw.applyNote),
+    mutationType: params.raw.mutationType == null ? null : String(params.raw.mutationType),
+    errorCode: params.raw.errorCode == null ? null : String(params.raw.errorCode),
+    normalizedFromLegacy: true,
+    legacyNormalizationReason: reason,
+    previousReviewState,
+    nextReviewState,
+    previousApplyState,
+    nextApplyState,
+    createdAt: params.createdAt,
+    eventId: params.eventId,
+  });
+}
+
+function inferBackfillEventType(raw: Record<string, unknown>): {
+  eventType: "review" | "apply" | null;
+  inferred: boolean;
+  reasonCode?: string;
+} {
+  if (raw.eventType === "review" || raw.eventType === "apply") {
+    return { eventType: raw.eventType, inferred: false };
+  }
+  const hasReviewStrongSignal =
+    typeof raw.reviewNote === "string" ||
+    typeof raw.reviewedBy === "string";
+  const hasReviewDecisionSignal =
+    parseReviewDecision(raw.nextReviewState) !== null ||
+    parseReviewDecision(raw.reviewState) !== null;
+  const applyState = parseApplyState(raw.nextApplyState) ?? parseApplyState(raw.applyState);
+  const hasApplyStrongSignal =
+    raw.result === "applied" ||
+    raw.result === "failed" ||
+    typeof raw.appliedBy === "string" ||
+    typeof raw.applyNote === "string" ||
+    typeof raw.applyError === "string" ||
+    typeof raw.targetType === "string" ||
+    typeof raw.targetId === "string" ||
+    typeof raw.mutationType === "string";
+  const hasApplyResultSignal =
+    inferApplyResult(raw) !== null ||
+    applyState === "applied" ||
+    applyState === "apply_failed";
+
+  if ((hasApplyStrongSignal || hasApplyResultSignal) && hasReviewStrongSignal) {
+    return { eventType: null, inferred: false, reasonCode: "ambiguous_event_signals" };
+  }
+  if (hasApplyStrongSignal || hasApplyResultSignal) return { eventType: "apply", inferred: true };
+  if (hasReviewStrongSignal || hasReviewDecisionSignal) return { eventType: "review", inferred: true };
+  return { eventType: null, inferred: false, reasonCode: "event_type_unrecoverable" };
+}
+
+function inferBackfillActor(raw: Record<string, unknown>) {
+  if (typeof raw.actorUserId === "string" && raw.actorUserId.trim()) {
+    return { actorUserId: raw.actorUserId.trim(), reasonCode: null as string | null };
+  }
+  if (typeof raw.reviewedBy === "string" && raw.reviewedBy.trim()) {
+    return { actorUserId: raw.reviewedBy.trim(), reasonCode: "actor_inferred" };
+  }
+  if (typeof raw.appliedBy === "string" && raw.appliedBy.trim()) {
+    return { actorUserId: raw.appliedBy.trim(), reasonCode: "actor_inferred" };
+  }
+  return { actorUserId: "unknown", reasonCode: "actor_inferred_unknown" };
+}
+
+function inferBackfillTimestamp(raw: Record<string, unknown>) {
+  const checks: Array<{ field: string; value: unknown }> = [
+    { field: "createdAt", value: raw.createdAt },
+    { field: "reviewedAt", value: raw.reviewedAt },
+    { field: "appliedAt", value: raw.appliedAt },
+    { field: "updatedAt", value: raw.updatedAt },
+  ];
+  for (const check of checks) {
+    if (typeof check.value !== "string") continue;
+    const trimmed = check.value.trim();
+    if (!trimmed || Number.isNaN(Date.parse(trimmed))) continue;
+    if (check.field === "createdAt") {
+      return { value: trimmed, reasonCode: null as string | null };
+    }
+    return { value: trimmed, reasonCode: "timestamp_inferred" };
+  }
+  const oid = parseObjectIdLike(raw._id);
+  if (oid) {
+    return { value: oid.getTimestamp().toISOString(), reasonCode: "timestamp_inferred_from_object_id" };
+  }
+  return { value: null, reasonCode: "timestamp_unrecoverable" };
+}
+
+function resolveBackfillEventId(
+  raw: Record<string, unknown>,
+  params: {
+    draftId: string;
+    actorUserId: string;
+    createdAt: string;
+    eventType: "review" | "apply";
+  },
+) {
+  if (typeof raw.eventId === "string" && raw.eventId.trim()) {
+    return { eventId: raw.eventId.trim(), reasonCode: null as string | null };
+  }
+  const oid = parseObjectIdLike(raw._id);
+  if (oid) {
+    return { eventId: oid.toHexString(), reasonCode: "event_id_inferred_from_row_id" };
+  }
+  return {
+    eventId: deriveDeterministicObjectIdHex(
+      `${params.draftId}|${params.createdAt}|${params.actorUserId}|${params.eventType}`,
+    ),
+    reasonCode: "event_id_generated",
+  };
+}
+
+function inferApplyResult(raw: Record<string, unknown>): "applied" | "failed" | null {
+  if (raw.result === "applied" || raw.result === "failed") return raw.result;
+  const nextState = parseApplyState(raw.nextApplyState) ?? parseApplyState(raw.applyState);
+  if (nextState === "applied") return "applied";
+  if (nextState === "apply_failed") return "failed";
+  return null;
+}
+
+function parseTargetType(value: unknown): CreatePrepareAttachTargetType | "unknown" {
+  if (value === "claim" || value === "anlassraum" || value === "dossier" || value === "perspective") {
+    return value;
+  }
+  return "unknown";
+}
+
+function isCanonicalHistoryRow(raw: Record<string, unknown>, eventType: "review" | "apply") {
+  if (String(raw.schemaVersion || "") !== CREATE_PREPARE_ATTACH_HISTORY_SCHEMA_VERSION) return false;
+  if (raw.eventType !== eventType) return false;
+  if (typeof raw.eventId !== "string" || !raw.eventId.trim()) return false;
+  if (typeof raw.draftId !== "string" || !raw.draftId.trim()) return false;
+  if (typeof raw.actorUserId !== "string" || !raw.actorUserId.trim()) return false;
+  if (typeof raw.createdAt !== "string" || Number.isNaN(Date.parse(raw.createdAt))) return false;
+  if (eventType === "review") {
+    if (!isReviewStateOrNull(raw.previousReviewState)) return false;
+    if (!parseReviewDecision(raw.nextReviewState)) return false;
+    if (!isApplyStateOrNull(raw.previousApplyState)) return false;
+    if (!parseApplyState(raw.nextApplyState)) return false;
+    if (raw.resultCode !== "review_state_changed") return false;
+    return true;
+  }
+  if (!isReviewStateOrNull(raw.previousReviewState)) return false;
+  if (!isReviewStateOrNull(raw.nextReviewState)) return false;
+  if (!isApplyStateOrNull(raw.previousApplyState)) return false;
+  if (!parseApplyState(raw.nextApplyState)) return false;
+  if (raw.result !== "applied" && raw.result !== "failed") return false;
+  if (typeof raw.resultCode !== "string" || !raw.resultCode.trim()) return false;
+  return true;
+}
+
+function isReviewStateOrNull(value: unknown) {
+  if (value == null) return true;
+  return parseReviewState(value) !== null;
+}
+
+function isApplyStateOrNull(value: unknown) {
+  if (value == null) return true;
+  return parseApplyState(value) !== null;
+}
+
+function parseReviewState(value: unknown): CreatePrepareAttachDraftReviewState | null {
+  if (typeof value !== "string") return null;
+  return isCreatePrepareAttachDraftReviewState(value) ? value : null;
+}
+
+function parseReviewDecision(value: unknown): CreatePrepareAttachDraftReviewDecision | null {
+  if (typeof value !== "string") return null;
+  return isCreatePrepareAttachDraftReviewDecision(value) ? value : null;
+}
+
+function parseApplyState(value: unknown): CreatePrepareAttachDraftApplyState | null {
+  if (typeof value !== "string") return null;
+  return isCreatePrepareAttachDraftApplyState(value) ? value : null;
+}
+
+function parseObjectIdLike(value: unknown): ObjectId | null {
+  if (value instanceof ObjectId) return value;
+  if (typeof value === "string" && ObjectId.isValid(value)) return new ObjectId(value);
+  return null;
+}
+
+function getRowIdString(value: unknown): string | null {
+  if (value instanceof ObjectId) return value.toHexString();
+  if (typeof value === "string" && value.trim()) return value.trim();
+  return null;
+}
+
+function deriveDeterministicObjectIdHex(seed: string): string {
+  let hash = 2166136261;
+  for (let index = 0; index < seed.length; index += 1) {
+    hash ^= seed.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  const head = (hash >>> 0).toString(16).padStart(8, "0");
+  const body = seed
+    .split("")
+    .map((char) => char.charCodeAt(0).toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 16)
+    .padEnd(16, "0");
+  return `${head}${body}`.slice(0, 24);
+}

--- a/apps/web/tests/create-prepare-attach.history-backfill.service.test.ts
+++ b/apps/web/tests/create-prepare-attach.history-backfill.service.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ObjectId } from "mongodb";
+
+const mocks = vi.hoisted(() => {
+  const historyEvents: Array<Record<string, unknown>> = [];
+
+  const toId = (value: unknown) => {
+    if (value instanceof ObjectId) return value.toHexString();
+    return String(value ?? "");
+  };
+
+  const sortRows = (rows: Array<Record<string, unknown>>, dir: 1 | -1) =>
+    [...rows].sort((left, right) => {
+      const l = toId(left._id);
+      const r = toId(right._id);
+      return dir === 1 ? l.localeCompare(r) : r.localeCompare(l);
+    });
+
+  return {
+    reset() {
+      historyEvents.length = 0;
+    },
+    seedHistoryEvent(doc: Record<string, unknown>) {
+      historyEvents.push({ ...doc });
+    },
+    readHistoryEvents() {
+      return historyEvents.map((entry) => ({ ...entry }));
+    },
+    getCol: vi.fn(async (name: string) => {
+      if (name !== "create_prepare_attach_history_events") {
+        throw new Error(`unexpected_collection_${name}`);
+      }
+      return {
+        async createIndex() {
+          return "ok";
+        },
+        find() {
+          let current = historyEvents.map((entry) => ({ ...entry }));
+          return {
+            sort(spec: Record<string, 1 | -1>) {
+              if (spec._id) current = sortRows(current, spec._id);
+              return this;
+            },
+            limit(value: number) {
+              const limit = Math.max(0, Number(value) || 0);
+              current = current.slice(0, limit);
+              return this;
+            },
+            async toArray() {
+              return current.map((entry) => ({ ...entry }));
+            },
+          };
+        },
+        async updateOne(filter: Record<string, unknown>, update: Record<string, unknown>) {
+          const idx = historyEvents.findIndex((entry) => toId(entry._id) === toId(filter._id));
+          if (idx < 0) return { matchedCount: 0, modifiedCount: 0 };
+          const setValues = (update?.$set ?? {}) as Record<string, unknown>;
+          historyEvents[idx] = { ...historyEvents[idx], ...setValues };
+          return { matchedCount: 1, modifiedCount: 1 };
+        },
+      };
+    }),
+  };
+});
+
+vi.mock("@core/db/triMongo", async () => {
+  const mongodb = await import("mongodb");
+  return {
+    ObjectId: mongodb.ObjectId,
+    getCol: (...args: unknown[]) => mocks.getCol(...args),
+  };
+});
+
+import {
+  classifyCreatePrepareAttachHistoryLegacyRow,
+  parseCreatePrepareAttachHistoryBackfillArgs,
+  runCreatePrepareAttachHistoryBackfill,
+} from "@/features/create/attachDraftHistoryBackfill";
+
+describe("create prepare-attach history backfill service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.reset();
+  });
+
+  it("classifies canonical rows as no-op", () => {
+    const row = {
+      _id: new ObjectId("65f000000000000000000111"),
+      schemaVersion: "create_prepare_attach_history.v1",
+      eventType: "review",
+      eventId: "e-1",
+      draftId: "65f000000000000000000211",
+      actorUserId: "u-review",
+      previousReviewState: "pending",
+      nextReviewState: "accepted_for_apply",
+      previousApplyState: "not_applied",
+      nextApplyState: "not_applied",
+      reviewNote: null,
+      resultCode: "review_state_changed",
+      createdAt: "2026-03-20T10:00:00.000Z",
+    };
+    const assessment = classifyCreatePrepareAttachHistoryLegacyRow(row);
+    expect(assessment.status).toBe("canonical_already_ok");
+    expect(assessment.reasons).toEqual([]);
+    expect(assessment.normalizedEvent).toBeNull();
+  });
+
+  it("detects review legacy rows as normalizable", () => {
+    const row = {
+      _id: new ObjectId("65f000000000000000000112"),
+      draftId: "65f000000000000000000212",
+      reviewedBy: "legacy-reviewer",
+      reviewState: "accepted_for_apply",
+      reviewNote: "legacy review",
+      reviewedAt: "2026-03-20T11:00:00.000Z",
+      previousReviewState: "pending",
+      previousApplyState: "not_applied",
+      nextApplyState: "not_applied",
+    };
+    const assessment = classifyCreatePrepareAttachHistoryLegacyRow(row);
+    expect(assessment.status).toBe("normalizable");
+    expect(assessment.inferredEventType).toBe("review");
+    expect(assessment.reasons).toContain("event_type_inferred");
+    expect(assessment.normalizedEvent).toMatchObject({
+      schemaVersion: "create_prepare_attach_history.v1",
+      eventType: "review",
+      actorUserId: "legacy-reviewer",
+      resultCode: "review_state_changed",
+    });
+  });
+
+  it("detects apply legacy rows as normalizable", () => {
+    const row = {
+      _id: "65f000000000000000000113",
+      draftId: "65f000000000000000000213",
+      appliedBy: "legacy-applier",
+      result: "failed",
+      errorCode: "attach_target_not_found",
+      applyNote: "legacy failed",
+      appliedAt: "2026-03-20T11:05:00.000Z",
+      previousReviewState: "accepted_for_apply",
+      nextReviewState: "accepted_for_apply",
+      previousApplyState: "not_applied",
+      nextApplyState: "apply_failed",
+      targetType: "claim",
+      targetId: "legacy-claim-1",
+    };
+    const assessment = classifyCreatePrepareAttachHistoryLegacyRow(row);
+    expect(assessment.status).toBe("normalizable");
+    expect(assessment.inferredEventType).toBe("apply");
+    expect(assessment.normalizedEvent).toMatchObject({
+      schemaVersion: "create_prepare_attach_history.v1",
+      eventType: "apply",
+      actorUserId: "legacy-applier",
+      result: "failed",
+      targetType: "claim",
+      targetId: "legacy-claim-1",
+    });
+  });
+
+  it("marks ambiguous rows as unsafe instead of rewriting blindly", () => {
+    const row = {
+      _id: new ObjectId("65f000000000000000000114"),
+      draftId: "65f000000000000000000214",
+      reviewedBy: "legacy-reviewer",
+      reviewState: "accepted_for_apply",
+      result: "failed",
+      appliedBy: "legacy-applier",
+      appliedAt: "2026-03-20T11:10:00.000Z",
+    };
+    const assessment = classifyCreatePrepareAttachHistoryLegacyRow(row);
+    expect(assessment.status).toBe("unsafe_to_backfill");
+    expect(assessment.reasons).toContain("ambiguous_event_signals");
+    expect(assessment.normalizedEvent).toBeNull();
+  });
+
+  it("handles string _id deterministically and reports missing _id as unsafe", () => {
+    const stringIdRow = {
+      _id: "65f000000000000000000115",
+      draftId: "65f000000000000000000215",
+      appliedBy: "legacy-applier",
+      result: "failed",
+      nextApplyState: "apply_failed",
+      appliedAt: "2026-03-20T11:20:00.000Z",
+      previousReviewState: "accepted_for_apply",
+      nextReviewState: "accepted_for_apply",
+      targetType: "claim",
+      targetId: "legacy-claim-2",
+    };
+    const missingIdRow = {
+      draftId: "65f000000000000000000216",
+      reviewedBy: "legacy-reviewer",
+      reviewState: "parked",
+      reviewedAt: "2026-03-20T11:21:00.000Z",
+    };
+
+    const withStringId = classifyCreatePrepareAttachHistoryLegacyRow(stringIdRow);
+    expect(withStringId.status).toBe("normalizable");
+    expect(withStringId.rowId).toBe("65f000000000000000000115");
+    expect(withStringId.normalizedEvent?.eventId).toBe("65f000000000000000000115");
+
+    const missingId = classifyCreatePrepareAttachHistoryLegacyRow(missingIdRow);
+    expect(missingId.status).toBe("unsafe_to_backfill");
+    expect(missingId.reasons).toContain("row_id_missing");
+  });
+
+  it("supports dry-run summary and explicit apply mode", async () => {
+    mocks.seedHistoryEvent({
+      _id: new ObjectId("65f000000000000000000116"),
+      draftId: "65f000000000000000000217",
+      reviewedBy: "legacy-reviewer",
+      reviewState: "accepted_for_apply",
+      reviewedAt: "2026-03-20T11:30:00.000Z",
+      previousReviewState: "pending",
+      previousApplyState: "not_applied",
+      nextApplyState: "not_applied",
+    });
+
+    const dryRun = await runCreatePrepareAttachHistoryBackfill();
+    expect(dryRun.mode).toBe("dry_run");
+    expect(dryRun.totalScanned).toBe(1);
+    expect(dryRun.normalizable).toBe(1);
+    expect(dryRun.applied).toBe(0);
+
+    const apply = await runCreatePrepareAttachHistoryBackfill({ mode: "apply" });
+    expect(apply.mode).toBe("apply");
+    expect(apply.normalizable).toBe(1);
+    expect(apply.applied).toBe(1);
+  });
+
+  it("is idempotent across repeated apply runs", async () => {
+    mocks.seedHistoryEvent({
+      _id: new ObjectId("65f000000000000000000117"),
+      draftId: "65f000000000000000000218",
+      reviewedBy: "legacy-reviewer",
+      reviewState: "accepted_for_apply",
+      reviewedAt: "2026-03-20T11:40:00.000Z",
+      previousReviewState: "pending",
+      previousApplyState: "not_applied",
+      nextApplyState: "not_applied",
+    });
+
+    const first = await runCreatePrepareAttachHistoryBackfill({ mode: "apply" });
+    expect(first.applied).toBe(1);
+
+    const second = await runCreatePrepareAttachHistoryBackfill({ mode: "apply" });
+    expect(second.applied).toBe(0);
+    expect(second.canonical).toBe(1);
+  });
+
+  it("reports unsafe rows in dry-run output", async () => {
+    mocks.seedHistoryEvent({
+      _id: new ObjectId("65f000000000000000000118"),
+      draftId: "65f000000000000000000219",
+      reviewedBy: "legacy-reviewer",
+      appliedBy: "legacy-applier",
+      reviewState: "accepted_for_apply",
+      result: "failed",
+      appliedAt: "2026-03-20T11:50:00.000Z",
+    });
+
+    const report = await runCreatePrepareAttachHistoryBackfill({ mode: "dry_run", previewLimit: 5 });
+    expect(report.unsafe).toBe(1);
+    expect(report.samples[0]?.status).toBe("unsafe_to_backfill");
+    expect(report.reasonBuckets.ambiguous_event_signals).toBe(1);
+  });
+
+  it("rejects invalid mode in runner and cli parsing", async () => {
+    await expect(
+      runCreatePrepareAttachHistoryBackfill({ mode: "invalid" as any }),
+    ).rejects.toThrow("invalid_history_backfill_mode");
+    expect(() => parseCreatePrepareAttachHistoryBackfillArgs(["--mode=invalid"])).toThrow(
+      "invalid_history_backfill_mode",
+    );
+  });
+});

--- a/docs/E150/OpenTasks.md
+++ b/docs/E150/OpenTasks.md
@@ -133,6 +133,7 @@ Status: **Open (Architecture alignment required / 2026-03-20)**
 | --- | --- | --- | --- |
 | PR-AI-CREATE-01 `/create` auf kanonischen Orchestrierungsfluss harmonisieren | In Progress (implementation baseline active / 2026-03-20) | GOV-AI-02 | Freistart-Entry ohne primaeren Modus-Split aktiv; `/api/contributions/analyze` liefert typed `createAnalyze`-Envelope (intake/quality/graph_matching/cta_suggestions, matchType/matchEntityType, noAutoPublish/noSilentMerge); `AnalyzeWorkspace` zeigt Input-Typ/Qualitaet/Matches/CTAs; Parser akzeptiert `preparedText`-Alias; Tests: `apps/web/tests/create-analyze.contract.test.ts`, `apps/web/tests/create-analyze.route.test.ts`, `apps/web/tests/create-mode.page.test.ts`, `apps/web/tests/create-mode.analyze-parse.test.ts` |
 | PR-AI-MATCH-11 Single Opaque History Cursor + lazy queue cleanup | Done (contract/UX polish active / 2026-03-21) | Monitoring/Polish | Produktiver History-Read-Contract fuer Prepare-Attach ist auf einen einzelnen opaquen Cursor reduziert: `GET /api/admin/create/attach-drafts/[draftId]/history` liefert `nextCursor` (kein `nextScanCursor` mehr). Interner Cursor bleibt robust (Scan+Accepted-Position im Payload, draft-/type-gebunden, `invalid_history_cursor` bei Mismatch). Queue-UI nutzt pro Draft nur noch einen Cursor-State fuer lazy "Mehr Verlauf laden". Legacy-Read-Normalisierung bleibt unveraendert aktiv (`normalizedFromLegacy`, `legacyNormalizationReason`); keine neue Auto-Mutation. |
+| PR-AI-MATCH-10 History Backfill Utility + Contract Docs | Done (maintenance slice active / 2026-03-21) | Monitoring/Polish | Legacy-History-Maintenance als expliziter Pfad: Utility `apps/web/src/features/create/attachDraftHistoryBackfill.ts`, Script `apps/web/scripts/create.history-backfill.ts`; Default dry-run, Apply nur explizit (`--apply`/`--mode=apply`), idempotent ohne Event-Duplikate. Sichere Legacy-Faelle sind `normalizable`; ambige/unsichere Faelle werden nur reportet (`unsafe_to_backfill`) und nicht umgeschrieben. Produktiver Read-Contract bleibt Single-Cursor (`nextCursor`), Legacy-Read-Normalisierung bleibt aktiv; keine neue Auto-Mutation. |
 | Create IA v2: dedizierte Mode-Module (`manual/source/ai`) statt nur Workspace-Parametrisierung | Superseded (legacy intermediate state, no longer target architecture) | GOV-AI-01 | `manual/source/ai` bleibt nur als Legacy-Kompatibilitaets-/Migrationsschicht aktiv (inkl. Alias-Normalisierung + Persistenz), ist aber nicht mehr der kanonische Produktpfad; kanonisch: Freistart + verpflichtende Qualitaetsschicht + Graph-Matching + CTA-Layer |
 | Runden Entry Surface auf produktive Quelle umstellen (statt Seed aus `features/topicRound/data.ts`) | Done (productive source + compatibility matrix active / 2026-03-19) | PR-0039 | `/runden` liest aus produktivem `output_seed`/`anlassraum`-Read-Model (`features/topicRound/entrySource.ts`, `GET /api/runden/entry`); `/demo/runden` ist expliziter Compat-Redirect auf `/runden` (kein Seed-Fallback), inkl. Tests `apps/web/tests/runden-entry.*`, `apps/web/tests/runden-compat.*`, `apps/web/tests/runden-page.acceptance.test.ts` |
 | Backward-Compatibility finalisieren | Done (legacy/demo round entry clarified / 2026-03-19) | PR-0039 | Canonical Round-Entry = `/runden`; alte Demo-Pfade zeigen explizit auf produktiven Einstieg (`apps/web/src/app/demo/runden/page.tsx`, `apps/web/src/app/demo/page.tsx`, `apps/web/src/app/demo/DemoNavClient.tsx`) |
@@ -159,7 +160,7 @@ Status: **Open (Architecture alignment required / 2026-03-20)**
 Produktiver Read-Contract:
 - Endpoint: `GET /api/admin/create/attach-drafts/[draftId]/history`
 - Query:
-  - `type=all|review|apply`
+  - `type=all|review|apply` (default: `all`)
   - `limit`
   - `cursor` (opaque)
 - Response:
@@ -167,17 +168,26 @@ Produktiver Read-Contract:
   - `hasMore`, `nextCursor`
   - `type`, `limit`, `draft`
 
-Contract-Polish:
+Cursor-/Contract-Polish:
 - Extern wird nur noch ein Cursor ausgegeben (`nextCursor`).
 - `nextScanCursor` ist nicht mehr Teil des oeffentlichen API-Contracts.
 - Intern darf der Cursor weiterhin robuste Scan-Semantik tragen (accepted/scan/tie-break), bleibt fuer Clients aber opaque.
-- Cursor sind draft- und filter-gebunden (`type`); Mismatch wird mit `invalid_history_cursor` abgelehnt.
+- Cursor sind draft- und filter-gebunden (`type`); fremde/ungueltige Cursor liefern `invalid_history_cursor` (400).
 
 Read-/Legacy-Verhalten:
 - deterministische Sortierung bleibt erhalten (`createdAt` desc, `_id` als tie-break)
 - Legacy-Rows werden weiterhin read-time defensiv normalisiert:
   - `normalizedFromLegacy`
   - `legacyNormalizationReason`
+
+Maintenance-/Backfill-Pfad:
+- Utility: `apps/web/src/features/create/attachDraftHistoryBackfill.ts`
+- Script: `apps/web/scripts/create.history-backfill.ts`
+- Default: `dry_run`
+- Apply nur explizit: `--apply` oder `--mode=apply`
+- Klassifikation: `canonical_already_ok`, `normalizable`, `unsafe_to_backfill`
+- Sichere Legacy-Faelle werden deterministisch normalisiert; ambige/unsichere Rows werden nur reportet.
+- Apply bleibt idempotent als in-place Update bestehender Rows (keine Event-Duplikate).
 
 Guardrails unveraendert:
 - kein Auto-Apply

--- a/docs/E150/Part15.md
+++ b/docs/E150/Part15.md
@@ -47,6 +47,14 @@ Dieses Dokument dient als Status-Zusammenfassung der Pfade (Part00–Part15). Es
 - Read-time Legacy-Normalisierung bleibt unveraendert aktiv:
   - `normalizedFromLegacy`
   - `legacyNormalizationReason`
+- Maintenance-/Backfill-Pfad (kein neuer Produkt-Mutationspfad):
+  - Utility: `apps/web/src/features/create/attachDraftHistoryBackfill.ts`
+  - Script: `apps/web/scripts/create.history-backfill.ts`
+  - Default: dry-run
+  - Apply nur explizit (`--apply` oder `--mode=apply`)
+  - Klassifikation: `canonical_already_ok`, `normalizable`, `unsafe_to_backfill`
+  - Apply bleibt idempotent als in-place Update ohne Event-Duplikate
+  - Unsichere/ambige Rows werden nur reportet, nicht blind umgeschrieben
 - Guardrails bleiben unveraendert:
   kein Auto-Apply, kein Auto-Merge, kein Auto-Publish, keine neue Produkt-Mutation.
 - Stage-2/Stage-3 bleiben unberuehrt und hard-deferred.

--- a/docs/E150/Part16.md
+++ b/docs/E150/Part16.md
@@ -300,6 +300,12 @@ Cursor-Regel:
 Legacy-Verhalten:
 - Read-time Legacy-Normalisierung bleibt unveraendert aktiv (`normalizedFromLegacy`, `legacyNormalizationReason`).
 
+Legacy-Backfill/Maintenance:
+- Nur expliziter Maintenance-Pfad (`apps/web/scripts/create.history-backfill.ts`, Utility `apps/web/src/features/create/attachDraftHistoryBackfill.ts`).
+- Default ist dry-run.
+- Apply nur explizit (`--apply` oder `--mode=apply`) und idempotent ohne Event-Duplikate.
+- Unsichere/ambige Rows werden reportet (`unsafe_to_backfill`), nicht blind umgeschrieben.
+
 Guardrails bleiben unveraendert:
 - kein Auto-Apply
 - kein Auto-Merge


### PR DESCRIPTION
## Ziel

Ergänzt einen konservativen Maintenance-Pfad für Legacy-History-Events bei Create Prepare-Attach und dokumentiert den aktuellen produktiven Cursor-/History-Contract sauber in E150.

## Änderungen

- add create prepare-attach history backfill utility
- add dry-run/apply maintenance script for legacy history rows
- classify rows as:
  - canonical_already_ok
  - normalizable
  - unsafe_to_backfill
- keep backfill conservative and idempotent
- update E150 docs for:
  - history route contract
  - cursor semantics
  - legacy normalization
  - maintenance/backfill workflow

## Verification

- `pnpm -C apps/web exec vitest run tests/create-prepare-attach.history-backfill.service.test.ts`
- `pnpm -C apps/web exec vitest run tests/create-prepare-attach.review-history.service.test.ts tests/create-prepare-attach.history-route.test.ts`
- `pnpm -C apps/web exec tsc --noEmit -p tsconfig.json`

## Explicitly

- backfill supports dry-run and explicit apply
- safe legacy cases are normalized
- ambiguous / unsafe rows are only reported, not rewritten
- no new auto-mutation introduced
- Stage-2 / Stage-3 remain untouched
