### PR TITLE
GOV-AI-ORCH-05 split: frontend verification status mapping and badges

### DIFF
--- a/apps/web/src/app/api/factcheck/page.tsx
+++ b/apps/web/src/app/api/factcheck/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import VerificationStatusPanel from "@/components/ai/VerificationStatusPanel";
 
 export default function FactcheckPage() {
   const [text, setText] = useState("");
@@ -67,6 +68,15 @@ export default function FactcheckPage() {
           <div className="text-sm text-gray-600">
             Job #{result.job.jobId} – {result.job.status}
           </div>
+          <VerificationStatusPanel
+            lane={result.job?.lane ?? "sealed_factcheck"}
+            status={result.job?.status}
+            verificationMode={result.job?.verificationMode}
+            researchUsed={result.job?.researchUsed}
+            sealEligible={result.job?.sealEligible}
+            sealGranted={result.job?.sealGranted}
+            showHint
+          />
           {result.job?.verdict && (
             <div className="text-xs text-gray-500">
               Verdict: <b>{result.job.verdict}</b>

--- a/apps/web/src/components/ai/VerificationStatusPanel.tsx
+++ b/apps/web/src/components/ai/VerificationStatusPanel.tsx
@@ -1,0 +1,68 @@
+import {
+  resolveVerificationPresentationView,
+  type VerificationBadgeTone,
+} from "@features/ai/e150/verificationPresentation";
+
+type VerificationStatusPanelProps = {
+  lane?: "standard" | "sealed_factcheck" | null;
+  status?: string | null;
+  verificationMode?: "none" | "precheck" | "sealed" | null;
+  researchUsed?: "none" | "lite" | "search" | "deep_search" | null;
+  sealEligible?: boolean | null;
+  sealGranted?: boolean | null;
+  showHint?: boolean;
+  className?: string;
+};
+
+const BADGE_TONE_CLASS: Record<VerificationBadgeTone, string> = {
+  neutral:
+    "border-[rgb(var(--border))] bg-[rgb(var(--bg))] text-[rgb(var(--muted))]",
+  caution:
+    "border-amber-300/60 bg-amber-50/80 text-amber-800 dark:border-amber-400/40 dark:bg-amber-500/10 dark:text-amber-200",
+  success:
+    "border-emerald-300/60 bg-emerald-50/80 text-emerald-800 dark:border-emerald-400/40 dark:bg-emerald-500/10 dark:text-emerald-200",
+};
+
+function Badge({
+  text,
+  tone = "neutral",
+}: {
+  text: string;
+  tone?: VerificationBadgeTone;
+}) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-wide ${BADGE_TONE_CLASS[tone]}`}
+    >
+      {text}
+    </span>
+  );
+}
+
+export default function VerificationStatusPanel(props: VerificationStatusPanelProps) {
+  const view = resolveVerificationPresentationView({
+    lane: props.lane,
+    status: props.status,
+    verificationMode: props.verificationMode,
+    researchUsed: props.researchUsed,
+    sealEligible: props.sealEligible,
+    sealGranted: props.sealGranted,
+  });
+  const showHint = props.showHint !== false;
+
+  return (
+    <div
+      className={`rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] px-3 py-2 text-[11px] text-[rgb(var(--muted))] ${props.className ?? ""}`.trim()}
+    >
+      <p className="text-[10px] font-semibold uppercase tracking-wide">Status</p>
+      <div className="mt-1 flex flex-wrap gap-1.5">
+        <Badge text={view.verificationLabelDisplay} tone={view.badgeTone} />
+        <Badge text={view.laneLabel} />
+        <Badge text={`Recherche: ${view.researchLabel}`} />
+        {view.workflowLabel ? <Badge text={`Workflow: ${view.workflowLabel}`} /> : null}
+        <Badge text={`Siegel: ${view.sealLabel}`} tone={view.isVerified ? "success" : "neutral"} />
+      </div>
+      {showHint ? <p className="mt-2 text-[10px]">{view.verificationHint}</p> : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/create/analyzeEnvelope.ts
+++ b/apps/web/src/features/create/analyzeEnvelope.ts
@@ -3,6 +3,13 @@ import {
 } from "@/features/create/analyzeBoundaryContract";
 import type { CreateAnalyzeResponse } from "@/features/create/analyzeContract";
 import type { SourceGroundingAudit } from "@features/analyze/sourceGroundingContract";
+import {
+  deriveVerificationLabel,
+  type ResearchUsed,
+  type UserFacingVerificationLabel,
+  type VerificationMode,
+} from "@features/ai/e150/verificationContract";
+import type { E150Lane } from "@features/ai/e150/journeyProfiles";
 
 export type CreateAnalyzeEnvelopeProviderMatrixEntry = {
   provider: string;
@@ -21,6 +28,16 @@ export type ParsedCreateAnalyzeEnvelope = {
   degraded: boolean;
   fallback: boolean;
   sourceGrounding: SourceGroundingAudit | null;
+  verification: ParsedCreateAnalyzeVerification | null;
+};
+
+export type ParsedCreateAnalyzeVerification = {
+  lane: E150Lane;
+  verificationMode: VerificationMode;
+  researchUsed: ResearchUsed;
+  sealEligible: boolean;
+  sealGranted: boolean;
+  verificationLabel: UserFacingVerificationLabel;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -158,6 +175,94 @@ function normalizeSourceGroundingAudit(value: unknown): SourceGroundingAudit | n
   };
 }
 
+function asVerificationMode(value: unknown): VerificationMode | null {
+  if (value === "none" || value === "precheck" || value === "sealed") return value;
+  return null;
+}
+
+function asResearchUsed(value: unknown): ResearchUsed | null {
+  if (
+    value === "none" ||
+    value === "lite" ||
+    value === "search" ||
+    value === "deep_search"
+  ) {
+    return value;
+  }
+  return null;
+}
+
+function asVerificationLabel(value: unknown): UserFacingVerificationLabel | null {
+  if (value === "analysiert" || value === "geprueft" || value === "verifiziert") return value;
+  return null;
+}
+
+function asLane(value: unknown): E150Lane | null {
+  if (value === "standard" || value === "sealed_factcheck") return value;
+  return null;
+}
+
+function resolveCreateAnalyzeVerification(value: {
+  root: Record<string, unknown>;
+  meta: Record<string, unknown>;
+}): ParsedCreateAnalyzeVerification | null {
+  const verificationMode = asVerificationMode(
+    value.root.verificationMode ?? value.meta.verificationMode,
+  );
+  const researchUsed = asResearchUsed(value.root.researchUsed ?? value.meta.researchUsed);
+  const sealEligibleRaw = value.root.sealEligible ?? value.meta.sealEligible;
+  const sealGrantedRaw = value.root.sealGranted ?? value.meta.sealGranted;
+  const sealEligible = typeof sealEligibleRaw === "boolean" ? sealEligibleRaw : null;
+  const sealGranted = typeof sealGrantedRaw === "boolean" ? sealGrantedRaw : null;
+  const verificationLabel = asVerificationLabel(
+    value.root.verificationLabel ?? value.meta.verificationLabel,
+  );
+  const lane = asLane(value.root.lane ?? value.meta.lane);
+
+  if (
+    !verificationMode &&
+    !verificationLabel &&
+    !researchUsed &&
+    sealEligible === null &&
+    sealGranted === null
+  ) {
+    return null;
+  }
+
+  const inferredModeFromLabel: VerificationMode | null =
+    verificationLabel === "analysiert"
+      ? "none"
+      : verificationLabel === "verifiziert"
+        ? "sealed"
+        : sealEligible === true
+          ? "sealed"
+          : "precheck";
+
+  const resolvedVerificationMode = verificationMode ?? inferredModeFromLabel;
+  if (!resolvedVerificationMode) return null;
+
+  const resolvedSealGranted = sealGranted ?? verificationLabel === "verifiziert";
+  const resolvedSealEligible =
+    sealEligible ?? resolvedVerificationMode === "sealed";
+  const resolvedResearchUsed =
+    researchUsed ?? (resolvedVerificationMode === "sealed" ? "search" : "none");
+  const resolvedLane = lane ?? "standard";
+
+  return {
+    lane: resolvedLane,
+    verificationMode: resolvedVerificationMode,
+    researchUsed: resolvedResearchUsed,
+    sealEligible: resolvedSealEligible,
+    sealGranted: resolvedSealGranted,
+    verificationLabel:
+      verificationLabel ??
+      deriveVerificationLabel({
+        verificationMode: resolvedVerificationMode,
+        sealGranted: resolvedSealGranted,
+      }),
+  };
+}
+
 export function parseCreateAnalyzeEnvelope(value: unknown): ParsedCreateAnalyzeEnvelope {
   const root = isRecord(value) ? value : {};
   const meta = isRecord(root.meta) ? root.meta : {};
@@ -167,6 +272,10 @@ export function parseCreateAnalyzeEnvelope(value: unknown): ParsedCreateAnalyzeE
     meta,
   });
   const sourceGrounding = normalizeSourceGroundingAudit(meta.sourceGrounding);
+  const verification = resolveCreateAnalyzeVerification({
+    root,
+    meta,
+  });
 
   return {
     createAnalyze,
@@ -174,5 +283,6 @@ export function parseCreateAnalyzeEnvelope(value: unknown): ParsedCreateAnalyzeE
     degraded: Boolean(root.degraded) || createAnalyze?.matchSourceState === "degraded",
     fallback: Boolean(root.fallback),
     sourceGrounding,
+    verification,
   };
 }

--- a/apps/web/tests/create-analyze-envelope.verification.test.ts
+++ b/apps/web/tests/create-analyze-envelope.verification.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCreateAnalyzeEnvelope } from "@/features/create/analyzeEnvelope";
+
+describe("create analyze envelope verification parsing", () => {
+  it("parses verification contract fields from response root", () => {
+    const parsed = parseCreateAnalyzeEnvelope({
+      verificationMode: "none",
+      researchUsed: "none",
+      sealEligible: false,
+      sealGranted: false,
+      verificationLabel: "analysiert",
+    });
+
+    expect(parsed.verification).toEqual({
+      lane: "standard",
+      verificationMode: "none",
+      researchUsed: "none",
+      sealEligible: false,
+      sealGranted: false,
+      verificationLabel: "analysiert",
+    });
+  });
+
+  it("falls back to meta fields when root fields are absent", () => {
+    const parsed = parseCreateAnalyzeEnvelope({
+      meta: {
+        verificationMode: "precheck",
+        researchUsed: "none",
+        sealEligible: false,
+        sealGranted: false,
+      },
+    });
+
+    expect(parsed.verification?.verificationMode).toBe("precheck");
+    expect(parsed.verification?.verificationLabel).toBe("geprueft");
+    expect(parsed.verification?.lane).toBe("standard");
+  });
+});

--- a/apps/web/tests/e150-verification-label.contract.test.ts
+++ b/apps/web/tests/e150-verification-label.contract.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSealedLaneContract,
+  buildStandardLaneContract,
+  deriveVerificationLabel,
+} from "@features/ai/e150/verificationContract";
+
+describe("verification label contract", () => {
+  it("maps none to analysiert", () => {
+    const contract = buildStandardLaneContract({ verificationMode: "none" });
+    expect(deriveVerificationLabel(contract)).toBe("analysiert");
+    expect(contract.researchUsed).toBe("none");
+    expect(contract.sealEligible).toBe(false);
+    expect(contract.sealGranted).toBe(false);
+  });
+
+  it("maps precheck to geprueft", () => {
+    const contract = buildStandardLaneContract({ verificationMode: "precheck" });
+    expect(deriveVerificationLabel(contract)).toBe("geprueft");
+  });
+
+  it("does not mark sealed without seal as verifiziert", () => {
+    const contract = buildSealedLaneContract({
+      researchUsed: "search",
+      sealGranted: false,
+    });
+    expect(deriveVerificationLabel(contract)).toBe("geprueft");
+  });
+
+  it("maps sealed plus sealGranted to verifiziert", () => {
+    const contract = buildSealedLaneContract({
+      researchUsed: "deep_search",
+      sealGranted: true,
+    });
+    expect(deriveVerificationLabel(contract)).toBe("verifiziert");
+  });
+});

--- a/apps/web/tests/e150-verification-presentation.contract.test.ts
+++ b/apps/web/tests/e150-verification-presentation.contract.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveVerificationPresentationView } from "@features/ai/e150/verificationPresentation";
+
+describe("e150 verification presentation contract", () => {
+  it("maps standard lane to analysiert with no research/seal", () => {
+    const view = resolveVerificationPresentationView({
+      lane: "standard",
+      verificationMode: "none",
+      researchUsed: "none",
+      sealEligible: false,
+      sealGranted: false,
+    });
+
+    expect(view.lane).toBe("standard");
+    expect(view.verificationLabel).toBe("analysiert");
+    expect(view.verificationLabelDisplay).toBe("analysiert");
+    expect(view.researchUsed).toBe("none");
+    expect(view.sealGranted).toBe(false);
+    expect(view.sealLabel).toBe("kein Siegel");
+    expect(view.isVerified).toBe(false);
+  });
+
+  it("never marks standard lane as verifiziert even with inconsistent sealed fields", () => {
+    const view = resolveVerificationPresentationView({
+      lane: "standard",
+      verificationMode: "sealed",
+      researchUsed: "deep_search",
+      sealEligible: true,
+      sealGranted: true,
+    });
+
+    expect(view.lane).toBe("standard");
+    expect(view.verificationMode).toBe("none");
+    expect(view.verificationLabel).toBe("analysiert");
+    expect(view.researchUsed).toBe("none");
+    expect(view.sealGranted).toBe(false);
+    expect(view.isVerified).toBe(false);
+  });
+
+  it("keeps sealed lane in geprueft while seal is pending", () => {
+    const view = resolveVerificationPresentationView({
+      lane: "sealed_factcheck",
+      status: "queued",
+      verificationMode: "sealed",
+      researchUsed: "search",
+      sealEligible: true,
+      sealGranted: false,
+    });
+
+    expect(view.lane).toBe("sealed_factcheck");
+    expect(view.verificationLabel).toBe("geprueft");
+    expect(view.workflowStage).toBe("queued");
+    expect(view.workflowLabel).toBe("in Warteschlange");
+    expect(view.sealLabel).toBe("Siegel ausstehend");
+    expect(view.isVerified).toBe(false);
+  });
+
+  it("marks verifiziert only for sealed lane with seal granted", () => {
+    const view = resolveVerificationPresentationView({
+      lane: "sealed_factcheck",
+      status: "completed",
+      verificationMode: "sealed",
+      researchUsed: "deep_search",
+      sealEligible: true,
+      sealGranted: true,
+    });
+
+    expect(view.verificationLabel).toBe("verifiziert");
+    expect(view.verificationLabelDisplay).toBe("verifiziert");
+    expect(view.workflowStage).toBe("completed");
+    expect(view.sealLabel).toBe("Siegel erteilt");
+    expect(view.isVerified).toBe(true);
+  });
+
+  it("falls back defensively for partial payloads", () => {
+    const view = resolveVerificationPresentationView({});
+    expect(view.lane).toBe("standard");
+    expect(view.verificationMode).toBe("none");
+    expect(view.verificationLabel).toBe("analysiert");
+    expect(view.researchUsed).toBe("none");
+  });
+});

--- a/features/ai/e150/verificationPresentation.ts
+++ b/features/ai/e150/verificationPresentation.ts
@@ -1,0 +1,149 @@
+import type { E150Lane } from "./journeyProfiles";
+import {
+  buildStandardLaneContract,
+  deriveVerificationLabel,
+  type ResearchUsed,
+  type UserFacingVerificationLabel,
+  type VerificationMode,
+} from "./verificationContract";
+import type { SealedFactcheckWorkflowStage } from "./factcheckStatus";
+import { resolveSealedFactcheckStatusView } from "./factcheckStatus";
+
+export type VerificationBadgeTone = "neutral" | "caution" | "success";
+
+export type VerificationPresentationView = {
+  lane: E150Lane;
+  laneLabel: string;
+  verificationMode: VerificationMode;
+  verificationLabel: UserFacingVerificationLabel;
+  verificationLabelDisplay: string;
+  verificationHint: string;
+  researchUsed: ResearchUsed;
+  researchLabel: string;
+  sealEligible: boolean;
+  sealGranted: boolean;
+  sealLabel: string;
+  workflowStage: SealedFactcheckWorkflowStage | null;
+  workflowLabel: string | null;
+  badgeTone: VerificationBadgeTone;
+  isVerified: boolean;
+};
+
+type ResolveVerificationPresentationArgs = {
+  lane?: unknown;
+  status?: string | null;
+  verificationMode?: unknown;
+  researchUsed?: unknown;
+  sealEligible?: unknown;
+  sealGranted?: unknown;
+};
+
+const LABEL_DISPLAY: Record<UserFacingVerificationLabel, string> = {
+  analysiert: "analysiert",
+  geprueft: "geprüft",
+  verifiziert: "verifiziert",
+};
+
+const LABEL_HINT: Record<UserFacingVerificationLabel, string> = {
+  analysiert: "Analysiert: Struktur und Plausibilisierung ohne verifizierten Faktencheck.",
+  geprueft: "Geprüft: Vorprüfung oder laufender sealed Factcheck, Siegel noch ausstehend.",
+  verifiziert: "Verifiziert: sealed Factcheck vollständig abgeschlossen, Siegel erteilt.",
+};
+
+const RESEARCH_LABEL: Record<ResearchUsed, string> = {
+  none: "keine Recherche",
+  lite: "Lite-Recherche",
+  search: "Search",
+  deep_search: "Deep Search",
+};
+
+const WORKFLOW_LABEL: Record<SealedFactcheckWorkflowStage, string> = {
+  started: "gestartet",
+  queued: "in Warteschlange",
+  in_progress: "in Prüfung",
+  completed: "abgeschlossen",
+};
+
+function asLane(value: unknown): E150Lane | null {
+  if (value === "standard" || value === "sealed_factcheck") return value;
+  return null;
+}
+
+function asVerificationMode(value: unknown): VerificationMode | null {
+  if (value === "none" || value === "precheck" || value === "sealed") return value;
+  return null;
+}
+
+function resolveLane(args: ResolveVerificationPresentationArgs): E150Lane {
+  const explicitLane = asLane(args.lane);
+  if (explicitLane) return explicitLane;
+  return asVerificationMode(args.verificationMode) === "sealed" ? "sealed_factcheck" : "standard";
+}
+
+function resolveBadgeTone(label: UserFacingVerificationLabel): VerificationBadgeTone {
+  if (label === "verifiziert") return "success";
+  if (label === "geprueft") return "caution";
+  return "neutral";
+}
+
+export function resolveVerificationPresentationView(
+  args: ResolveVerificationPresentationArgs,
+): VerificationPresentationView {
+  const lane = resolveLane(args);
+
+  if (lane === "sealed_factcheck") {
+    const sealedView = resolveSealedFactcheckStatusView({
+      status: args.status,
+      verificationMode: args.verificationMode,
+      researchUsed: args.researchUsed,
+      sealEligible: args.sealEligible,
+      sealGranted: args.sealGranted,
+    });
+    return {
+      lane,
+      laneLabel: "Sealed Factcheck-Lane",
+      verificationMode: sealedView.verificationMode,
+      verificationLabel: sealedView.verificationLabel,
+      verificationLabelDisplay: LABEL_DISPLAY[sealedView.verificationLabel],
+      verificationHint: LABEL_HINT[sealedView.verificationLabel],
+      researchUsed: sealedView.researchUsed,
+      researchLabel: RESEARCH_LABEL[sealedView.researchUsed],
+      sealEligible: sealedView.sealEligible,
+      sealGranted: sealedView.sealGranted,
+      sealLabel: sealedView.sealLabel,
+      workflowStage: sealedView.workflowStage,
+      workflowLabel: WORKFLOW_LABEL[sealedView.workflowStage],
+      badgeTone: resolveBadgeTone(sealedView.verificationLabel),
+      isVerified: sealedView.verificationLabel === "verifiziert",
+    };
+  }
+
+  const modeRaw = asVerificationMode(args.verificationMode);
+  const standardMode: "none" | "precheck" =
+    modeRaw === "precheck" ? "precheck" : "none";
+  const standardContract = buildStandardLaneContract({
+    verificationMode: standardMode,
+  });
+  const verificationLabel = deriveVerificationLabel({
+    verificationMode: standardContract.verificationMode,
+    sealGranted: standardContract.sealGranted,
+  });
+
+  return {
+    lane,
+    laneLabel: "Standard-Lane",
+    verificationMode: standardContract.verificationMode,
+    verificationLabel,
+    verificationLabelDisplay: LABEL_DISPLAY[verificationLabel],
+    verificationHint: LABEL_HINT[verificationLabel],
+    researchUsed: standardContract.researchUsed,
+    researchLabel: RESEARCH_LABEL[standardContract.researchUsed],
+    sealEligible: standardContract.sealEligible,
+    sealGranted: standardContract.sealGranted,
+    sealLabel: "kein Siegel",
+    workflowStage: null,
+    workflowLabel: null,
+    badgeTone: resolveBadgeTone(verificationLabel),
+    isVerified: false,
+  };
+}


### PR DESCRIPTION
## Ziel
UI-/Status-Splitblock für contract-scharfe Darstellung:
- `analysiert` / `geprüft` / `verifiziert`
- Lane-/Research-/Seal-Badges aus zentralem Mapper

## Scope
- `features/ai/e150/verificationPresentation.ts`
- `apps/web/src/components/ai/VerificationStatusPanel.tsx`
- `apps/web/src/features/create/analyzeEnvelope.ts`
- `apps/web/src/app/api/factcheck/page.tsx`
- passende Presentation-/Envelope-Tests

## Abhängigkeit
Base ist der Foundation-PR `disagreement/confidence + sealed endpath`, damit sealed status helper/contracts konsistent sind.

## Validierung
- `pnpm -C apps/web exec vitest run tests/e150-verification-label.contract.test.ts tests/e150-verification-presentation.contract.test.ts tests/create-analyze-envelope.verification.test.ts` ✅