### PR TITLE
GOV-AI-ORCH-05 split: disagreement/confidence + sealed factcheck endpath

### DIFF
--- a/apps/web/src/app/api/_diag/gpt/route.ts
+++ b/apps/web/src/app/api/_diag/gpt/route.ts
@@ -2,9 +2,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { callOpenAI } from "@features/ai/providers/openai";
 import { requireAdminOrEditor } from "../../feeds/_auth";
+import { resolveAiRouteClassification } from "@features/ai/e150/routeClassification";
 export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {
+  const routeClassification = resolveAiRouteClassification("/api/_diag/gpt");
   const gate = await requireAdminOrEditor(req);
   if (gate) return gate;
 
@@ -18,8 +20,17 @@ export async function GET(req: NextRequest) {
         Number(process.env.OPENAI_TIMEOUT_MS || 18000),
       ),
     });
-    return NextResponse.json({ ok: true, text, model: (raw as any)?.model ?? null, timeMs: Date.now() - t0 });
+    return NextResponse.json({
+      ok: true,
+      text,
+      model: (raw as any)?.model ?? null,
+      timeMs: Date.now() - t0,
+      meta: { routeClassification },
+    });
   } catch (e: any) {
-    return NextResponse.json({ ok: false, error: String(e) }, { status: 500 });
+    return NextResponse.json(
+      { ok: false, error: String(e), meta: { routeClassification } },
+      { status: 500 },
+    );
   }
 }

--- a/apps/web/src/app/api/contributions/refine/route.ts
+++ b/apps/web/src/app/api/contributions/refine/route.ts
@@ -5,6 +5,7 @@ import {
   PROMPT_OUTPUT_CONTRACT_VERSION,
   type PromptOutputMeta,
 } from "@/features/ai/promptOutputEnvelope";
+import { resolveAiRouteClassification } from "@features/ai/e150/routeClassification";
 
 /* -------------------- JSON helpers -------------------- */
 function jsonOk(data: any, status = 200) {
@@ -139,11 +140,14 @@ export const dynamic = "force-dynamic";
 
 /* -------------------- POST -------------------- */
 export async function POST(req: NextRequest) {
+  const routeClassification = resolveAiRouteClassification("/api/contributions/refine");
   try {
     const body = await req.json().catch(() => null);
     const claims = isArray(body?.claims) ? body!.claims : null;
     const locale: "de" | "en" = body?.locale === "en" ? "en" : "de";
-    if (!claims || claims.length === 0) return jsonErr("INVALID_PAYLOAD", { hint: "claims[]" }, 400);
+    if (!claims || claims.length === 0) {
+      return jsonErr("INVALID_PAYLOAD", { hint: "claims[]", meta: { routeClassification } }, 400);
+    }
 
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort("AI_TIMEOUT"), REFINE_BUDGET_MS);
@@ -174,6 +178,7 @@ export async function POST(req: NextRequest) {
         claims,
         draftIndexes: drafts,
         promptOutput: buildPromptOutputMeta(extracted.meta.parserMode),
+        meta: { routeClassification },
       });
     }
 
@@ -186,6 +191,7 @@ export async function POST(req: NextRequest) {
         promptVersion: extracted.meta.promptVersion,
         outputVersion: extracted.meta.outputVersion,
       },
+      meta: { routeClassification },
     });
   } catch (e: any) {
     const msg = String(e?.message || "INTERNAL_ERROR");
@@ -196,6 +202,7 @@ export async function POST(req: NextRequest) {
       reason: degraded ? "AI_TIMEOUT" : msg,
       ...base,
       promptOutput: buildPromptOutputMeta("invalid"),
+      meta: { routeClassification },
     });
   }
 }

--- a/apps/web/src/app/api/contributions/trace/route.ts
+++ b/apps/web/src/app/api/contributions/trace/route.ts
@@ -11,6 +11,7 @@ import {
   PROMPT_OUTPUT_CONTRACT_VERSION,
   type PromptOutputMeta,
 } from "@/features/ai/promptOutputEnvelope";
+import { resolveAiRouteClassification } from "@features/ai/e150/routeClassification";
 
 const TraceSchema = z.object({
   textOriginal: z.string().min(1).max(10_000),
@@ -85,15 +86,27 @@ function buildPromptOutputMeta(
 }
 
 export async function POST(req: NextRequest) {
+  const routeClassification = resolveAiRouteClassification("/api/contributions/trace");
   const ip = (req.headers.get("x-forwarded-for") || "local").split(",")[0].trim();
   const rl = await rateLimitOrThrow(`trace:ip:${ip}`, 30, 10 * 60 * 1000, { salt: "trace" });
   if (!rl.ok) {
-    return NextResponse.json({ ok: false, error: "rate_limited" }, { status: 429 });
+    return NextResponse.json(
+      { ok: false, error: "rate_limited", meta: { routeClassification } },
+      { status: 429 },
+    );
   }
 
   const body = TraceSchema.safeParse(await req.json().catch(() => ({})));
   if (!body.success) {
-    return NextResponse.json({ ok: false, error: "invalid_body", issues: body.error.issues }, { status: 400 });
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "invalid_body",
+        issues: body.error.issues,
+        meta: { routeClassification },
+      },
+      { status: 400 },
+    );
   }
 
   const prompt = buildPrompt(body.data);
@@ -121,6 +134,7 @@ export async function POST(req: NextRequest) {
         ok: false,
         error: "trace_parse_failed",
         promptOutput: buildPromptOutputMeta(extracted.meta.parserMode),
+        meta: { routeClassification },
       },
       { status: 502 },
     );
@@ -136,6 +150,7 @@ export async function POST(req: NextRequest) {
         promptVersion: extracted.meta.promptVersion,
         outputVersion: extracted.meta.outputVersion,
       },
+      meta: { routeClassification },
     },
     { status: 200 },
   );

--- a/apps/web/src/app/api/diag/gpt/route.ts
+++ b/apps/web/src/app/api/diag/gpt/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from "next/server";
 import { callOpenAI } from "@features/ai/providers/openai";
+import { resolveAiRouteClassification } from "@features/ai/e150/routeClassification";
 export const dynamic = "force-dynamic";
 
 export async function GET() {
+  const routeClassification = resolveAiRouteClassification("/api/diag/gpt");
   const t0 = Date.now();
   try {
     const prompt = 'Gib NUR JSON: {"ok":true,"echo":"hi"}';
@@ -13,8 +15,17 @@ export async function GET() {
         Number(process.env.OPENAI_TIMEOUT_MS || 18000),
       ),
     });
-    return NextResponse.json({ ok: true, text: out.text, raw: out.raw, timeMs: Date.now()-t0 });
+    return NextResponse.json({
+      ok: true,
+      text: out.text,
+      raw: out.raw,
+      timeMs: Date.now()-t0,
+      meta: { routeClassification },
+    });
   } catch (e:any) {
-    return NextResponse.json({ ok: false, error: String(e?.message || e) }, { status: 500 });
+    return NextResponse.json(
+      { ok: false, error: String(e?.message || e), meta: { routeClassification } },
+      { status: 500 },
+    );
   }
 }

--- a/apps/web/src/app/api/factcheck/enqueue/route.ts
+++ b/apps/web/src/app/api/factcheck/enqueue/route.ts
@@ -16,6 +16,8 @@ import {
   getSealedFactcheckJourneyProfile,
 } from "@features/ai/e150/factcheckProfiles";
 import { deriveVerificationLabel } from "@features/ai/e150/verificationContract";
+import { resolveSealedFactcheckStatusView } from "@features/ai/e150/factcheckStatus";
+import { resolveAiRouteClassification } from "@features/ai/e150/routeClassification";
 import {
   ensureDossierForStatement,
   dossierSourcesCol,
@@ -361,6 +363,7 @@ export async function POST(req: NextRequest) {
 
     const lang = toShortLang(payload.language);
     const jobId = safeRandomId();
+    const routeClassification = resolveAiRouteClassification("/api/factcheck/enqueue");
 
     // 1) Input bestimmen: Text oder Draft laden
     let inputText = (payload.text ?? "").trim();
@@ -413,6 +416,11 @@ export async function POST(req: NextRequest) {
       }
     }
 
+    const analysisMeta = analysis && typeof (analysis as any)?._meta === "object" ? (analysis as any)._meta : null;
+    const disagreement = analysisMeta?.disagreement ?? null;
+    const orchestrationConfidence = analysisMeta?.confidence ?? null;
+    const fallbackUsed = typeof analysisMeta?.fallbackUsed === "boolean" ? analysisMeta.fallbackUsed : false;
+
     const status: FactcheckJobStatus = analysisError ? "failed" : "completed";
 
     // 3) SERP (optional, schnell & begrenzt)
@@ -425,6 +433,11 @@ export async function POST(req: NextRequest) {
     // 4) Persist Job (triMongo)
     const col = await factcheckJobsCol();
     const now = new Date();
+    const verification = buildSealedFactcheckContract({
+      deepSearch: payload.deepSearch === true,
+      sealGranted: false,
+    });
+
     await col.insertOne({
       jobId,
       draftId: payload.draftId ?? null,
@@ -436,6 +449,13 @@ export async function POST(req: NextRequest) {
       confidence: 0.5,
       claims,
       serpResults,
+      verificationMode: verification.verificationMode,
+      researchUsed: verification.researchUsed,
+      sealEligible: verification.sealEligible,
+      sealGranted: verification.sealGranted,
+      fallbackUsed,
+      disagreement,
+      orchestrationConfidence,
       error: analysisError,
       createdAt: now,
       updatedAt: now,
@@ -458,13 +478,13 @@ export async function POST(req: NextRequest) {
     }
 
     const journeyProfile = getSealedFactcheckJourneyProfile();
-    const verification = buildSealedFactcheckContract({
-      deepSearch: payload.deepSearch === true,
-      sealGranted: false,
+    const verificationStatus = resolveSealedFactcheckStatusView({
+      status,
+      verification,
     });
     const verificationLabel = deriveVerificationLabel({
-      verificationMode: verification.verificationMode,
-      sealGranted: verification.sealGranted,
+      verificationMode: verificationStatus.verificationMode,
+      sealGranted: verificationStatus.sealGranted,
     });
 
     const durationMs = Date.now() - t0;
@@ -476,11 +496,17 @@ export async function POST(req: NextRequest) {
       serpCount: serpResults.length,
       durationMs,
       analysisError: analysisError ?? undefined,
-      verificationMode: verification.verificationMode,
-      researchUsed: verification.researchUsed,
-      sealEligible: verification.sealEligible,
-      sealGranted: verification.sealGranted,
+      verificationMode: verificationStatus.verificationMode,
+      researchUsed: verificationStatus.researchUsed,
+      sealEligible: verificationStatus.sealEligible,
+      sealGranted: verificationStatus.sealGranted,
       verificationLabel,
+      fallbackUsed,
+      disagreement,
+      orchestrationConfidence,
+      workflowStage: verificationStatus.workflowStage,
+      workflowLabel: verificationStatus.workflowLabel,
+      sealStatus: verificationStatus.sealLabel,
       meta: {
         journeyProfile: journeyProfile.journey,
         lane: journeyProfile.lane,
@@ -490,6 +516,18 @@ export async function POST(req: NextRequest) {
           fallback: journeyProfile.fallbackProviders,
           openAiRoles: journeyProfile.openAiRoles,
         },
+        verificationMode: verificationStatus.verificationMode,
+        researchUsed: verificationStatus.researchUsed,
+        sealEligible: verificationStatus.sealEligible,
+        sealGranted: verificationStatus.sealGranted,
+        verificationLabel,
+        workflowStage: verificationStatus.workflowStage,
+        workflowLabel: verificationStatus.workflowLabel,
+        sealStatus: verificationStatus.sealLabel,
+        fallbackUsed,
+        disagreement,
+        orchestrationConfidence,
+        routeClassification,
       },
     });
   } catch (e: any) {

--- a/apps/web/src/app/api/factcheck/result/[contributionId]/route.ts
+++ b/apps/web/src/app/api/factcheck/result/[contributionId]/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { factcheckJobsCol } from "@features/factcheck/db";
+import { resolveSealedFactcheckStatusView } from "@features/ai/e150/factcheckStatus";
+import { resolveAiRouteClassification } from "@features/ai/e150/routeClassification";
 
 const ParamsSchema = z.object({ contributionId: z.string().min(1) });
 
@@ -14,6 +16,9 @@ export async function GET(
   context: { params: Promise<{ contributionId: string }> },
 ) {
   const { contributionId } = await resolveParams(context.params);
+  const routeClassification = resolveAiRouteClassification(
+    `/api/factcheck/result/${contributionId}`,
+  );
 
   const col = await factcheckJobsCol();
   const job = await col
@@ -30,6 +35,14 @@ export async function GET(
     );
   }
 
+  const sealedStatus = resolveSealedFactcheckStatusView({
+    status: job.status ?? null,
+    verificationMode: (job as any)?.verificationMode,
+    researchUsed: (job as any)?.researchUsed,
+    sealEligible: (job as any)?.sealEligible,
+    sealGranted: (job as any)?.sealGranted,
+  });
+
   return NextResponse.json({
     ok: true,
     job: {
@@ -40,9 +53,41 @@ export async function GET(
       durationMs: job.durationMs ?? null,
       createdAt: job.createdAt ?? null,
       finishedAt: job.finishedAt ?? null,
+      verificationMode: sealedStatus.verificationMode,
+      researchUsed: sealedStatus.researchUsed,
+      sealEligible: sealedStatus.sealEligible,
+      sealGranted: sealedStatus.sealGranted,
+      sealedAt: (job as any)?.sealedAt ?? null,
+      verificationLabel: sealedStatus.verificationLabel,
+      workflowStage: sealedStatus.workflowStage,
+      workflowLabel: sealedStatus.workflowLabel,
+      sealStatus: sealedStatus.sealLabel,
+      fallbackUsed: (job as any)?.fallbackUsed ?? false,
+      disagreement: (job as any)?.disagreement ?? null,
+      orchestrationConfidence: (job as any)?.orchestrationConfidence ?? null,
+      lane: "sealed_factcheck",
+      journeyProfile: "sealed_factcheck",
     },
     results: job.claims ?? [],
     serpResults: job.serpResults ?? [],
     error: job.error ?? null,
+    verificationMode: sealedStatus.verificationMode,
+    researchUsed: sealedStatus.researchUsed,
+    sealEligible: sealedStatus.sealEligible,
+    sealGranted: sealedStatus.sealGranted,
+    sealedAt: (job as any)?.sealedAt ?? null,
+    verificationLabel: sealedStatus.verificationLabel,
+    workflowStage: sealedStatus.workflowStage,
+    workflowLabel: sealedStatus.workflowLabel,
+    sealStatus: sealedStatus.sealLabel,
+    confidence: job.confidence ?? null,
+    fallbackUsed: (job as any)?.fallbackUsed ?? false,
+    disagreement: (job as any)?.disagreement ?? null,
+    orchestrationConfidence: (job as any)?.orchestrationConfidence ?? null,
+    meta: {
+      lane: "sealed_factcheck",
+      journeyProfile: "sealed_factcheck",
+      routeClassification,
+    },
   });
 }

--- a/apps/web/src/app/api/factcheck/status/[jobId]/route.ts
+++ b/apps/web/src/app/api/factcheck/status/[jobId]/route.ts
@@ -4,6 +4,8 @@ import { formatError } from "@core/errors/formatError";
 import { logger } from "@core/observability/logger";
 import { hasPermission, PERMISSIONS } from "@core/auth/rbac";
 import { factcheckJobsCol } from "@features/factcheck/db";
+import { resolveSealedFactcheckStatusView } from "@features/ai/e150/factcheckStatus";
+import { resolveAiRouteClassification } from "@features/ai/e150/routeClassification";
 import { logPermissionDenied, resolveRoleFromRequest } from "@/lib/server/auth/requestRole";
 import {
   internalSystemIdentityAuditFields,
@@ -58,6 +60,7 @@ export async function GET(
     }
 
     const { jobId } = await resolveParams(ctx.params);
+    const routeClassification = resolveAiRouteClassification(`/api/factcheck/status/${jobId}`);
 
     const col = await factcheckJobsCol();
     const job = await col.findOne(
@@ -75,6 +78,14 @@ export async function GET(
           contributionId: 1,
           claims: 1,
           serpResults: 1,
+          verificationMode: 1,
+          researchUsed: 1,
+          sealEligible: 1,
+          sealGranted: 1,
+          sealedAt: 1,
+          fallbackUsed: 1,
+          disagreement: 1,
+          orchestrationConfidence: 1,
           error: 1,
         },
       },
@@ -84,6 +95,14 @@ export async function GET(
       logger.warn({ fe }, "FACTCHECK_STATUS_NOT_FOUND");
       return NextResponse.json(fe, { status: 404 });
     }
+
+    const sealedStatus = resolveSealedFactcheckStatusView({
+      status: job.status,
+      verificationMode: (job as any)?.verificationMode,
+      researchUsed: (job as any)?.researchUsed,
+      sealEligible: (job as any)?.sealEligible,
+      sealGranted: (job as any)?.sealGranted,
+    });
 
     const durationMs = Date.now() - t0;
     return NextResponse.json({
@@ -99,10 +118,42 @@ export async function GET(
         durationMs,
         draftId: job.draftId ?? null,
         contributionId: job.contributionId ?? null,
+        verificationMode: sealedStatus.verificationMode,
+        researchUsed: sealedStatus.researchUsed,
+        sealEligible: sealedStatus.sealEligible,
+        sealGranted: sealedStatus.sealGranted,
+        sealedAt: (job as any)?.sealedAt ?? null,
+        verificationLabel: sealedStatus.verificationLabel,
+        workflowStage: sealedStatus.workflowStage,
+        workflowLabel: sealedStatus.workflowLabel,
+        sealStatus: sealedStatus.sealLabel,
+        fallbackUsed: (job as any)?.fallbackUsed ?? false,
+        disagreement: (job as any)?.disagreement ?? null,
+        orchestrationConfidence: (job as any)?.orchestrationConfidence ?? null,
+        lane: "sealed_factcheck",
+        journeyProfile: "sealed_factcheck",
       },
       claims: job.claims ?? [],
       serpResults: job.serpResults ?? [],
       error: job.error ?? null,
+      verificationMode: sealedStatus.verificationMode,
+      researchUsed: sealedStatus.researchUsed,
+      sealEligible: sealedStatus.sealEligible,
+      sealGranted: sealedStatus.sealGranted,
+      sealedAt: (job as any)?.sealedAt ?? null,
+      verificationLabel: sealedStatus.verificationLabel,
+      workflowStage: sealedStatus.workflowStage,
+      workflowLabel: sealedStatus.workflowLabel,
+      sealStatus: sealedStatus.sealLabel,
+      confidence: job.confidence ?? null,
+      fallbackUsed: (job as any)?.fallbackUsed ?? false,
+      disagreement: (job as any)?.disagreement ?? null,
+      orchestrationConfidence: (job as any)?.orchestrationConfidence ?? null,
+      meta: {
+        lane: "sealed_factcheck",
+        journeyProfile: "sealed_factcheck",
+        routeClassification,
+      },
     });
   } catch (e: any) {
     if (e instanceof ZodError) {

--- a/apps/web/src/app/api/factcheck/status/[jobId]/seal/route.ts
+++ b/apps/web/src/app/api/factcheck/status/[jobId]/seal/route.ts
@@ -1,0 +1,165 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { hasPermission, PERMISSIONS } from "@core/auth/rbac";
+import { factcheckJobsCol } from "@features/factcheck/db";
+import { buildSealedFactcheckContract } from "@features/ai/e150/factcheckProfiles";
+import { deriveVerificationLabel } from "@features/ai/e150/verificationContract";
+import { resolveSealedFactcheckStatusView } from "@features/ai/e150/factcheckStatus";
+import { resolveAiRouteClassification } from "@features/ai/e150/routeClassification";
+import { logPermissionDenied, resolveRoleFromRequest } from "@/lib/server/auth/requestRole";
+import {
+  internalSystemIdentityAuditFields,
+  resolveInternalSystemIdentity,
+  resolveTrustedInternalSystemIdentity,
+} from "@/lib/server/auth/systemIdentity";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const ParamsSchema = z.object({ jobId: z.string().min(3) });
+
+async function resolveParams(p: any): Promise<{ jobId: string }> {
+  const val = p && typeof p.then === "function" ? await p : p;
+  return ParamsSchema.parse(val);
+}
+
+export async function POST(
+  req: NextRequest,
+  ctx: { params: Promise<{ jobId: string }> },
+) {
+  const systemIdentity = resolveInternalSystemIdentity(req);
+  const trustedSystemIdentity = resolveTrustedInternalSystemIdentity(req);
+  const roleContext = resolveRoleFromRequest(req);
+  const hasSessionAccess =
+    roleContext.source === "cookie" && hasPermission(roleContext.role, PERMISSIONS.FACTCHECK_STATUS);
+  const hasTrustedSystemAccess =
+    trustedSystemIdentity?.source === "factcheck_queue" ||
+    trustedSystemIdentity?.source === "factcheck_worker";
+
+  if (!hasSessionAccess && !hasTrustedSystemAccess) {
+    logPermissionDenied({
+      req,
+      scope: "factcheck.status.seal",
+      permission: PERMISSIONS.FACTCHECK_STATUS,
+      role: roleContext.role,
+      source: roleContext.source,
+      details: {
+        ...internalSystemIdentityAuditFields(systemIdentity),
+        denyReason: systemIdentity
+          ? "system_identity_untrusted_or_disallowed"
+          : roleContext.source === "header"
+            ? "header_role_not_allowed"
+            : "missing_permission",
+      },
+    });
+    return NextResponse.json(
+      { ok: false, code: "FORBIDDEN", message: "Permission denied" },
+      { status: 403 },
+    );
+  }
+
+  const { jobId } = await resolveParams(ctx.params);
+  const routeClassification = resolveAiRouteClassification(`/api/factcheck/status/${jobId}/seal`);
+  const col = await factcheckJobsCol();
+  const job = await col.findOne(
+    { jobId },
+    {
+      projection: {
+        jobId: 1,
+        status: 1,
+        claims: 1,
+        error: 1,
+        researchUsed: 1,
+      },
+    },
+  );
+
+  if (!job) {
+    return NextResponse.json(
+      { ok: false, code: "NOT_FOUND", message: "Job not found", jobId },
+      { status: 404 },
+    );
+  }
+
+  if (job.status !== "completed") {
+    return NextResponse.json(
+      {
+        ok: false,
+        code: "SEAL_NOT_READY",
+        message: "Seal can only be granted for completed jobs.",
+        status: job.status,
+      },
+      { status: 409 },
+    );
+  }
+
+  if (job.error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        code: "SEAL_NOT_READY",
+        message: "Seal cannot be granted while job has errors.",
+      },
+      { status: 409 },
+    );
+  }
+
+  const claimCount = Array.isArray((job as any)?.claims) ? (job as any).claims.length : 0;
+  if (claimCount === 0) {
+    return NextResponse.json(
+      {
+        ok: false,
+        code: "SEAL_NOT_READY",
+        message: "Seal cannot be granted without evaluated claims.",
+      },
+      { status: 409 },
+    );
+  }
+
+  const verification = buildSealedFactcheckContract({
+    researchUsed: (job as any)?.researchUsed === "deep_search" ? "deep_search" : "search",
+    sealGranted: true,
+  });
+  const now = new Date();
+  await col.updateOne(
+    { jobId },
+    {
+      $set: {
+        verificationMode: verification.verificationMode,
+        researchUsed: verification.researchUsed,
+        sealEligible: verification.sealEligible,
+        sealGranted: verification.sealGranted,
+        sealedAt: now,
+        updatedAt: now,
+      },
+    },
+  );
+
+  const statusView = resolveSealedFactcheckStatusView({
+    status: "completed",
+    verification,
+  });
+  const verificationLabel = deriveVerificationLabel({
+    verificationMode: statusView.verificationMode,
+    sealGranted: statusView.sealGranted,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    jobId,
+    verificationMode: statusView.verificationMode,
+    researchUsed: statusView.researchUsed,
+    sealEligible: statusView.sealEligible,
+    sealGranted: statusView.sealGranted,
+    verificationLabel,
+    workflowStage: statusView.workflowStage,
+    workflowLabel: statusView.workflowLabel,
+    sealStatus: statusView.sealLabel,
+    sealedAt: now.toISOString(),
+    meta: {
+      lane: "sealed_factcheck",
+      journeyProfile: "sealed_factcheck",
+      routeClassification,
+    },
+  });
+}

--- a/apps/web/src/app/api/factcheck/status/route.ts
+++ b/apps/web/src/app/api/factcheck/status/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { hasPermission, PERMISSIONS } from "@core/auth/rbac";
 import { formatError } from "@core/errors/formatError";
 import { factcheckJobsCol } from "@features/factcheck/db";
+import { resolveSealedFactcheckStatusView } from "@features/ai/e150/factcheckStatus";
+import { resolveAiRouteClassification } from "@features/ai/e150/routeClassification";
 import { logPermissionDenied, resolveRoleFromRequest } from "@/lib/server/auth/requestRole";
 import {
   internalSystemIdentityAuditFields,
@@ -43,6 +45,7 @@ export async function GET(req: NextRequest) {
 
   const url = new URL(req.url);
   const limit = Math.min(Number(url.searchParams.get("limit") || 20), 100);
+  const routeClassification = resolveAiRouteClassification("/api/factcheck/status");
 
   const col = await factcheckJobsCol();
   const jobs = await col
@@ -61,10 +64,53 @@ export async function GET(req: NextRequest) {
           contributionId: { $ifNull: ["$contributionId", null] },
           claimsCount: { $size: { $ifNull: ["$claims", []] } },
           serpCount: { $size: { $ifNull: ["$serpResults", []] } },
+          verificationMode: { $ifNull: ["$verificationMode", null] },
+          researchUsed: { $ifNull: ["$researchUsed", null] },
+          sealEligible: { $ifNull: ["$sealEligible", null] },
+          sealGranted: { $ifNull: ["$sealGranted", null] },
+          sealedAt: { $ifNull: ["$sealedAt", null] },
+          fallbackUsed: { $ifNull: ["$fallbackUsed", false] },
+          disagreement: { $ifNull: ["$disagreement", null] },
+          orchestrationConfidence: { $ifNull: ["$orchestrationConfidence", null] },
         },
       },
     ])
     .toArray();
 
-  return NextResponse.json({ ok: true, jobs });
+  const normalizedJobs = jobs.map((job: any) => {
+    const sealedStatus = resolveSealedFactcheckStatusView({
+      status: job.status,
+      verificationMode: job.verificationMode,
+      researchUsed: job.researchUsed,
+      sealEligible: job.sealEligible,
+      sealGranted: job.sealGranted,
+    });
+    return {
+      ...job,
+      verificationMode: sealedStatus.verificationMode,
+      researchUsed: sealedStatus.researchUsed,
+      sealEligible: sealedStatus.sealEligible,
+      sealGranted: sealedStatus.sealGranted,
+      sealedAt: job.sealedAt ?? null,
+      verificationLabel: sealedStatus.verificationLabel,
+      workflowStage: sealedStatus.workflowStage,
+      workflowLabel: sealedStatus.workflowLabel,
+      sealStatus: sealedStatus.sealLabel,
+      fallbackUsed: job.fallbackUsed ?? false,
+      disagreement: job.disagreement ?? null,
+      orchestrationConfidence: job.orchestrationConfidence ?? null,
+      lane: "sealed_factcheck",
+      journeyProfile: "sealed_factcheck",
+    };
+  });
+
+  return NextResponse.json({
+    ok: true,
+    jobs: normalizedJobs,
+    meta: {
+      lane: "sealed_factcheck",
+      journeyProfile: "sealed_factcheck",
+      routeClassification,
+    },
+  });
 }

--- a/apps/web/src/app/api/quality/polish/route.ts
+++ b/apps/web/src/app/api/quality/polish/route.ts
@@ -1,11 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
+import { resolveAiRouteClassification } from "@features/ai/e150/routeClassification";
 export const runtime = "nodejs"; export const dynamic = "force-dynamic";
 type PolishOut = { improved: string; notes: string[]; claimsHint: { count: number; split?: string[] } | null; };
 
 export async function POST(req: NextRequest){
+  const routeClassification = resolveAiRouteClassification("/api/quality/polish");
   const { text } = await req.json().catch(()=>({text:""}));
   const t = String(text||"").trim();
-  if(!t) return NextResponse.json({ improved:"", notes:["Kein Text."], claimsHint:null });
+  if(!t) {
+    return NextResponse.json({
+      improved:"",
+      notes:["Kein Text."],
+      claimsHint:null,
+      meta: { routeClassification },
+    });
+  }
 
   try{
     const mod = await import("@/core/gpt").catch(()=>null) as any;
@@ -28,7 +37,7 @@ TEXT:
           ? { count: Number(j.claimsHint.count||0), split: Array.isArray(j.claimsHint.split)? j.claimsHint.split.slice(0,5):[] }
           : { count: 1, split: [t] }
       };
-      return NextResponse.json(safe);
+      return NextResponse.json({ ...safe, meta: { routeClassification } });
     }
   }catch(_e){}
   const sentences = t.split(/[.!?]\s+/).filter(Boolean);
@@ -38,5 +47,10 @@ TEXT:
     "Begriffe schärfen (was genau ist gemeint?).",
     "Falls mehrere Punkte: in getrennte Aussagen teilen.",
   ];
-  return NextResponse.json({ improved, notes, claimsHint: { count: sentences.length, split: sentences.slice(0,5) } });
+  return NextResponse.json({
+    improved,
+    notes,
+    claimsHint: { count: sentences.length, split: sentences.slice(0,5) },
+    meta: { routeClassification },
+  });
 }

--- a/apps/web/src/lib/worker.ts
+++ b/apps/web/src/lib/worker.ts
@@ -11,23 +11,64 @@ type EnqueuePayload = {
   language?: string;
   topic?: string;
   priority?: number;
+  deepSearch?: boolean;
+  withSerp?: boolean;
 };
 
 type EnqueueResponse =
-  | { ok: true; jobId: string; message?: string }
+  | {
+      ok: true;
+      jobId: string;
+      status?: string;
+      message?: string;
+      verificationMode?: "none" | "precheck" | "sealed";
+      researchUsed?: "none" | "lite" | "search" | "deep_search";
+      sealEligible?: boolean;
+      sealGranted?: boolean;
+      verificationLabel?: "analysiert" | "geprueft" | "verifiziert";
+      workflowStage?: "started" | "queued" | "in_progress" | "completed";
+      workflowLabel?: string;
+      sealStatus?: string;
+      meta?: {
+        lane?: "standard" | "sealed_factcheck";
+        journeyProfile?: "analyze" | "media" | "guided" | "sealed_factcheck";
+      };
+    }
   | { ok: false; reason?: string; code?: string; message?: string };
 
 type StatusResponse =
   | {
       ok: true;
       job: {
-        id: string;
+        id?: string;
         jobId: string;
-        status: "PENDING" | "PROCESSING" | "COMPLETED" | "FAILED";
-        tokensUsed: number;
-        durationMs: number;
+        status: string;
+        tokensUsed?: number;
+        durationMs?: number;
+        verificationMode?: "none" | "precheck" | "sealed";
+        researchUsed?: "none" | "lite" | "search" | "deep_search";
+        sealEligible?: boolean;
+        sealGranted?: boolean;
+        verificationLabel?: "analysiert" | "geprueft" | "verifiziert";
+        workflowStage?: "started" | "queued" | "in_progress" | "completed";
+        workflowLabel?: string;
+        sealStatus?: string;
+        lane?: "standard" | "sealed_factcheck";
+        journeyProfile?: "analyze" | "media" | "guided" | "sealed_factcheck";
       };
       claims: any[];
+      verificationMode?: "none" | "precheck" | "sealed";
+      researchUsed?: "none" | "lite" | "search" | "deep_search";
+      sealEligible?: boolean;
+      sealGranted?: boolean;
+      verificationLabel?: "analysiert" | "geprueft" | "verifiziert";
+      workflowStage?: "started" | "queued" | "in_progress" | "completed";
+      workflowLabel?: string;
+      sealStatus?: string;
+      meta?: {
+        lane?: "standard" | "sealed_factcheck";
+        journeyProfile?: "analyze" | "media" | "guided" | "sealed_factcheck";
+      };
     }
   | { ok: false; reason?: string; code?: string; message?: string };
 

--- a/apps/web/tests/e150-disagreement-confidence.contract.test.ts
+++ b/apps/web/tests/e150-disagreement-confidence.contract.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { computeDisagreementConfidence } from "@features/ai/e150/disagreementConfidence";
+
+describe("e150 disagreement/confidence contract", () => {
+  it("reports high specialist agreement without fallback reliance", () => {
+    const { disagreement, confidence } = computeDisagreementConfidence({
+      primaryProviders: ["mistral", "gemini", "anthropic"],
+      successfulProviders: ["mistral", "gemini", "anthropic"],
+      failedProviders: [],
+      candidateScores: [
+        { provider: "mistral", score: 1.1 },
+        { provider: "gemini", score: 1.05 },
+        { provider: "anthropic", score: 1.08 },
+      ],
+      bestProvider: "mistral",
+      fallbackProviders: ["openai"],
+      fallbackUsed: false,
+    });
+
+    expect(disagreement.present).toBe(false);
+    expect(disagreement.specialistAgreement).toBe("high");
+    expect(disagreement.missingSpecialists).toEqual([]);
+    expect(disagreement.fallbackReliance).toBe("none");
+    expect(confidence.bucket).toBe("high");
+    expect(confidence.score).toBeGreaterThanOrEqual(0.75);
+  });
+
+  it("reports disagreement for missing specialists and fallback reliance", () => {
+    const { disagreement, confidence } = computeDisagreementConfidence({
+      primaryProviders: ["mistral", "gemini", "anthropic"],
+      successfulProviders: ["openai"],
+      failedProviders: ["gemini"],
+      candidateScores: [{ provider: "openai", score: 0.7 }],
+      bestProvider: "openai",
+      fallbackProviders: ["openai"],
+      fallbackUsed: true,
+    });
+
+    expect(disagreement.present).toBe(true);
+    expect(disagreement.missingSpecialists).toEqual(["mistral", "gemini", "anthropic"]);
+    expect(disagreement.fallbackReliance).toBe("full");
+    expect(disagreement.coverage.successfulPrimary).toBe(0);
+    expect(confidence.bucket).toBe("low");
+    expect(confidence.reasons).toContain("fallback_reliance");
+    expect(confidence.reasons.some((reason) => reason.startsWith("missing_specialists"))).toBe(
+      true,
+    );
+  });
+});

--- a/apps/web/tests/e150-journey-routing.contract.test.ts
+++ b/apps/web/tests/e150-journey-routing.contract.test.ts
@@ -9,7 +9,9 @@ import { resolveJourneyKey } from "@features/ai/e150/roleRouting";
 import {
   applyPresentationPassStub,
   canUsePresentationPass,
+  isPresentationPassNonMutative,
 } from "@features/ai/e150/presentationPass";
+import { resolveSealedFactcheckStatusView } from "@features/ai/e150/factcheckStatus";
 
 describe("GOV-AI-ORCH-05 journey defaults", () => {
   const standardJourneys: E150JourneyKey[] = ["analyze", "media", "guided"];
@@ -59,5 +61,62 @@ describe("GOV-AI-ORCH-05 journey defaults", () => {
     expect(applied.applied).toBe(false);
     expect(applied.text).toBe(sample);
     expect(applied.policy?.nonMutative).toBe(true);
+
+    const before = {
+      claims: [{ id: "c1", text: "A" }],
+      evidence: [{ id: "e1" }],
+      trust: { score: 0.7 },
+      verificationMode: "sealed" as const,
+      researchUsed: "search" as const,
+      sealEligible: true,
+      sealGranted: false,
+    };
+
+    const afterStyleOnly = {
+      ...before,
+      trust: { score: 0.7 },
+    };
+    const afterMutative = {
+      ...before,
+      claims: [{ id: "c2", text: "Changed" }],
+    };
+
+    expect(isPresentationPassNonMutative(before, afterStyleOnly)).toBe(true);
+    expect(isPresentationPassNonMutative(before, afterMutative)).toBe(false);
+  });
+
+  it("maps sealed status stages and keeps seal pending until granted", () => {
+    const started = resolveSealedFactcheckStatusView({
+      status: "started",
+      verificationMode: "sealed",
+      researchUsed: "search",
+      sealEligible: true,
+      sealGranted: false,
+    });
+    expect(started.workflowStage).toBe("started");
+    expect(started.verificationLabel).toBe("geprueft");
+    expect(started.sealLabel).toBe("Siegel ausstehend");
+
+    const queued = resolveSealedFactcheckStatusView({
+      status: "queued",
+      verificationMode: "sealed",
+      researchUsed: "search",
+      sealEligible: true,
+      sealGranted: false,
+    });
+    expect(queued.workflowStage).toBe("queued");
+    expect(queued.verificationLabel).toBe("geprueft");
+    expect(queued.sealLabel).toBe("Siegel ausstehend");
+
+    const completed = resolveSealedFactcheckStatusView({
+      status: "completed",
+      verificationMode: "sealed",
+      researchUsed: "deep_search",
+      sealEligible: true,
+      sealGranted: true,
+    });
+    expect(completed.workflowStage).toBe("completed");
+    expect(completed.verificationLabel).toBe("verifiziert");
+    expect(completed.sealLabel).toBe("Siegel erteilt");
   });
 });

--- a/apps/web/tests/e150-journey-routing.contract.test.ts
+++ b/apps/web/tests/e150-journey-routing.contract.test.ts
@@ -9,7 +9,6 @@ import { resolveJourneyKey } from "@features/ai/e150/roleRouting";
 import {
   applyPresentationPassStub,
   canUsePresentationPass,
-  isPresentationPassNonMutative,
 } from "@features/ai/e150/presentationPass";
 import { resolveSealedFactcheckStatusView } from "@features/ai/e150/factcheckStatus";
 
@@ -62,27 +61,6 @@ describe("GOV-AI-ORCH-05 journey defaults", () => {
     expect(applied.text).toBe(sample);
     expect(applied.policy?.nonMutative).toBe(true);
 
-    const before = {
-      claims: [{ id: "c1", text: "A" }],
-      evidence: [{ id: "e1" }],
-      trust: { score: 0.7 },
-      verificationMode: "sealed" as const,
-      researchUsed: "search" as const,
-      sealEligible: true,
-      sealGranted: false,
-    };
-
-    const afterStyleOnly = {
-      ...before,
-      trust: { score: 0.7 },
-    };
-    const afterMutative = {
-      ...before,
-      claims: [{ id: "c2", text: "Changed" }],
-    };
-
-    expect(isPresentationPassNonMutative(before, afterStyleOnly)).toBe(true);
-    expect(isPresentationPassNonMutative(before, afterMutative)).toBe(false);
   });
 
   it("maps sealed status stages and keeps seal pending until granted", () => {

--- a/apps/web/tests/e150-route-classification.contract.test.ts
+++ b/apps/web/tests/e150-route-classification.contract.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveAiRouteClassification } from "@features/ai/e150/routeClassification";
+
+describe("e150 route classification", () => {
+  it("marks canonical analyze route as canonical", () => {
+    const classification = resolveAiRouteClassification("/api/contributions/analyze");
+    expect(classification.canonical).toBe(true);
+    expect(classification.notCanonical).toBe(false);
+    expect(classification.routeProfile).toBe("e150_canonical");
+    expect(classification.directProviderPath).toBe(false);
+  });
+
+  it("marks factcheck seal route as sealed canonical path", () => {
+    const classification = resolveAiRouteClassification("/api/factcheck/status/job_1/seal");
+    expect(classification.canonical).toBe(true);
+    expect(classification.routeProfile).toBe("sealed_factcheck");
+  });
+
+  it("marks direct provider legacy paths as not canonical", () => {
+    const trace = resolveAiRouteClassification("/api/contributions/trace");
+    expect(trace.canonical).toBe(false);
+    expect(trace.legacyExceptionPath).toBe(true);
+    expect(trace.directProviderPath).toBe(true);
+    expect(trace.routeProfile).toBe("legacy_exception");
+
+    const diag = resolveAiRouteClassification("/api/diag/gpt");
+    expect(diag.canonical).toBe(false);
+    expect(diag.routeProfile).toBe("diagnostic");
+    expect(diag.directProviderPath).toBe(true);
+  });
+});

--- a/apps/web/tests/factcheck-enqueue.auth.route.test.ts
+++ b/apps/web/tests/factcheck-enqueue.auth.route.test.ts
@@ -110,8 +110,12 @@ describe("factcheck enqueue auth contract", () => {
     expect(body?.sealEligible).toBe(true);
     expect(body?.sealGranted).toBe(false);
     expect(body?.verificationLabel).toBe("geprueft");
+    expect(body?.workflowStage).toBe("completed");
+    expect(body?.workflowLabel).toBe("abgeschlossen");
+    expect(body?.sealStatus).toBe("Siegel ausstehend");
     expect(body?.meta?.lane).toBe("sealed_factcheck");
     expect(body?.meta?.journeyProfile).toBe("sealed_factcheck");
+    expect(body?.meta?.verificationMode).toBe("sealed");
     expect(body?.meta?.roleProviderMapping?.fallback).toEqual(["openai"]);
   });
 });

--- a/apps/web/tests/factcheck-status-seal.route.test.ts
+++ b/apps/web/tests/factcheck-status-seal.route.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  findOne: vi.fn(),
+  updateOne: vi.fn(),
+}));
+
+vi.mock("@features/factcheck/db", () => ({
+  factcheckJobsCol: vi.fn(async () => ({
+    findOne: (...args: unknown[]) => mocks.findOne(...args),
+    updateOne: (...args: unknown[]) => mocks.updateOne(...args),
+  })),
+}));
+
+vi.mock("@core/observability/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { POST as factcheckSealPOST } from "@/app/api/factcheck/status/[jobId]/seal/route";
+
+describe("factcheck seal end-state contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findOne.mockResolvedValue(null);
+    mocks.updateOne.mockResolvedValue({ acknowledged: true, modifiedCount: 1 });
+  });
+
+  it("does not grant seal before completed status", async () => {
+    mocks.findOne.mockResolvedValue({
+      jobId: "job_running",
+      status: "processing",
+      claims: [{ id: "c1", text: "Claim A" }],
+      error: null,
+      researchUsed: "search",
+    });
+
+    const req = new NextRequest("http://localhost/api/factcheck/status/job_running/seal", {
+      method: "POST",
+      headers: { cookie: "u_role=editor" },
+    });
+    const res = await factcheckSealPOST(req, {
+      params: Promise.resolve({ jobId: "job_running" }),
+    });
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body?.ok).toBe(false);
+    expect(body?.code).toBe("SEAL_NOT_READY");
+    expect(mocks.updateOne).not.toHaveBeenCalled();
+  });
+
+  it("grants seal only for completed jobs with evaluated claims", async () => {
+    mocks.findOne.mockResolvedValue({
+      jobId: "job_done",
+      status: "completed",
+      claims: [{ id: "c1", text: "Claim A" }],
+      error: null,
+      researchUsed: "deep_search",
+    });
+
+    const req = new NextRequest("http://localhost/api/factcheck/status/job_done/seal", {
+      method: "POST",
+      headers: { cookie: "u_role=editor" },
+    });
+    const res = await factcheckSealPOST(req, {
+      params: Promise.resolve({ jobId: "job_done" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mocks.updateOne).toHaveBeenCalledTimes(1);
+    const body = await res.json();
+    expect(body?.ok).toBe(true);
+    expect(body?.verificationMode).toBe("sealed");
+    expect(body?.researchUsed).toBe("deep_search");
+    expect(body?.sealEligible).toBe(true);
+    expect(body?.sealGranted).toBe(true);
+    expect(body?.verificationLabel).toBe("verifiziert");
+    expect(body?.workflowStage).toBe("completed");
+    expect(body?.sealStatus).toBe("Siegel erteilt");
+    expect(body?.meta?.lane).toBe("sealed_factcheck");
+  });
+});

--- a/apps/web/tests/factcheck-status.detail.contract.test.ts
+++ b/apps/web/tests/factcheck-status.detail.contract.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  findOne: vi.fn(),
+}));
+
+vi.mock("@features/factcheck/db", () => ({
+  factcheckJobsCol: vi.fn(async () => ({
+    findOne: (...args: unknown[]) => mocks.findOne(...args),
+  })),
+}));
+
+vi.mock("@core/observability/logger", () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { GET as factcheckStatusDetailGET } from "@/app/api/factcheck/status/[jobId]/route";
+
+describe("factcheck status detail sealed contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findOne.mockResolvedValue(null);
+  });
+
+  it("returns sealed verification fields from job state", async () => {
+    mocks.findOne.mockResolvedValue({
+      jobId: "job_1",
+      status: "processing",
+      verdict: "UNDETERMINED",
+      confidence: 0.5,
+      language: "de",
+      createdAt: new Date("2026-04-23T10:00:00.000Z"),
+      finishedAt: null,
+      draftId: null,
+      contributionId: "cid_1",
+      claims: [{ id: "c1", text: "Claim A" }],
+      serpResults: [],
+      verificationMode: "sealed",
+      researchUsed: "deep_search",
+      sealEligible: true,
+      sealGranted: false,
+      error: null,
+    });
+
+    const req = new NextRequest("http://localhost/api/factcheck/status/job_1", {
+      headers: { cookie: "u_role=editor" },
+    });
+    const res = await factcheckStatusDetailGET(req, {
+      params: Promise.resolve({ jobId: "job_1" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body?.ok).toBe(true);
+    expect(body?.verificationMode).toBe("sealed");
+    expect(body?.researchUsed).toBe("deep_search");
+    expect(body?.sealEligible).toBe(true);
+    expect(body?.sealGranted).toBe(false);
+    expect(body?.verificationLabel).toBe("geprueft");
+    expect(body?.workflowStage).toBe("in_progress");
+    expect(body?.sealStatus).toBe("Siegel ausstehend");
+    expect(body?.meta?.lane).toBe("sealed_factcheck");
+    expect(body?.job?.verificationMode).toBe("sealed");
+  });
+
+  it("defaults legacy jobs to sealed pending contract without granting seal", async () => {
+    mocks.findOne.mockResolvedValue({
+      jobId: "job_legacy",
+      status: "completed",
+      verdict: "UNDETERMINED",
+      confidence: 0.5,
+      language: "de",
+      createdAt: new Date("2026-04-23T10:00:00.000Z"),
+      finishedAt: new Date("2026-04-23T10:00:05.000Z"),
+      draftId: null,
+      contributionId: "cid_legacy",
+      claims: [],
+      serpResults: [],
+      error: null,
+    });
+
+    const req = new NextRequest("http://localhost/api/factcheck/status/job_legacy", {
+      headers: { cookie: "u_role=editor" },
+    });
+    const res = await factcheckStatusDetailGET(req, {
+      params: Promise.resolve({ jobId: "job_legacy" }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body?.verificationMode).toBe("sealed");
+    expect(body?.researchUsed).toBe("search");
+    expect(body?.sealEligible).toBe(true);
+    expect(body?.sealGranted).toBe(false);
+    expect(body?.verificationLabel).toBe("geprueft");
+    expect(body?.workflowStage).toBe("completed");
+    expect(body?.sealStatus).toBe("Siegel ausstehend");
+  });
+});

--- a/features/ai/e150/disagreementConfidence.ts
+++ b/features/ai/e150/disagreementConfidence.ts
@@ -1,0 +1,153 @@
+import type { E150ProviderName } from "./journeyProfiles";
+
+export type E150AgreementLevel = "high" | "mixed" | "low";
+export type E150ConfidenceBucket = "high" | "medium" | "low";
+
+export type E150DisagreementMeta = {
+  present: boolean;
+  specialistAgreementScore: number;
+  specialistAgreement: E150AgreementLevel;
+  missingSpecialists: E150ProviderName[];
+  successfulProviders: E150ProviderName[];
+  failedProviders: E150ProviderName[];
+  fallbackReliance: "none" | "full";
+  fallbackRelianceScore: number;
+  coverage: {
+    requiredPrimary: number;
+    successfulPrimary: number;
+    missingPrimary: number;
+  };
+};
+
+export type E150ConfidenceMeta = {
+  score: number;
+  bucket: E150ConfidenceBucket;
+  reasons: string[];
+};
+
+type ProviderScore = { provider: E150ProviderName; score: number };
+
+function clamp(value: number, min = 0, max = 1): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function round(value: number): number {
+  return Number(clamp(value).toFixed(3));
+}
+
+function uniqueProviders(entries: E150ProviderName[]): E150ProviderName[] {
+  const seen = new Set<E150ProviderName>();
+  const out: E150ProviderName[] = [];
+  entries.forEach((provider) => {
+    if (seen.has(provider)) return;
+    seen.add(provider);
+    out.push(provider);
+  });
+  return out;
+}
+
+function agreementLevel(score: number): E150AgreementLevel {
+  if (score >= 0.75) return "high";
+  if (score >= 0.45) return "mixed";
+  return "low";
+}
+
+function confidenceBucket(score: number): E150ConfidenceBucket {
+  if (score >= 0.75) return "high";
+  if (score >= 0.45) return "medium";
+  return "low";
+}
+
+function computeAgreementScore(params: {
+  primarySuccessScores: number[];
+  coverageRatio: number;
+}): number {
+  const scores = params.primarySuccessScores;
+  if (scores.length === 0) return 0;
+  if (scores.length === 1) return round(0.45 * params.coverageRatio + 0.15);
+
+  const max = Math.max(...scores);
+  const min = Math.min(...scores);
+  const spread = Math.max(0, max - min);
+  const spreadFactor = clamp(1 - spread / 1.4);
+  const score = spreadFactor * 0.7 + params.coverageRatio * 0.3;
+  return round(score);
+}
+
+export function computeDisagreementConfidence(params: {
+  primaryProviders: readonly E150ProviderName[];
+  successfulProviders: E150ProviderName[];
+  failedProviders: E150ProviderName[];
+  candidateScores: ProviderScore[];
+  bestProvider: E150ProviderName | null;
+  fallbackProviders: readonly E150ProviderName[];
+  fallbackUsed: boolean;
+}): { disagreement: E150DisagreementMeta; confidence: E150ConfidenceMeta } {
+  const primaryProviders = uniqueProviders([...params.primaryProviders]);
+  const successfulProviders = uniqueProviders([...params.successfulProviders]);
+  const failedProviders = uniqueProviders([...params.failedProviders]);
+  const successfulSet = new Set(successfulProviders);
+
+  const successfulPrimary = primaryProviders.filter((provider) => successfulSet.has(provider));
+  const missingSpecialists = primaryProviders.filter((provider) => !successfulSet.has(provider));
+  const coverageRatio =
+    primaryProviders.length > 0 ? successfulPrimary.length / primaryProviders.length : 1;
+  const primarySuccessScoreList = params.candidateScores
+    .filter((entry) => successfulPrimary.includes(entry.provider))
+    .map((entry) => entry.score);
+  const specialistAgreementScore = computeAgreementScore({
+    primarySuccessScores: primarySuccessScoreList,
+    coverageRatio,
+  });
+  const fallbackRelianceScore =
+    params.fallbackUsed === true ||
+    (params.bestProvider ? params.fallbackProviders.includes(params.bestProvider) : false)
+      ? 1
+      : 0;
+  const attemptedCount = successfulProviders.length + failedProviders.length;
+  const failureRatio = attemptedCount > 0 ? failedProviders.length / attemptedCount : 0;
+
+  const disagreementPresent =
+    missingSpecialists.length > 0 ||
+    specialistAgreementScore < 0.55 ||
+    fallbackRelianceScore > 0 ||
+    failureRatio > 0.34;
+
+  const disagreement: E150DisagreementMeta = {
+    present: disagreementPresent,
+    specialistAgreementScore,
+    specialistAgreement: agreementLevel(specialistAgreementScore),
+    missingSpecialists,
+    successfulProviders,
+    failedProviders,
+    fallbackReliance: fallbackRelianceScore > 0 ? "full" : "none",
+    fallbackRelianceScore,
+    coverage: {
+      requiredPrimary: primaryProviders.length,
+      successfulPrimary: successfulPrimary.length,
+      missingPrimary: missingSpecialists.length,
+    },
+  };
+
+  const confidenceScore = round(
+    0.15 +
+      coverageRatio * 0.45 +
+      specialistAgreementScore * 0.3 -
+      fallbackRelianceScore * 0.2 -
+      failureRatio * 0.2,
+  );
+  const reasons: string[] = [];
+  if (missingSpecialists.length > 0) reasons.push(`missing_specialists:${missingSpecialists.length}`);
+  if (fallbackRelianceScore > 0) reasons.push("fallback_reliance");
+  if (failureRatio > 0.34) reasons.push("provider_failures");
+  if (specialistAgreementScore < 0.45) reasons.push("high_disagreement");
+  if (reasons.length === 0) reasons.push("strong_specialist_alignment");
+
+  const confidence: E150ConfidenceMeta = {
+    score: confidenceScore,
+    bucket: confidenceBucket(confidenceScore),
+    reasons,
+  };
+
+  return { disagreement, confidence };
+}

--- a/features/ai/e150/factcheckStatus.ts
+++ b/features/ai/e150/factcheckStatus.ts
@@ -1,0 +1,145 @@
+import { buildSealedFactcheckContract } from "./factcheckProfiles";
+import {
+  deriveVerificationLabel,
+  type ResearchUsed,
+  type UserFacingVerificationLabel,
+  type VerificationContract,
+  type VerificationMode,
+} from "./verificationContract";
+
+export type SealedFactcheckWorkflowStage =
+  | "started"
+  | "queued"
+  | "in_progress"
+  | "completed";
+
+export type SealedFactcheckSealState = "not_eligible" | "pending" | "granted";
+
+export type SealedFactcheckStatusView = VerificationContract & {
+  verificationLabel: UserFacingVerificationLabel;
+  workflowStage: SealedFactcheckWorkflowStage;
+  workflowLabel: string;
+  sealState: SealedFactcheckSealState;
+  sealLabel: string;
+};
+
+type VerificationLike = Partial<VerificationContract> | null | undefined;
+
+const WORKFLOW_LABELS: Record<SealedFactcheckWorkflowStage, string> = {
+  started: "gestartet",
+  queued: "queued",
+  in_progress: "in Prüfung",
+  completed: "abgeschlossen",
+};
+
+const SEAL_LABELS: Record<SealedFactcheckSealState, string> = {
+  not_eligible: "kein Siegel",
+  pending: "Siegel ausstehend",
+  granted: "Siegel erteilt",
+};
+
+function asVerificationMode(value: unknown): VerificationMode | null {
+  if (value === "none" || value === "precheck" || value === "sealed") return value;
+  return null;
+}
+
+function asResearchUsed(value: unknown): ResearchUsed | null {
+  if (
+    value === "none" ||
+    value === "lite" ||
+    value === "search" ||
+    value === "deep_search"
+  ) {
+    return value;
+  }
+  return null;
+}
+
+function asOptionalBoolean(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
+function resolveSealState(params: {
+  verificationMode: VerificationMode;
+  sealEligible: boolean;
+  sealGranted: boolean;
+}): SealedFactcheckSealState {
+  if (!params.sealEligible) return "not_eligible";
+  if (params.verificationMode === "sealed" && params.sealGranted) return "granted";
+  return "pending";
+}
+
+export function resolveSealedFactcheckWorkflowStage(
+  status: string | null | undefined,
+): SealedFactcheckWorkflowStage {
+  const normalized = (status ?? "").trim().toLowerCase();
+  if (!normalized) return "started";
+  if (normalized === "started" || normalized === "created" || normalized === "init") {
+    return "started";
+  }
+  if (normalized === "queued" || normalized === "pending") return "queued";
+  if (
+    normalized === "processing" ||
+    normalized === "running" ||
+    normalized === "in_progress"
+  ) {
+    return "in_progress";
+  }
+  if (normalized === "completed" || normalized === "failed" || normalized === "error") {
+    return "completed";
+  }
+  return "started";
+}
+
+export function resolveSealedFactcheckStatusView(params: {
+  status?: string | null;
+  verification?: VerificationLike;
+  verificationMode?: unknown;
+  researchUsed?: unknown;
+  sealEligible?: unknown;
+  sealGranted?: unknown;
+}): SealedFactcheckStatusView {
+  const verificationMode =
+    asVerificationMode(params.verification?.verificationMode) ??
+    asVerificationMode(params.verificationMode);
+  const researchUsed =
+    asResearchUsed(params.verification?.researchUsed) ??
+    asResearchUsed(params.researchUsed);
+  const sealEligible =
+    asOptionalBoolean(params.verification?.sealEligible) ??
+    asOptionalBoolean(params.sealEligible);
+  const sealGranted =
+    asOptionalBoolean(params.verification?.sealGranted) ??
+    asOptionalBoolean(params.sealGranted);
+
+  const fallback = buildSealedFactcheckContract({
+    researchUsed: researchUsed === "deep_search" ? "deep_search" : "search",
+    sealGranted: sealGranted === true,
+  });
+
+  const resolvedVerificationMode = verificationMode ?? fallback.verificationMode;
+  const resolvedResearchUsed = researchUsed ?? fallback.researchUsed;
+  const resolvedSealEligible = sealEligible ?? fallback.sealEligible;
+  const resolvedSealGranted = sealGranted ?? fallback.sealGranted;
+  const workflowStage = resolveSealedFactcheckWorkflowStage(params.status);
+  const sealState = resolveSealState({
+    verificationMode: resolvedVerificationMode,
+    sealEligible: resolvedSealEligible,
+    sealGranted: resolvedSealGranted,
+  });
+
+  return {
+    verificationMode: resolvedVerificationMode,
+    researchUsed: resolvedResearchUsed,
+    sealEligible: resolvedSealEligible,
+    sealGranted: resolvedSealGranted,
+    verificationLabel: deriveVerificationLabel({
+      verificationMode: resolvedVerificationMode,
+      sealGranted: resolvedSealGranted,
+    }),
+    workflowStage,
+    workflowLabel: WORKFLOW_LABELS[workflowStage],
+    sealState,
+    sealLabel: SEAL_LABELS[sealState],
+  };
+}

--- a/features/ai/e150/routeClassification.ts
+++ b/features/ai/e150/routeClassification.ts
@@ -1,0 +1,82 @@
+export type AiRouteProfile =
+  | "e150_canonical"
+  | "sealed_factcheck"
+  | "legacy_exception"
+  | "diagnostic"
+  | "unknown";
+
+export type AiRouteClassification = {
+  routePath: string;
+  routeProfile: AiRouteProfile;
+  canonical: boolean;
+  notCanonical: boolean;
+  legacyExceptionPath: boolean;
+  directProviderPath: boolean;
+  note: string;
+};
+
+function canonical(routePath: string, routeProfile: AiRouteProfile, note: string): AiRouteClassification {
+  return {
+    routePath,
+    routeProfile,
+    canonical: true,
+    notCanonical: false,
+    legacyExceptionPath: false,
+    directProviderPath: false,
+    note,
+  };
+}
+
+function exception(
+  routePath: string,
+  routeProfile: AiRouteProfile,
+  note: string,
+  directProviderPath = true,
+): AiRouteClassification {
+  return {
+    routePath,
+    routeProfile,
+    canonical: false,
+    notCanonical: true,
+    legacyExceptionPath: true,
+    directProviderPath,
+    note,
+  };
+}
+
+export function resolveAiRouteClassification(routePath: string): AiRouteClassification {
+  const normalized = String(routePath || "").trim().toLowerCase();
+  if (normalized === "/api/contributions/analyze") {
+    return canonical(normalized, "e150_canonical", "journey_specialist_routing");
+  }
+  if (normalized === "/api/factcheck/enqueue") {
+    return canonical(normalized, "sealed_factcheck", "sealed_factcheck_lane");
+  }
+  if (normalized === "/api/factcheck/status" || normalized.startsWith("/api/factcheck/status/")) {
+    return canonical(normalized, "sealed_factcheck", "sealed_factcheck_status");
+  }
+  if (normalized.startsWith("/api/factcheck/result/")) {
+    return canonical(normalized, "sealed_factcheck", "sealed_factcheck_result");
+  }
+  if (normalized === "/api/contributions/trace") {
+    return exception(normalized, "legacy_exception", "direct_provider_trace_path");
+  }
+  if (normalized === "/api/contributions/refine") {
+    return exception(normalized, "legacy_exception", "direct_provider_refine_path");
+  }
+  if (normalized === "/api/quality/polish") {
+    return exception(normalized, "legacy_exception", "direct_provider_polish_path");
+  }
+  if (normalized === "/api/diag/gpt" || normalized === "/api/_diag/gpt") {
+    return exception(normalized, "diagnostic", "diagnostic_direct_provider_path");
+  }
+  return {
+    routePath: normalized,
+    routeProfile: "unknown",
+    canonical: false,
+    notCanonical: true,
+    legacyExceptionPath: false,
+    directProviderPath: false,
+    note: "unclassified",
+  };
+}

--- a/features/ai/orchestratorE150.ts
+++ b/features/ai/orchestratorE150.ts
@@ -32,6 +32,11 @@ import {
   type E150JourneyProfile,
   type E150Lane,
 } from "./e150/journeyProfiles";
+import {
+  computeDisagreementConfidence,
+  type E150ConfidenceMeta,
+  type E150DisagreementMeta,
+} from "./e150/disagreementConfidence";
 import type {
   ResearchUsed,
   VerificationMode,
@@ -221,11 +226,8 @@ export type E150OrchestratorMeta = {
     openAiRoles: readonly ("fallback" | "presentation_pass")[];
   };
   fallbackUsed?: boolean;
-  disagreement?: {
-    present: boolean;
-    successfulProviders: E150ProviderName[];
-    failedProviders: E150ProviderName[];
-  };
+  disagreement?: E150DisagreementMeta;
+  confidence?: E150ConfidenceMeta;
   verificationMode?: VerificationMode;
   researchUsed?: ResearchUsed;
   sealEligible?: boolean;
@@ -1732,9 +1734,18 @@ export async function callE150Orchestrator(
   const failedProviderNames = providerOutcomes
     .filter((outcome): outcome is ProviderFailure => !outcome.ok)
     .map((outcome) => outcome.provider);
-  const disagreementPresent =
-    new Set(successfulProviders).size > 1 ||
-    (successfulProviders.length > 0 && failedProviderNames.length > 0);
+  const disagreementConfidence = computeDisagreementConfidence({
+    primaryProviders: primaryProviderNames,
+    successfulProviders,
+    failedProviders: failedProviderNames,
+    candidateScores: sortedCandidates.map((candidate) => ({
+      provider: candidate.provider,
+      score: candidate.score,
+    })),
+    bestProvider: best?.provider ?? null,
+    fallbackProviders: fallbackProviderNames,
+    fallbackUsed,
+  });
 
   const telemetryEvents = providerOutcomes.map((outcome) => {
     const success = outcome.ok ? (outcome as ProviderSuccess) : null;
@@ -1778,11 +1789,8 @@ export async function callE150Orchestrator(
         openAiRoles: journeyProfile.openAiRoles,
       },
       fallbackUsed,
-      disagreement: {
-        present: disagreementPresent,
-        successfulProviders,
-        failedProviders: failedProviderNames,
-      },
+      disagreement: disagreementConfidence.disagreement,
+      confidence: disagreementConfidence.confidence,
       verificationMode: journeyProfile.verificationDefaults.verificationMode,
       researchUsed: journeyProfile.verificationDefaults.researchUsed,
       sealEligible: journeyProfile.verificationDefaults.sealEligible,

--- a/features/factcheck/db.ts
+++ b/features/factcheck/db.ts
@@ -2,6 +2,11 @@ import { coreCol, type ObjectId } from "@core/db/triMongo";
 import type { StatementRecord } from "@features/analyze/schemas";
 import type { FactVerdict } from "./types";
 import type { SerpResultLite } from "@features/ai/providers/ari_search";
+import type { ResearchUsed, VerificationMode } from "@features/ai/e150/verificationContract";
+import type {
+  E150ConfidenceMeta,
+  E150DisagreementMeta,
+} from "@features/ai/e150/disagreementConfidence";
 
 export type FactcheckJobStatus = "queued" | "processing" | "completed" | "failed" | "error";
 
@@ -22,6 +27,15 @@ export type FactcheckJobDoc = {
 
   claims: StatementRecord[];
   serpResults?: SerpResultLite[];
+
+  verificationMode?: VerificationMode;
+  researchUsed?: ResearchUsed;
+  sealEligible?: boolean;
+  sealGranted?: boolean;
+  sealedAt?: Date;
+  fallbackUsed?: boolean;
+  disagreement?: E150DisagreementMeta | null;
+  orchestrationConfidence?: E150ConfidenceMeta | null;
 
   error?: string | null;
 


### PR DESCRIPTION
## Ziel
Sauberer Split-Block für GOV-AI-ORCH-05 Foundation-Logik:
- disagreement/confidence scoring
- sealed factcheck end-state (inkl. seal endpoint)
- explizite Legacy-/Direct-Provider-Klassifikation in Ausnahmepfaden

## Scope
- `features/ai/e150/{disagreementConfidence,routeClassification,factcheckStatus}.ts`
- `features/ai/orchestratorE150.ts`
- Factcheck status/result/enqueue routes inkl. `/api/factcheck/status/[jobId]/seal`
- Legacy-Exception-Meta für `trace/refine/polish/diag`
- passende Contract-Tests

## Nicht im Scope
- Companion/UI-Tone-Pass-Flows
- AI-Usage Admin-Ops-Frontend

## Validierung
- `pnpm -C apps/web exec vitest run tests/e150-disagreement-confidence.contract.test.ts tests/e150-route-classification.contract.test.ts tests/factcheck-status-seal.route.test.ts tests/factcheck-status.detail.contract.test.ts tests/e150-journey-routing.contract.test.ts tests/factcheck-enqueue.auth.route.test.ts` ✅