### PR TITLE
GOV-AI-ORCH-05 split: route-bound companion + non-mutative presentation pass

### DIFF
--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -1,12 +1,141 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import {
+  buildRouteBoundCompanionAnswer,
+  resolveRouteBoundCompanionContext,
+  runRouteBoundCompanionPresentationPass,
+  type RouteBoundCompanionContextKind,
+} from "@features/ai/e150/routeBoundCompanion";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-  return NextResponse.json({ ok: false, error: "not_implemented" }, { status: 501 });
+  return NextResponse.json(
+    {
+      ok: false,
+      error: "global_chat_disabled",
+      message:
+        "Globaler Chat ist deaktiviert. Verwende routegebundene Companion-Anfragen mit Kontext.",
+      supportedContexts: [
+        "dossier",
+        "factcheck",
+        "guided_workspace",
+        "journalist_companion",
+      ] as RouteBoundCompanionContextKind[],
+    },
+    { status: 400 },
+  );
 }
 
-export async function POST() {
-  return NextResponse.json({ ok: false, error: "not_implemented" }, { status: 501 });
+const ChatContextSchema = z.object({
+  kind: z.enum(["dossier", "factcheck", "guided_workspace", "journalist_companion"]),
+  title: z.string().trim().min(1).max(180).optional(),
+  analysisMode: z.enum(["analyze", "media", "guided"]).optional(),
+  routePath: z.string().trim().min(1).max(200).optional(),
+  parentStatus: z
+    .object({
+      status: z.string().trim().min(1).max(80).optional(),
+      lane: z.enum(["standard", "sealed_factcheck"]).optional(),
+      verificationMode: z.enum(["none", "precheck", "sealed"]).optional(),
+      researchUsed: z.enum(["none", "lite", "search", "deep_search"]).optional(),
+      sealEligible: z.boolean().optional(),
+      sealGranted: z.boolean().optional(),
+    })
+    .optional(),
+});
+
+const ChatRequestSchema = z.object({
+  message: z.string().trim().min(2).max(2000),
+  context: ChatContextSchema,
+  presentationPass: z.boolean().optional(),
+});
+
+function resolvePresentationPassEnabled(params: {
+  requested?: boolean;
+  contextKind: RouteBoundCompanionContextKind;
+}): boolean {
+  if (typeof params.requested === "boolean") {
+    return params.requested;
+  }
+  if (process.env.E150_PRESENTATION_PASS_DEFAULT !== "true") {
+    return false;
+  }
+  return (
+    params.contextKind === "dossier" ||
+    params.contextKind === "guided_workspace" ||
+    params.contextKind === "journalist_companion"
+  );
+}
+
+export async function POST(req: NextRequest) {
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "invalid_json", message: "Ungültiger JSON-Body." },
+      { status: 400 },
+    );
+  }
+
+  const parsed = ChatRequestSchema.safeParse(raw);
+  if (!parsed.success) {
+    const issue = parsed.error.issues?.[0];
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "invalid_input",
+        message: issue?.message ?? "Ungültige Anfrage für den Companion-Dialog.",
+      },
+      { status: 400 },
+    );
+  }
+
+  const payload = parsed.data;
+  const resolved = resolveRouteBoundCompanionContext(payload.context);
+  const answer = buildRouteBoundCompanionAnswer({
+    context: payload.context,
+    userMessage: payload.message,
+    resolved,
+  });
+  const presentationPassResult = runRouteBoundCompanionPresentationPass({
+    resolved,
+    answer,
+    enabled: resolvePresentationPassEnabled({
+      requested: payload.presentationPass,
+      contextKind: resolved.contextKind,
+    }),
+  });
+  const presentedAnswer = presentationPassResult.answer;
+
+  return NextResponse.json({
+    ok: true,
+    companion: {
+      mode: "route_bound_companion",
+      contextKind: resolved.contextKind,
+      journeyProfile: resolved.journeyProfile,
+      lane: resolved.lane,
+      verificationMode: resolved.verificationMode,
+      researchUsed: resolved.researchUsed,
+      sealEligible: resolved.sealEligible,
+      sealGranted: resolved.sealGranted,
+      verificationLabel: resolved.verificationLabel,
+      verificationHint: resolved.verificationHint,
+      workflowLabel: resolved.workflowLabel,
+      parentStatus: resolved.parentStatus,
+      tonePassUsed: presentationPassResult.meta.applied,
+      presentationPass: presentationPassResult.meta,
+      text: presentedAnswer.text,
+      followUps: presentedAnswer.followUps,
+      disclaimers: presentedAnswer.disclaimers,
+      rules: [
+        "route_bound_profile_reuse",
+        "no_silent_research_on_standard_lane",
+        "no_implicit_verification",
+        "no_seal_outside_sealed_factcheck",
+        "presentation_pass_non_mutative",
+      ] as const,
+    },
+  });
 }

--- a/apps/web/src/app/api/contributions/analyze/parseAnalyzeRequest.ts
+++ b/apps/web/src/app/api/contributions/analyze/parseAnalyzeRequest.ts
@@ -52,6 +52,7 @@ export const AnalyzeRequestSchemaV2 = z
         z.enum(CREATE_PRODUCT_MODE_VALUES).optional(),
       )
       .optional(),
+    presentationPass: z.boolean().optional(),
     anlassraumId: z.preprocess(
       (value) => {
         if (typeof value !== "string") return value;

--- a/apps/web/src/app/api/contributions/analyze/route.ts
+++ b/apps/web/src/app/api/contributions/analyze/route.ts
@@ -24,6 +24,7 @@ import {
   type VerificationContract,
 } from "@features/ai/e150/verificationContract";
 import { resolveJourneyProfile } from "@features/ai/e150/roleRouting";
+import { resolveAiRouteClassification } from "@features/ai/e150/routeClassification";
 import {
   buildSourceGroundingContext,
   finalizeSourceGroundingAudit,
@@ -108,6 +109,7 @@ type AnalyzeJobInput = {
   maxClaims: number;
   contributionId: string;
   analysisMode: CreateProductMode;
+  presentationPassEnabled: boolean;
   sourceGrounding: SourceGroundingContext;
   userId?: string | null;
 };
@@ -130,6 +132,19 @@ function resolveAnalyzeAudienceRole(mode: CreateProductMode): "citizen" | "staff
   if (mode === "media") return "staff";
   if (mode === "guided") return "institution";
   return "citizen";
+}
+
+function resolvePresentationPassEnabled(params: {
+  analysisMode: CreateProductMode;
+  requested?: boolean;
+}): boolean {
+  if (typeof params.requested === "boolean") {
+    return params.requested;
+  }
+  if (process.env.E150_PRESENTATION_PASS_DEFAULT !== "true") {
+    return false;
+  }
+  return params.analysisMode === "media" || params.analysisMode === "guided";
 }
 
 /**
@@ -180,6 +195,7 @@ export async function POST(req: NextRequest): Promise<Response> {
     analysisMode,
     routePath: "/api/contributions/analyze",
   });
+  const routeClassification = resolveAiRouteClassification("/api/contributions/analyze");
   const userId = req.cookies.get("u_id")?.value ?? null;
   const contributionId = resolveContributionId(body.contributionId, text);
   const sourceGrounding = buildSourceGroundingContext({
@@ -200,6 +216,10 @@ export async function POST(req: NextRequest): Promise<Response> {
     maxClaims,
     contributionId,
     analysisMode,
+    presentationPassEnabled: resolvePresentationPassEnabled({
+      analysisMode,
+      requested: body.presentationPass,
+    }),
     sourceGrounding,
     userId,
   };
@@ -270,6 +290,12 @@ export async function POST(req: NextRequest): Promise<Response> {
             successfulProviders: [],
             failedProviders: [],
           },
+          confidence: (result as any)?._meta?.confidence ?? {
+            score: 0.5,
+            bucket: "medium",
+            reasons: ["fallback_confidence_default"],
+          },
+          routeClassification: (result as any)?._meta?.routeClassification ?? routeClassification,
           sourceGrounding: sourceGroundingAudit,
         },
       },
@@ -347,6 +373,12 @@ export async function POST(req: NextRequest): Promise<Response> {
             successfulProviders: [],
             failedProviders: [],
           },
+          confidence: {
+            score: 0.35,
+            bucket: "low",
+            reasons: ["heuristic_fallback_path"],
+          },
+          routeClassification,
           sourceGrounding: sourceGroundingAudit,
         },
       });
@@ -457,6 +489,12 @@ export async function POST(req: NextRequest): Promise<Response> {
               successfulProviders: [],
               failedProviders: [],
             },
+            confidence: {
+              score: 0.25,
+              bucket: "low",
+              reasons: ["degraded_provider_path"],
+            },
+            routeClassification,
             sourceGrounding: sourceGroundingAudit,
           },
         },
@@ -537,6 +575,7 @@ async function runAnalyzeJob(input: AnalyzeJobInput): Promise<AnalyzeResultWithM
     analysisMode: input.analysisMode,
     routePath: "/api/contributions/analyze",
     sourceGroundingPromptAddon: input.sourceGrounding.promptAddon,
+    presentationPassEnabled: input.presentationPassEnabled,
   });
   return finalizeAnalyzeResult(analyzed);
 }

--- a/apps/web/src/app/dossier/[id]/ui.tsx
+++ b/apps/web/src/app/dossier/[id]/ui.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import type { Dossier } from "@features/dossier";
 import demoFallback from "@features/dossier/data/demoDossier";
 import { DossierViewer } from "@/components/dossier/DossierViewer";
+import RouteBoundCompanionPanel from "@/components/ai/RouteBoundCompanionPanel";
 
 type ApiResponse =
   | { ok: true; dossier: Dossier }
@@ -36,6 +37,23 @@ export default function DossierPageClient({ dossierId }: { dossierId: string }) 
       <p className="mb-3 text-xs text-[rgb(var(--muted))]">
         Dossier = strukturierte Verdichtung; der thematische Arbeitskontext bleibt bei den Anlässen (/runden).
       </p>
+      <div className="mb-4">
+        <RouteBoundCompanionPanel
+          contextKind="dossier"
+          title="Dossier"
+          routePath={`/dossier/${dossierId}`}
+          analysisMode="media"
+          intro="Companion für Dossier-Nachfragen auf Media-/Dossier-Journey, ohne implizites Siegel."
+          placeholder="Welche Konfliktlinie oder Quelle soll im Dossier als Nächstes geklärt werden?"
+          parentStatus={{
+            lane: "standard",
+            verificationMode: "precheck",
+            researchUsed: "none",
+            sealEligible: false,
+            sealGranted: false,
+          }}
+        />
+      </div>
       <DossierViewer dossier={dossier} />
     </div>
   );

--- a/apps/web/src/components/ai/RouteBoundCompanionPanel.tsx
+++ b/apps/web/src/components/ai/RouteBoundCompanionPanel.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState } from "react";
+import VerificationStatusPanel from "./VerificationStatusPanel";
+
+type CompanionContextKind =
+  | "dossier"
+  | "factcheck"
+  | "guided_workspace"
+  | "journalist_companion";
+
+type ParentStatus = {
+  status?: string | null;
+  lane?: "standard" | "sealed_factcheck";
+  verificationMode?: "none" | "precheck" | "sealed";
+  researchUsed?: "none" | "lite" | "search" | "deep_search";
+  sealEligible?: boolean;
+  sealGranted?: boolean;
+};
+
+type CompanionResponse = {
+  ok: boolean;
+  companion?: {
+    contextKind: CompanionContextKind;
+    journeyProfile: "analyze" | "media" | "guided" | "sealed_factcheck";
+    lane: "standard" | "sealed_factcheck";
+    verificationMode: "none" | "precheck" | "sealed";
+    researchUsed: "none" | "lite" | "search" | "deep_search";
+    sealEligible: boolean;
+    sealGranted: boolean;
+    verificationLabel: "analysiert" | "geprueft" | "verifiziert";
+    verificationHint: string;
+    workflowLabel: string | null;
+    text: string;
+    followUps: string[];
+    disclaimers: string[];
+  };
+  error?: string;
+  message?: string;
+};
+
+type RouteBoundCompanionPanelProps = {
+  contextKind: CompanionContextKind;
+  title?: string;
+  intro?: string;
+  placeholder?: string;
+  analysisMode?: "analyze" | "media" | "guided";
+  routePath?: string;
+  parentStatus?: ParentStatus;
+};
+
+export default function RouteBoundCompanionPanel(props: RouteBoundCompanionPanelProps) {
+  const [prompt, setPrompt] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [answer, setAnswer] = useState<CompanionResponse["companion"] | null>(null);
+
+  async function handleAsk() {
+    const message = prompt.trim();
+    if (message.length < 2) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          message,
+          context: {
+            kind: props.contextKind,
+            title: props.title,
+            analysisMode: props.analysisMode,
+            routePath: props.routePath,
+            parentStatus: props.parentStatus,
+          },
+        }),
+      });
+      const body = (await res.json().catch(() => null)) as CompanionResponse | null;
+      if (!res.ok || !body?.ok || !body.companion) {
+        throw new Error(body?.message ?? body?.error ?? "Companion-Antwort fehlgeschlagen.");
+      }
+      setAnswer(body.companion);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Companion-Antwort fehlgeschlagen.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <section className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-4 space-y-3">
+      <div className="space-y-1">
+        <p className="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">
+          Routegebundener Companion
+        </p>
+        <p className="text-sm text-[rgb(var(--muted))]">
+          {props.intro ??
+            "Kontextdialog auf Journey-Basis. Kein globaler Chat, kein Wahrheitssiegel."}
+        </p>
+      </div>
+
+      <VerificationStatusPanel
+        lane={props.parentStatus?.lane}
+        status={props.parentStatus?.status ?? null}
+        verificationMode={props.parentStatus?.verificationMode}
+        researchUsed={props.parentStatus?.researchUsed}
+        sealEligible={props.parentStatus?.sealEligible}
+        sealGranted={props.parentStatus?.sealGranted}
+        showHint
+      />
+
+      <div className="space-y-2">
+        <textarea
+          value={prompt}
+          onChange={(event) => setPrompt(event.target.value)}
+          rows={3}
+          className="w-full rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] px-3 py-2 text-sm text-[rgb(var(--fg))]"
+          placeholder={props.placeholder ?? "Nachfrage oder Kontextfrage eingeben…"}
+        />
+        <button
+          type="button"
+          disabled={loading || prompt.trim().length < 2}
+          onClick={() => void handleAsk()}
+          className="rounded-full border border-[rgb(var(--border))] bg-[rgb(var(--bg))] px-3 py-1.5 text-xs font-semibold text-[rgb(var(--muted))] disabled:opacity-50"
+        >
+          {loading ? "Companion antwortet…" : "Nachfrage stellen"}
+        </button>
+      </div>
+
+      {error ? (
+        <div className="rounded-xl border border-rose-300/60 bg-rose-50/80 px-3 py-2 text-xs text-rose-700">
+          {error}
+        </div>
+      ) : null}
+
+      {answer ? (
+        <div className="space-y-2 rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] px-3 py-3">
+          <VerificationStatusPanel
+            lane={answer.lane}
+            status={null}
+            verificationMode={answer.verificationMode}
+            researchUsed={answer.researchUsed}
+            sealEligible={answer.sealEligible}
+            sealGranted={answer.sealGranted}
+            showHint
+          />
+          <p className="text-sm text-[rgb(var(--fg))]">{answer.text}</p>
+          {answer.followUps.length > 0 ? (
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">
+                Nächste Nachfragen
+              </p>
+              <ul className="mt-1 list-disc space-y-1 pl-4 text-xs text-[rgb(var(--muted))]">
+                {answer.followUps.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/components/analyze/AnalyzeWorkspace.tsx
+++ b/apps/web/src/components/analyze/AnalyzeWorkspace.tsx
@@ -34,6 +34,8 @@ import SerpResultsList from "@/features/research/SerpResultsList";
 import EditorialAuditPanel from "@/components/analyze/EditorialAuditPanel";
 import EvidenceGraphPanel from "@/components/analyze/EvidenceGraphPanel";
 import RunReceiptPanel from "@/components/analyze/RunReceiptPanel";
+import VerificationStatusPanel from "@/components/ai/VerificationStatusPanel";
+import RouteBoundCompanionPanel from "@/components/ai/RouteBoundCompanionPanel";
 import ContentLanguageSelect from "@/components/ContentLanguageSelect";
 import { useContentLang } from "@/lib/i18n/contentLanguage";
 import { DEFAULT_BASE_LANG, LANGUAGE_CODES, type LanguageCode } from "@features/i18n/languages";
@@ -43,6 +45,7 @@ import type { CreateAnalyzeResponse } from "@/features/create/analyzeContract";
 import {
   parseCreateAnalyzeEnvelope,
   type CreateAnalyzeEnvelopeProviderMatrixEntry,
+  type ParsedCreateAnalyzeVerification,
 } from "@/features/create/analyzeEnvelope";
 import {
   resolveAndNavigateAfterFinalize,
@@ -107,6 +110,23 @@ function TinyPill({
     >
       {children}
     </span>
+  );
+}
+
+function AnalyzeVerificationPanel({
+  verification,
+}: {
+  verification: ParsedCreateAnalyzeVerification;
+}) {
+  return (
+    <VerificationStatusPanel
+      lane={verification.lane}
+      verificationMode={verification.verificationMode}
+      researchUsed={verification.researchUsed}
+      sealEligible={verification.sealEligible}
+      sealGranted={verification.sealGranted}
+      showHint
+    />
   );
 }
 
@@ -916,7 +936,10 @@ export default function AnalyzeWorkspace({
   const [runReceipt, setRunReceipt] = React.useState<RunReceipt | null>(null);
   const [providerMatrix, setProviderMatrix] = React.useState<ProviderMatrixEntry[]>([]);
   const [createAnalyze, setCreateAnalyze] = React.useState<CreateAnalyzeResponse | null>(null);
+  const [analysisVerification, setAnalysisVerification] = React.useState<ParsedCreateAnalyzeVerification | null>(null);
   const [sourceGroundingAudit, setSourceGroundingAudit] = React.useState<SourceGroundingAudit | null>(null);
+  const showGuidedCompanion =
+    analysisModeHint === "guided" || flow === "guided";
   const [ctaHandoffState, setCtaHandoffState] = React.useState<CreateCtaHandoffUiState>(
     () => createInitialCreateCtaHandoffState(),
   );
@@ -1875,6 +1898,7 @@ export default function AnalyzeWorkspace({
     setEvidenceGraph(null);
     setRunReceipt(null);
     setCreateAnalyze(null);
+    setAnalysisVerification(null);
     setSourceGroundingAudit(null);
     setCtaHandoffState(createInitialCreateCtaHandoffState());
     setPrepareAttachReview(null);
@@ -1917,6 +1941,7 @@ export default function AnalyzeWorkspace({
       }
       const parsedEnvelope = parseCreateAnalyzeEnvelope(data);
       setCreateAnalyze(parsedEnvelope.createAnalyze);
+      setAnalysisVerification(parsedEnvelope.verification);
       setSourceGroundingAudit(parsedEnvelope.sourceGrounding);
       setCtaHandoffState(createInitialCreateCtaHandoffState());
       setPrepareAttachReview(null);
@@ -2052,6 +2077,7 @@ export default function AnalyzeWorkspace({
       setEvidenceGraph(null);
       setRunReceipt(null);
       setCreateAnalyze(null);
+      setAnalysisVerification(null);
       setSourceGroundingAudit(null);
       setCtaHandoffState(createInitialCreateCtaHandoffState());
       setPrepareAttachReview(null);
@@ -2980,6 +3006,25 @@ export default function AnalyzeWorkspace({
                 </div>
               ) : null}
 
+              {analysisVerification ? <AnalyzeVerificationPanel verification={analysisVerification} /> : null}
+              {showGuidedCompanion ? (
+                <RouteBoundCompanionPanel
+                  contextKind="guided_workspace"
+                  title="Guided Workspace"
+                  routePath="/create"
+                  analysisMode="guided"
+                  intro="Guided-Companion für Rückfragen zur Struktur, Zuständigkeit und nächsten Schritten."
+                  placeholder="Welche offene Frage oder welcher nächste Schritt soll geklärt werden?"
+                  parentStatus={{
+                    lane: analysisVerification?.lane ?? "standard",
+                    verificationMode: analysisVerification?.verificationMode ?? "precheck",
+                    researchUsed: analysisVerification?.researchUsed ?? "none",
+                    sealEligible: analysisVerification?.sealEligible ?? false,
+                    sealGranted: analysisVerification?.sealGranted ?? false,
+                  }}
+                />
+              ) : null}
+
               {createAnalyzeRoutingHint ? (
                 <div
                   className={`rounded-xl border px-3 py-2 text-[11px] ${
@@ -3170,6 +3215,25 @@ export default function AnalyzeWorkspace({
                     </ul>
                   ) : null}
                 </div>
+              ) : null}
+
+              {analysisVerification ? <AnalyzeVerificationPanel verification={analysisVerification} /> : null}
+              {showGuidedCompanion ? (
+                <RouteBoundCompanionPanel
+                  contextKind="guided_workspace"
+                  title="Guided Workspace"
+                  routePath="/create"
+                  analysisMode="guided"
+                  intro="Guided-Companion für Rückfragen zur Struktur, Zuständigkeit und nächsten Schritten."
+                  placeholder="Welche offene Frage oder welcher nächste Schritt soll geklärt werden?"
+                  parentStatus={{
+                    lane: analysisVerification?.lane ?? "standard",
+                    verificationMode: analysisVerification?.verificationMode ?? "precheck",
+                    researchUsed: analysisVerification?.researchUsed ?? "none",
+                    sealEligible: analysisVerification?.sealEligible ?? false,
+                    sealGranted: analysisVerification?.sealGranted ?? false,
+                  }}
+                />
               ) : null}
 
               {createAnalyzeRoutingHint ? (

--- a/apps/web/src/features/surfaces/factcheck/FactcheckSurface.tsx
+++ b/apps/web/src/features/surfaces/factcheck/FactcheckSurface.tsx
@@ -5,6 +5,8 @@ import { useFactcheckJob } from "@/hooks/useFactcheckJob";
 import { buildCreateHref } from "@/features/create/intents";
 import { getDemoPersonaConfig, type DemoPersona } from "@/features/demo/personas";
 import { DEMO_STATUS_GLOSSARY, getDemoStatusLabel } from "@/features/demo/statusLanguage";
+import VerificationStatusPanel from "@/components/ai/VerificationStatusPanel";
+import RouteBoundCompanionPanel from "@/components/ai/RouteBoundCompanionPanel";
 import type { SurfaceContext } from "@/features/surface";
 
 type Verdict = "LIKELY_TRUE" | "LIKELY_FALSE" | "MIXED" | "UNDETERMINED";
@@ -88,7 +90,19 @@ export function FactcheckSurface({ context, persona }: FactcheckSurfaceProps) {
   const [manualConfidence, setManualConfidence] = useState(70);
   const [manualNote, setManualNote] = useState("");
   const [manualSources, setManualSources] = useState("");
-  const { jobId, status, claims, loading, error, enqueue, done } =
+  const {
+    jobId,
+    status,
+    claims,
+    loading,
+    error,
+    enqueue,
+    done,
+    verificationMode,
+    researchUsed,
+    sealEligible,
+    sealGranted,
+  } =
     useFactcheckJob();
 
   const aiClaims = useMemo(() => {
@@ -417,6 +431,34 @@ export function FactcheckSurface({ context, persona }: FactcheckSurfaceProps) {
           {jobId && <div className="text-xs text-[rgb(var(--muted))]">Lauf-ID: {jobId}</div>}
           {status && <div className="text-xs text-[rgb(var(--muted))]">Status: {status}</div>}
         </div>
+
+        {status !== "idle" ? (
+          <VerificationStatusPanel
+            lane="sealed_factcheck"
+            status={status}
+            verificationMode={verificationMode}
+            researchUsed={researchUsed}
+            sealEligible={sealEligible}
+            sealGranted={sealGranted}
+            showHint
+          />
+        ) : null}
+
+        <RouteBoundCompanionPanel
+          contextKind="factcheck"
+          title="Factcheck"
+          routePath="/factcheck"
+          intro="Companion für Rückfragen im Factcheck-Lane. Kein Siegel ohne abgeschlossenen sealed Workflow."
+          placeholder="Welche Aussage oder Quelle soll als Nächstes geprüft werden?"
+          parentStatus={{
+            status: status === "idle" ? "started" : status,
+            lane: "sealed_factcheck",
+            verificationMode: verificationMode,
+            researchUsed: researchUsed,
+            sealEligible: sealEligible,
+            sealGranted: sealGranted,
+          }}
+        />
 
         {error && <div className="text-sm text-red-600">Fehler: {error}</div>}
         {manualStatus && <div className="text-xs text-[rgb(var(--muted))]">{manualStatus}</div>}

--- a/apps/web/src/features/surfaces/topic-round/TopicRoundSurface.tsx
+++ b/apps/web/src/features/surfaces/topic-round/TopicRoundSurface.tsx
@@ -10,6 +10,7 @@ import {
 } from "./distribution";
 import SharePanel from "./SharePanel";
 import PublicFollowUpBlock from "./PublicFollowUpBlock";
+import RouteBoundCompanionPanel from "@/components/ai/RouteBoundCompanionPanel";
 
 const ROUND_TYPE_LABELS: Record<Round["type"], string> = {
   event: "Event",
@@ -432,6 +433,22 @@ export function CompanionSurface({
           </div>
         ) : null}
       </section>
+
+      <RouteBoundCompanionPanel
+        contextKind="journalist_companion"
+        title={companion.title}
+        routePath={`/companion/${companion.slug}`}
+        analysisMode="media"
+        intro="Companion-Dialog für journalistische Anschlussfragen, ohne implizite Verifikation."
+        placeholder="Welche Einordnung oder Quelle soll als Nächstes geklärt werden?"
+        parentStatus={{
+          lane: "standard",
+          verificationMode: "precheck",
+          researchUsed: "none",
+          sealEligible: false,
+          sealGranted: false,
+        }}
+      />
 
       <section id="fragen" className="rounded-3xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-5 shadow-sm">
         <h2 className="text-lg font-semibold text-[rgb(var(--fg))]">Fragen & Einwände</h2>

--- a/apps/web/src/hooks/useFactcheckJob.ts
+++ b/apps/web/src/hooks/useFactcheckJob.ts
@@ -1,11 +1,233 @@
+"use client";
+
+import * as React from "react";
+import { resolveSealedFactcheckStatusView } from "@features/ai/e150/factcheckStatus";
+
+type FactcheckEnqueueRequest = {
+  contributionId?: string;
+  text?: string;
+  language?: string;
+  topic?: string;
+  priority?: number;
+  withSerp?: boolean;
+  deepSearch?: boolean;
+};
+
+type FactcheckEnvelope = {
+  status?: unknown;
+  verificationMode?: unknown;
+  researchUsed?: unknown;
+  sealEligible?: unknown;
+  sealGranted?: unknown;
+  claims?: unknown;
+  results?: unknown;
+  job?: {
+    status?: unknown;
+    verificationMode?: unknown;
+    researchUsed?: unknown;
+    sealEligible?: unknown;
+    sealGranted?: unknown;
+  } | null;
+};
+
+const TERMINAL_STATUSES = new Set(["completed", "failed", "error"]);
+const POLL_INTERVAL_MS = 1_800;
+
+function toStatusString(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return value.trim().toLowerCase();
+}
+
+function extractClaims(value: FactcheckEnvelope): any[] {
+  if (Array.isArray(value.claims)) return value.claims;
+  if (Array.isArray(value.results)) return value.results;
+  return [];
+}
+
 export function useFactcheckJob() {
+  const [jobId, setJobId] = React.useState<string | null>(null);
+  const [status, setStatus] = React.useState<string>("idle");
+  const [claims, setClaims] = React.useState<any[]>([]);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [done, setDone] = React.useState(false);
+  const [verification, setVerification] = React.useState(() =>
+    resolveSealedFactcheckStatusView({
+      status: "started",
+      verificationMode: "sealed",
+      researchUsed: "search",
+      sealEligible: true,
+      sealGranted: false,
+    }),
+  );
+
+  const mountedRef = React.useRef(true);
+  const activeJobRef = React.useRef<string | null>(null);
+  const pollTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearPollTimer = React.useCallback(() => {
+    if (!pollTimerRef.current) return;
+    clearTimeout(pollTimerRef.current);
+    pollTimerRef.current = null;
+  }, []);
+
+  React.useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      clearPollTimer();
+    };
+  }, [clearPollTimer]);
+
+  const applyEnvelope = React.useCallback((payload: FactcheckEnvelope) => {
+    const effectiveStatus = toStatusString(payload.job?.status ?? payload.status);
+    const normalizedStatus = effectiveStatus || "queued";
+    const statusView = resolveSealedFactcheckStatusView({
+      status: normalizedStatus,
+      verificationMode: payload.job?.verificationMode ?? payload.verificationMode,
+      researchUsed: payload.job?.researchUsed ?? payload.researchUsed,
+      sealEligible: payload.job?.sealEligible ?? payload.sealEligible,
+      sealGranted: payload.job?.sealGranted ?? payload.sealGranted,
+    });
+
+    setStatus(normalizedStatus);
+    setClaims(extractClaims(payload));
+    setVerification(statusView);
+
+    const isDone = TERMINAL_STATUSES.has(normalizedStatus);
+    setDone(isDone);
+    return isDone;
+  }, []);
+
+  const pollStatus = React.useCallback(
+    async (targetJobId: string) => {
+      try {
+        const res = await fetch(`/api/factcheck/status/${encodeURIComponent(targetJobId)}`, {
+          method: "GET",
+          cache: "no-store",
+          credentials: "same-origin",
+        });
+        const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+        if (!mountedRef.current || activeJobRef.current !== targetJobId) return;
+
+        if (!res.ok || data?.ok !== true) {
+          const message =
+            typeof data?.message === "string"
+              ? data.message
+              : typeof data?.reason === "string"
+                ? data.reason
+                : `Statusabfrage fehlgeschlagen (HTTP ${res.status})`;
+          setError(message);
+          setLoading(false);
+          setDone(true);
+          return;
+        }
+
+        const doneNow = applyEnvelope(data as FactcheckEnvelope);
+        setLoading(false);
+
+        if (!doneNow && activeJobRef.current === targetJobId) {
+          clearPollTimer();
+          pollTimerRef.current = setTimeout(() => {
+            void pollStatus(targetJobId);
+          }, POLL_INTERVAL_MS);
+        }
+      } catch (err: any) {
+        if (!mountedRef.current || activeJobRef.current !== targetJobId) return;
+        setLoading(false);
+        setDone(true);
+        setError(String(err?.message ?? "Statusabfrage fehlgeschlagen"));
+      }
+    },
+    [applyEnvelope, clearPollTimer],
+  );
+
+  const enqueue = React.useCallback(
+    async (request?: FactcheckEnqueueRequest) => {
+      clearPollTimer();
+      setLoading(true);
+      setError(null);
+      setDone(false);
+      setClaims([]);
+      setStatus("started");
+      setVerification(
+        resolveSealedFactcheckStatusView({
+          status: "started",
+          verificationMode: "sealed",
+          researchUsed: request?.deepSearch === true ? "deep_search" : "search",
+          sealEligible: true,
+          sealGranted: false,
+        }),
+      );
+
+      try {
+        const res = await fetch("/api/factcheck/enqueue", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          credentials: "same-origin",
+          body: JSON.stringify({
+            text: request?.text ?? "",
+            contributionId: request?.contributionId,
+            language: request?.language ?? "de",
+            priority: request?.priority ?? 5,
+            topic: request?.topic,
+            withSerp: request?.withSerp,
+            deepSearch: request?.deepSearch,
+          }),
+        });
+
+        const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+        if (!mountedRef.current) return;
+
+        if (!res.ok || data?.ok !== true) {
+          const message =
+            typeof data?.message === "string"
+              ? data.message
+              : typeof data?.reason === "string"
+                ? data.reason
+                : `Enqueue fehlgeschlagen (HTTP ${res.status})`;
+          throw new Error(message);
+        }
+
+        const nextJobId = typeof data?.jobId === "string" ? data.jobId : null;
+        setJobId(nextJobId);
+        activeJobRef.current = nextJobId;
+
+        const doneNow = applyEnvelope(data as FactcheckEnvelope);
+        if (nextJobId && !doneNow) {
+          pollTimerRef.current = setTimeout(() => {
+            void pollStatus(nextJobId);
+          }, POLL_INTERVAL_MS);
+        } else {
+          setLoading(false);
+        }
+      } catch (err: any) {
+        if (!mountedRef.current) return;
+        setLoading(false);
+        setDone(true);
+        setError(String(err?.message ?? "Factcheck enqueue fehlgeschlagen"));
+      }
+    },
+    [applyEnvelope, clearPollTimer, pollStatus],
+  );
+
   return {
-    jobId: null as string | null,
-    status: "idle" as string,
-    claims: [] as any[],
-    loading: false,
-    error: null as any,
-    enqueue: (_req?: any) => {},
-    done: false,
+    jobId,
+    status,
+    claims,
+    loading,
+    error,
+    enqueue,
+    done,
+    verificationMode: verification.verificationMode,
+    researchUsed: verification.researchUsed,
+    sealEligible: verification.sealEligible,
+    sealGranted: verification.sealGranted,
+    verificationLabel: verification.verificationLabel,
+    workflowStage: verification.workflowStage,
+    workflowLabel: verification.workflowLabel,
+    sealStatus: verification.sealLabel,
+    lane: "sealed_factcheck" as const,
+    journeyProfile: "sealed_factcheck" as const,
   };
 }

--- a/apps/web/tests/analyze-contribution.null-hardening.test.ts
+++ b/apps/web/tests/analyze-contribution.null-hardening.test.ts
@@ -169,4 +169,45 @@ describe("analyzeContribution null hardening", () => {
     expect(result.responsibilityPaths[0]?.nodes[0]?.actorKey).toBe("bundestag");
     expect(result.responsibilityPaths[0]?.nodes[0]?.displayName).toBe("Deutscher Bundestag");
   });
+
+  it("applies optional presentation pass only to display text and keeps verification fields stable", async () => {
+    mocks.callE150Orchestrator.mockResolvedValue(
+      orchestratorResult({
+        claims: [{ id: "claim-1", text: "Claim bleibt gleich." }],
+        notes: [{ id: "n1", text: "  Kontext   ;  knapp  " }],
+        questions: [{ id: "q1", text: "  Welche  Daten  fehlen ?  " }],
+        report: {
+          summary: "  Kompakt   ;  neutral !!  ",
+          keyConflicts: ["  Konflikt   A  "],
+          facts: { local: ["Fakt"], international: [] },
+          openQuestions: ["  Offen ?  "],
+          takeaways: ["  Nächster   Schritt  "],
+        },
+      }),
+    );
+
+    const result = await analyzeContribution({
+      text: "Ein längerer Medienbeitrag mit Kontext und Detailpunkten.",
+      locale: "de",
+      analysisMode: "media",
+      audienceRole: "staff",
+      presentationPassEnabled: true,
+    });
+
+    expect(result.claims).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "claim-1", text: "Claim bleibt gleich." })]),
+    );
+    expect(result.report.summary).toBe("Kompakt; neutral!");
+    expect(result.report.keyConflicts).toEqual(["Konflikt A"]);
+    expect(result.report.openQuestions).toEqual(["Offen?"]);
+    expect(result.report.takeaways).toEqual(["Nächster Schritt"]);
+    expect(result.notes[0]?.text).toBe("Kontext; knapp");
+    expect(result.questions[0]?.text).toBe("Welche Daten fehlen?");
+    expect(result?._meta?.verificationMode).toBe("precheck");
+    expect(result?._meta?.researchUsed).toBe("none");
+    expect(result?._meta?.sealEligible).toBe(false);
+    expect(result?._meta?.sealGranted).toBe(false);
+    expect(result?._meta?.tonePassUsed).toBe(true);
+    expect(result?._meta?.presentationPass?.applied).toBe(true);
+  });
 });

--- a/apps/web/tests/chat-route.contract.test.ts
+++ b/apps/web/tests/chat-route.contract.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+
+import { GET, POST } from "@/app/api/chat/route";
+
+function postReq(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/chat", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/chat route-bound companion", () => {
+  it("rejects global chat GET access", async () => {
+    const res = await GET();
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("global_chat_disabled");
+  });
+
+  it("rejects invalid payload without context", async () => {
+    const res = await POST(postReq({ message: "Hallo" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("invalid_input");
+  });
+
+  it("returns standard-lane dossier companion without implicit verification", async () => {
+    const res = await POST(
+      postReq({
+        message: "Welche Konfliktlinie ist am wichtigsten?",
+        context: {
+          kind: "dossier",
+          title: "Bildungsdossier",
+          parentStatus: {
+            verificationMode: "sealed",
+            researchUsed: "deep_search",
+            sealEligible: true,
+            sealGranted: true,
+          },
+        },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.companion.lane).toBe("standard");
+    expect(body.companion.journeyProfile).toBe("media");
+    expect(body.companion.researchUsed).toBe("none");
+    expect(body.companion.sealEligible).toBe(false);
+    expect(body.companion.sealGranted).toBe(false);
+    expect(body.companion.verificationLabel).not.toBe("verifiziert");
+  });
+
+  it("returns sealed factcheck companion with correct sealed defaults", async () => {
+    const res = await POST(
+      postReq({
+        message: "Welche Quelle fehlt noch?",
+        context: {
+          kind: "factcheck",
+          parentStatus: {
+            status: "queued",
+          },
+        },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.companion.lane).toBe("sealed_factcheck");
+    expect(body.companion.journeyProfile).toBe("sealed_factcheck");
+    expect(body.companion.verificationMode).toBe("sealed");
+    expect(body.companion.researchUsed).toBe("search");
+    expect(body.companion.sealEligible).toBe(true);
+    expect(body.companion.sealGranted).toBe(false);
+    expect(body.companion.verificationLabel).toBe("geprueft");
+  });
+
+  it("runs optional presentation pass without changing verification contract", async () => {
+    const res = await POST(
+      postReq({
+        message: "Bitte   knapp zusammenfassen!!!",
+        presentationPass: true,
+        context: {
+          kind: "factcheck",
+          parentStatus: {
+            status: "in_progress",
+          },
+        },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(typeof body.companion.tonePassUsed).toBe("boolean");
+    expect(body.companion.presentationPass).toBeTruthy();
+    expect(body.companion.lane).toBe("sealed_factcheck");
+    expect(body.companion.verificationMode).toBe("sealed");
+    expect(body.companion.researchUsed).toBe("search");
+    expect(body.companion.sealEligible).toBe(true);
+    expect(body.companion.sealGranted).toBe(false);
+  });
+});

--- a/apps/web/tests/create-analyze.route.test.ts
+++ b/apps/web/tests/create-analyze.route.test.ts
@@ -113,6 +113,7 @@ describe("/api/contributions/analyze create orchestration envelope", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     process.env.ANALYZE_ENABLED = "true";
+    delete process.env.E150_PRESENTATION_PASS_DEFAULT;
 
     mocks.rateLimitOrThrow.mockResolvedValue({ ok: true, retryIn: 0 });
     mocks.deriveContextNotes.mockReturnValue([]);
@@ -408,6 +409,27 @@ describe("/api/contributions/analyze create orchestration envelope", () => {
       expect.objectContaining({
         analysisMode: "guided",
         audienceRole: "institution",
+      }),
+    );
+  });
+
+  it("forwards explicit presentationPass flag to analyzeContribution as optional tone pass switch", async () => {
+    mocks.analyzeContribution.mockResolvedValue(buildAnalyzeResult({ claims: [] }));
+
+    const res = await analyzePOST(
+      req({
+        text: "Das ist ein ausreichend langer Text fuer den Presentation-Pass-Test.",
+        locale: "de-DE",
+        analysisMode: "media",
+        presentationPass: true,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mocks.analyzeContribution).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        analysisMode: "media",
+        presentationPassEnabled: true,
       }),
     );
   });

--- a/apps/web/tests/create-mode.analyze-parse.test.ts
+++ b/apps/web/tests/create-mode.analyze-parse.test.ts
@@ -38,4 +38,16 @@ describe("create mode analyze parse boundary", () => {
     if (parsed.ok) return;
     expect(parsed.error.message).toBe("invalid_anlassraum_id");
   });
+
+  it("keeps optional presentationPass flag for controlled non-mutative tone pass", () => {
+    const parsed = parseAnalyzeRequestBody({
+      text: "Genug langer Text fuer den Presentation-Pass Parse-Test.",
+      analysisMode: "media",
+      presentationPass: true,
+    });
+
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.value.presentationPass).toBe(true);
+  });
 });

--- a/apps/web/tests/e150-presentation-pass.guard.contract.test.ts
+++ b/apps/web/tests/e150-presentation-pass.guard.contract.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizePresentationText,
+  runNonMutativePresentationPass,
+} from "@features/ai/e150/presentationPass";
+
+type Payload = {
+  summary: string;
+  cards: string[];
+  protected: {
+    claims: unknown;
+    evidence: unknown;
+    trust: unknown;
+    verificationMode: "none" | "precheck" | "sealed";
+    researchUsed: "none" | "lite" | "search" | "deep_search";
+    sealEligible: boolean;
+    sealGranted: boolean;
+  };
+};
+
+function snapshot(payload: Payload) {
+  return {
+    claims: payload.protected.claims,
+    evidence: payload.protected.evidence,
+    trust: payload.protected.trust,
+    verificationMode: payload.protected.verificationMode,
+    researchUsed: payload.protected.researchUsed,
+    sealEligible: payload.protected.sealEligible,
+    sealGranted: payload.protected.sealGranted,
+  } as const;
+}
+
+describe("presentation pass non-mutation guard", () => {
+  it("normalizes presentation texts and keeps protected fields untouched", () => {
+    const payload: Payload = {
+      summary: "  Kompakt   ;  neutral !!  ",
+      cards: ["  Kontext ,  sauber  "],
+      protected: {
+        claims: [{ id: "c1", text: "Claim unveraendert" }],
+        evidence: [{ id: "e1" }],
+        trust: { score: 0.7 },
+        verificationMode: "sealed",
+        researchUsed: "search",
+        sealEligible: true,
+        sealGranted: false,
+      },
+    };
+
+    const result = runNonMutativePresentationPass({
+      provider: "openai",
+      enabled: true,
+      payload,
+      snapshot,
+      apply: (value) => ({
+        payload: {
+          ...value,
+          summary: normalizePresentationText(value.summary),
+          cards: value.cards.map((card) => normalizePresentationText(card)),
+        },
+        changed: true,
+        changedFields: ["summary", "cards"],
+      }),
+    });
+
+    expect(result.meta.applied).toBe(true);
+    expect(result.meta.reason).toBe("applied");
+    expect(result.payload.summary).toBe("Kompakt; neutral!");
+    expect(result.payload.cards).toEqual(["Kontext, sauber"]);
+    expect(result.payload.protected.claims).toEqual(payload.protected.claims);
+    expect(result.payload.protected.verificationMode).toBe("sealed");
+    expect(result.payload.protected.researchUsed).toBe("search");
+    expect(result.payload.protected.sealEligible).toBe(true);
+    expect(result.payload.protected.sealGranted).toBe(false);
+  });
+
+  it("reverts to original payload when guard detects protected-field mutation", () => {
+    const payload: Payload = {
+      summary: "Text",
+      cards: [],
+      protected: {
+        claims: [{ id: "c1", text: "Original" }],
+        evidence: [{ id: "e1" }],
+        trust: { score: 0.6 },
+        verificationMode: "none",
+        researchUsed: "none",
+        sealEligible: false,
+        sealGranted: false,
+      },
+    };
+
+    const result = runNonMutativePresentationPass({
+      provider: "openai",
+      enabled: true,
+      payload,
+      snapshot,
+      apply: (value) => ({
+        payload: {
+          ...value,
+          summary: "Text geglaettet",
+          protected: {
+            ...value.protected,
+            claims: [{ id: "c2", text: "Mutiert" }],
+          },
+        },
+        changed: true,
+        changedFields: ["summary", "claims"],
+      }),
+    });
+
+    expect(result.meta.applied).toBe(false);
+    expect(result.meta.reason).toBe("guard_blocked");
+    expect(result.meta.nonMutativeGuardPassed).toBe(false);
+    expect(result.payload).toEqual(payload);
+  });
+
+  it("blocks mutation when lane/provider meta changes", () => {
+    const payload: Payload = {
+      summary: "Text",
+      cards: [],
+      protected: {
+        claims: [{ id: "c1", text: "Original" }],
+        evidence: [{ id: "e1" }],
+        trust: { score: 0.6 },
+        verificationMode: "precheck",
+        researchUsed: "none",
+        sealEligible: false,
+        sealGranted: false,
+      },
+    };
+
+    const result = runNonMutativePresentationPass({
+      provider: "openai",
+      enabled: true,
+      payload,
+      snapshot: (value) => ({
+        ...snapshot(value),
+        laneMeta: { lane: "standard", summaryHash: value.summary },
+        providerMeta: { provider: "openai", role: "presentation_pass", summaryHash: value.summary },
+      }),
+      apply: (value) => ({
+        payload: {
+          ...value,
+          summary: "Text geglättet",
+        },
+        changed: true,
+        changedFields: ["summary"],
+      }),
+    });
+
+    expect(result.meta.applied).toBe(false);
+    expect(result.meta.reason).toBe("guard_blocked");
+    expect(result.meta.nonMutativeGuardPassed).toBe(false);
+    expect(result.payload).toEqual(payload);
+  });
+
+  it("falls back to original payload when presentation pass throws", () => {
+    const payload: Payload = {
+      summary: "Text",
+      cards: [],
+      protected: {
+        claims: [{ id: "c1", text: "Claim" }],
+        evidence: [{ id: "e1" }],
+        trust: { score: 0.5 },
+        verificationMode: "precheck",
+        researchUsed: "none",
+        sealEligible: false,
+        sealGranted: false,
+      },
+    };
+
+    const result = runNonMutativePresentationPass({
+      provider: "openai",
+      enabled: true,
+      payload,
+      snapshot,
+      apply: () => {
+        throw new Error("pass failed");
+      },
+    });
+
+    expect(result.meta.applied).toBe(false);
+    expect(result.meta.reason).toBe("failed");
+    expect(result.meta.failure).toContain("pass failed");
+    expect(result.payload).toEqual(payload);
+  });
+
+  it("does not run for non-openai providers", () => {
+    const payload: Payload = {
+      summary: "Text",
+      cards: [],
+      protected: {
+        claims: [],
+        evidence: [],
+        trust: null,
+        verificationMode: "none",
+        researchUsed: "none",
+        sealEligible: false,
+        sealGranted: false,
+      },
+    };
+
+    const result = runNonMutativePresentationPass({
+      provider: "anthropic",
+      enabled: true,
+      payload,
+      snapshot,
+      apply: (value) => ({ payload: value, changed: false }),
+    });
+
+    expect(result.meta.reason).toBe("provider_not_allowed");
+    expect(result.meta.applied).toBe(false);
+    expect(result.payload).toEqual(payload);
+  });
+});

--- a/apps/web/tests/route-bound-companion.contract.test.ts
+++ b/apps/web/tests/route-bound-companion.contract.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildRouteBoundCompanionAnswer,
+  resolveRouteBoundCompanionContext,
+  runRouteBoundCompanionPresentationPass,
+} from "@features/ai/e150/routeBoundCompanion";
+
+describe("route-bound companion contract", () => {
+  it("reuses media journey profile for dossier context", () => {
+    const resolved = resolveRouteBoundCompanionContext({
+      kind: "dossier",
+      title: "Haushaltsdossier",
+    });
+
+    expect(resolved.journeyProfile).toBe("media");
+    expect(resolved.lane).toBe("standard");
+    expect(resolved.verificationMode).toBe("precheck");
+    expect(resolved.researchUsed).toBe("none");
+    expect(resolved.sealEligible).toBe(false);
+    expect(resolved.sealGranted).toBe(false);
+    expect(resolved.verificationLabel).toBe("geprueft");
+  });
+
+  it("keeps standard-lane guardrails even when parent status is inconsistent", () => {
+    const resolved = resolveRouteBoundCompanionContext({
+      kind: "guided_workspace",
+      parentStatus: {
+        lane: "sealed_factcheck",
+        verificationMode: "sealed",
+        researchUsed: "deep_search",
+        sealEligible: true,
+        sealGranted: true,
+      },
+    });
+
+    expect(resolved.journeyProfile).toBe("guided");
+    expect(resolved.lane).toBe("standard");
+    expect(resolved.verificationMode).toBe("precheck");
+    expect(resolved.researchUsed).toBe("none");
+    expect(resolved.sealEligible).toBe(false);
+    expect(resolved.sealGranted).toBe(false);
+    expect(resolved.verificationLabel).toBe("geprueft");
+  });
+
+  it("keeps sealed_factcheck lane with search defaults", () => {
+    const resolved = resolveRouteBoundCompanionContext({
+      kind: "factcheck",
+    });
+
+    expect(resolved.journeyProfile).toBe("sealed_factcheck");
+    expect(resolved.lane).toBe("sealed_factcheck");
+    expect(resolved.verificationMode).toBe("sealed");
+    expect(resolved.researchUsed).toBe("search");
+    expect(resolved.sealEligible).toBe(true);
+    expect(resolved.sealGranted).toBe(false);
+    expect(resolved.verificationLabel).toBe("geprueft");
+  });
+
+  it("marks factcheck companion as verifiziert only when sealGranted is true", () => {
+    const resolved = resolveRouteBoundCompanionContext({
+      kind: "factcheck",
+      parentStatus: {
+        status: "completed",
+        verificationMode: "sealed",
+        researchUsed: "deep_search",
+        sealEligible: true,
+        sealGranted: true,
+      },
+    });
+
+    expect(resolved.lane).toBe("sealed_factcheck");
+    expect(resolved.verificationLabel).toBe("verifiziert");
+    expect(resolved.sealGranted).toBe(true);
+
+    const answer = buildRouteBoundCompanionAnswer({
+      context: { kind: "factcheck" },
+      userMessage: "Bitte Ergebnis knapp zusammenfassen.",
+      resolved,
+    });
+
+    expect(answer.text).toContain("kein Wahrheits- oder Siegelsystem");
+    expect(answer.disclaimers).toContain("Kein Siegel außerhalb sealed_factcheck.");
+  });
+
+  it("applies optional non-mutative presentation pass to companion text only", () => {
+    const resolved = resolveRouteBoundCompanionContext({
+      kind: "factcheck",
+      parentStatus: {
+        status: "queued",
+      },
+    });
+
+    const answer = buildRouteBoundCompanionAnswer({
+      context: { kind: "factcheck" },
+      userMessage: "Bitte kurz zusammenfassen!!!",
+      resolved,
+    });
+
+    const pass = runRouteBoundCompanionPresentationPass({
+      resolved,
+      answer,
+      enabled: true,
+    });
+
+    expect(pass.meta.reason === "applied" || pass.meta.reason === "no_change").toBe(true);
+    expect(pass.meta.nonMutativeGuardPassed).toBe(true);
+    expect(pass.answer.text).toContain("zusammenfassen!");
+    expect(resolved.verificationMode).toBe("sealed");
+    expect(resolved.researchUsed).toBe("search");
+    expect(resolved.sealEligible).toBe(true);
+    expect(resolved.sealGranted).toBe(false);
+  });
+});

--- a/features/ai/e150/presentationPass.ts
+++ b/features/ai/e150/presentationPass.ts
@@ -1,4 +1,5 @@
 import type { E150ProviderName } from "./journeyProfiles";
+import type { ResearchUsed, VerificationMode } from "./verificationContract";
 
 export type PresentationPassProvider = "openai";
 
@@ -7,6 +8,27 @@ export type PresentationPassPolicy = {
   role: "presentation_pass";
   nonMutative: true;
   rules: readonly string[];
+};
+
+export type PresentationPassReason =
+  | "disabled"
+  | "provider_not_allowed"
+  | "failed"
+  | "no_change"
+  | "guard_blocked"
+  | "applied";
+
+export type PresentationPassExecutionMeta = {
+  attempted: boolean;
+  enabled: boolean;
+  applied: boolean;
+  provider: PresentationPassProvider | null;
+  role: "presentation_pass";
+  reason: PresentationPassReason;
+  nonMutativeGuardPassed: boolean;
+  changedFields: string[];
+  failure: string | null;
+  policy: PresentationPassPolicy | null;
 };
 
 export const OPENAI_PRESENTATION_PASS_POLICY: PresentationPassPolicy = {
@@ -26,18 +48,213 @@ export function canUsePresentationPass(provider: E150ProviderName): boolean {
   return provider === "openai";
 }
 
+export type PresentationPassProtectedSnapshot = {
+  claims: unknown;
+  evidence: unknown;
+  trust: unknown;
+  verificationMode: VerificationMode;
+  researchUsed: ResearchUsed;
+  sealEligible: boolean;
+  sealGranted: boolean;
+  laneMeta?: unknown;
+  providerMeta?: unknown;
+};
+
+function safeStableStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? "null";
+  } catch {
+    return "__unserializable__";
+  }
+}
+
+export function isPresentationPassNonMutative(
+  before: PresentationPassProtectedSnapshot,
+  after: PresentationPassProtectedSnapshot,
+): boolean {
+  return (
+    safeStableStringify(before.claims) === safeStableStringify(after.claims) &&
+    safeStableStringify(before.evidence) === safeStableStringify(after.evidence) &&
+    safeStableStringify(before.trust) === safeStableStringify(after.trust) &&
+    before.verificationMode === after.verificationMode &&
+    before.researchUsed === after.researchUsed &&
+    before.sealEligible === after.sealEligible &&
+    before.sealGranted === after.sealGranted &&
+    safeStableStringify(before.laneMeta) === safeStableStringify(after.laneMeta) &&
+    safeStableStringify(before.providerMeta) === safeStableStringify(after.providerMeta)
+  );
+}
+
+export type PresentationPassApplyResult<TPayload> = {
+  payload: TPayload;
+  changed: boolean;
+  changedFields?: string[];
+};
+
+export function normalizePresentationText(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) return "";
+  return trimmed
+    .replace(/\s+/g, " ")
+    .replace(/\s+([,.;:!?])/g, "$1")
+    .replace(/([,.;:!?])([A-Za-zÄÖÜäöüß])/g, "$1 $2")
+    .replace(/([!?.,;:])\1+/g, "$1");
+}
+
+export function normalizePresentationTextList(items: readonly string[]): string[] {
+  return items
+    .map((item) => normalizePresentationText(item))
+    .filter((item) => item.length > 0);
+}
+
+export function runNonMutativePresentationPass<TPayload>(params: {
+  provider: E150ProviderName;
+  enabled?: boolean;
+  payload: TPayload;
+  snapshot: (payload: TPayload) => PresentationPassProtectedSnapshot;
+  apply: (payload: TPayload) => PresentationPassApplyResult<TPayload>;
+}): { payload: TPayload; meta: PresentationPassExecutionMeta } {
+  if (!params.enabled) {
+    return {
+      payload: params.payload,
+      meta: {
+        attempted: false,
+        enabled: false,
+        applied: false,
+        provider: null,
+        role: "presentation_pass",
+        reason: "disabled",
+        nonMutativeGuardPassed: true,
+        changedFields: [],
+        failure: null,
+        policy: null,
+      },
+    };
+  }
+  if (!canUsePresentationPass(params.provider)) {
+    return {
+      payload: params.payload,
+      meta: {
+        attempted: false,
+        enabled: true,
+        applied: false,
+        provider: null,
+        role: "presentation_pass",
+        reason: "provider_not_allowed",
+        nonMutativeGuardPassed: true,
+        changedFields: [],
+        failure: null,
+        policy: null,
+      },
+    };
+  }
+
+  const before = params.snapshot(params.payload);
+
+  try {
+    const applied = params.apply(params.payload);
+    const changedFields = applied.changedFields ?? [];
+    const after = params.snapshot(applied.payload);
+    const guardOk = isPresentationPassNonMutative(before, after);
+    if (!guardOk) {
+      return {
+        payload: params.payload,
+        meta: {
+          attempted: true,
+          enabled: true,
+          applied: false,
+          provider: "openai",
+          role: "presentation_pass",
+          reason: "guard_blocked",
+          nonMutativeGuardPassed: false,
+          changedFields: [],
+          failure: null,
+          policy: OPENAI_PRESENTATION_PASS_POLICY,
+        },
+      };
+    }
+
+    if (!applied.changed) {
+      return {
+        payload: applied.payload,
+        meta: {
+          attempted: true,
+          enabled: true,
+          applied: false,
+          provider: "openai",
+          role: "presentation_pass",
+          reason: "no_change",
+          nonMutativeGuardPassed: true,
+          changedFields: [],
+          failure: null,
+          policy: OPENAI_PRESENTATION_PASS_POLICY,
+        },
+      };
+    }
+
+    return {
+      payload: applied.payload,
+      meta: {
+        attempted: true,
+        enabled: true,
+        applied: true,
+        provider: "openai",
+        role: "presentation_pass",
+        reason: "applied",
+        nonMutativeGuardPassed: true,
+        changedFields,
+        failure: null,
+        policy: OPENAI_PRESENTATION_PASS_POLICY,
+      },
+    };
+  } catch (error) {
+    return {
+      payload: params.payload,
+      meta: {
+        attempted: true,
+        enabled: true,
+        applied: false,
+        provider: "openai",
+        role: "presentation_pass",
+        reason: "failed",
+        nonMutativeGuardPassed: true,
+        changedFields: [],
+        failure:
+          error instanceof Error
+            ? error.message
+            : typeof error === "string"
+              ? error
+              : "presentation_pass_failed",
+        policy: OPENAI_PRESENTATION_PASS_POLICY,
+      },
+    };
+  }
+}
+
 export function applyPresentationPassStub(params: {
   provider: E150ProviderName;
   text: string;
   enabled?: boolean;
 }): { applied: boolean; text: string; policy: PresentationPassPolicy | null } {
-  if (!params.enabled) return { applied: false, text: params.text, policy: null };
-  if (!canUsePresentationPass(params.provider)) {
-    return { applied: false, text: params.text, policy: null };
-  }
+  const result = runNonMutativePresentationPass({
+    provider: params.provider,
+    enabled: params.enabled,
+    payload: params.text,
+    snapshot: () => ({
+      claims: null,
+      evidence: null,
+      trust: null,
+      verificationMode: "none",
+      researchUsed: "none",
+      sealEligible: false,
+      sealGranted: false,
+    }),
+    apply: (payload) => ({ payload, changed: false }),
+  });
+
   return {
-    applied: false,
-    text: params.text,
-    policy: OPENAI_PRESENTATION_PASS_POLICY,
+    applied: result.meta.applied,
+    text: result.payload,
+    policy: result.meta.policy,
   };
 }

--- a/features/ai/e150/routeBoundCompanion.ts
+++ b/features/ai/e150/routeBoundCompanion.ts
@@ -1,0 +1,322 @@
+import { resolveJourneyProfile, type E150RoleRoutingInput } from "./roleRouting";
+import { resolveVerificationPresentationView } from "./verificationPresentation";
+import type {
+  ResearchUsed,
+  UserFacingVerificationLabel,
+  VerificationMode,
+} from "./verificationContract";
+import type { E150JourneyKey, E150Lane } from "./journeyProfiles";
+import {
+  normalizePresentationText,
+  normalizePresentationTextList,
+  runNonMutativePresentationPass,
+  type PresentationPassExecutionMeta,
+} from "./presentationPass";
+
+export type RouteBoundCompanionContextKind =
+  | "dossier"
+  | "factcheck"
+  | "guided_workspace"
+  | "journalist_companion";
+
+export type RouteBoundCompanionParentStatus = {
+  status?: string | null;
+  lane?: E150Lane;
+  verificationMode?: VerificationMode;
+  researchUsed?: ResearchUsed;
+  sealEligible?: boolean;
+  sealGranted?: boolean;
+};
+
+export type RouteBoundCompanionContext = {
+  kind: RouteBoundCompanionContextKind;
+  title?: string | null;
+  analysisMode?: "analyze" | "media" | "guided" | null;
+  routePath?: string | null;
+  parentStatus?: RouteBoundCompanionParentStatus | null;
+};
+
+export type RouteBoundCompanionResolved = {
+  contextKind: RouteBoundCompanionContextKind;
+  journeyProfile: E150JourneyKey;
+  lane: E150Lane;
+  verificationMode: VerificationMode;
+  researchUsed: ResearchUsed;
+  sealEligible: boolean;
+  sealGranted: boolean;
+  verificationLabel: UserFacingVerificationLabel;
+  verificationHint: string;
+  workflowLabel: string | null;
+  parentStatus: {
+    lane: E150Lane;
+    verificationMode: VerificationMode;
+    researchUsed: ResearchUsed;
+    sealEligible: boolean;
+    sealGranted: boolean;
+    verificationLabel: UserFacingVerificationLabel;
+    verificationHint: string;
+    workflowLabel: string | null;
+  };
+};
+
+export type RouteBoundCompanionAnswer = {
+  text: string;
+  followUps: string[];
+  disclaimers: string[];
+};
+
+function trimToSingleLine(input: string): string {
+  return input.replace(/\s+/g, " ").trim();
+}
+
+function compactMessage(input: string, maxLen = 220): string {
+  const text = trimToSingleLine(input);
+  if (!text) return "Kein Kontext übergeben.";
+  if (text.length <= maxLen) return text;
+  return `${text.slice(0, maxLen - 1).trim()}…`;
+}
+
+function routingInputForContext(
+  context: RouteBoundCompanionContext,
+): E150RoleRoutingInput {
+  switch (context.kind) {
+    case "factcheck":
+      return {
+        journeyHint: "sealed_factcheck",
+        sealedFactcheck: true,
+        pipeline: "factcheck",
+        routePath: context.routePath ?? "/api/factcheck/enqueue",
+      };
+    case "guided_workspace":
+      return {
+        analysisMode: "guided",
+        routePath: context.routePath ?? "/api/contributions/analyze",
+      };
+    case "journalist_companion":
+      return {
+        analysisMode: "media",
+        routePath: context.routePath ?? "/companion",
+      };
+    case "dossier":
+    default:
+      return {
+        analysisMode: context.analysisMode ?? "media",
+        routePath: context.routePath ?? "/dossier",
+      };
+  }
+}
+
+export function resolveRouteBoundCompanionContext(
+  context: RouteBoundCompanionContext,
+): RouteBoundCompanionResolved {
+  const journeyProfile = resolveJourneyProfile(routingInputForContext(context));
+  const defaults = journeyProfile.verificationDefaults;
+  const parent = context.parentStatus ?? null;
+
+  const normalizedVerificationMode: VerificationMode =
+    journeyProfile.lane === "standard"
+      ? parent?.verificationMode === "precheck" || parent?.verificationMode === "none"
+        ? parent.verificationMode
+        : defaults.verificationMode === "precheck"
+          ? "precheck"
+          : "none"
+      : parent?.verificationMode ?? defaults.verificationMode;
+  const normalizedResearchUsed: ResearchUsed =
+    journeyProfile.lane === "standard"
+      ? "none"
+      : parent?.researchUsed ?? defaults.researchUsed;
+  const normalizedSealEligible =
+    journeyProfile.lane === "standard"
+      ? false
+      : parent?.sealEligible ?? defaults.sealEligible;
+  const normalizedSealGranted =
+    journeyProfile.lane === "standard"
+      ? false
+      : parent?.sealGranted ?? defaults.sealGranted;
+
+  const presentation = resolveVerificationPresentationView({
+    lane: journeyProfile.lane,
+    status: parent?.status ?? null,
+    verificationMode: normalizedVerificationMode,
+    researchUsed: normalizedResearchUsed,
+    sealEligible: normalizedSealEligible,
+    sealGranted: normalizedSealGranted,
+  });
+
+  return {
+    contextKind: context.kind,
+    journeyProfile: journeyProfile.journey,
+    lane: presentation.lane,
+    verificationMode: presentation.verificationMode,
+    researchUsed: presentation.researchUsed,
+    sealEligible: presentation.sealEligible,
+    sealGranted: presentation.sealGranted,
+    verificationLabel: presentation.verificationLabel,
+    verificationHint: presentation.verificationHint,
+    workflowLabel: presentation.workflowLabel,
+    parentStatus: {
+      lane: presentation.lane,
+      verificationMode: presentation.verificationMode,
+      researchUsed: presentation.researchUsed,
+      sealEligible: presentation.sealEligible,
+      sealGranted: presentation.sealGranted,
+      verificationLabel: presentation.verificationLabel,
+      verificationHint: presentation.verificationHint,
+      workflowLabel: presentation.workflowLabel,
+    },
+  };
+}
+
+function followUpsForContext(
+  kind: RouteBoundCompanionContextKind,
+  verificationLabel: UserFacingVerificationLabel,
+): string[] {
+  if (kind === "factcheck") {
+    return verificationLabel === "verifiziert"
+      ? [
+          "Welche Aussage soll als Nächstes vertieft dokumentiert werden?",
+          "Sollen Gegenquellen und Einwände separat zusammengefasst werden?",
+        ]
+      : [
+          "Welche konkrete Aussage soll zuerst geprüft werden?",
+          "Welche Quelle fehlt noch für einen belastbaren Abschluss?",
+        ];
+  }
+  if (kind === "guided_workspace") {
+    return [
+      "Welcher nächste administrative Schritt ist jetzt entscheidungsreif?",
+      "Welche offene Frage blockiert die Umsetzung am stärksten?",
+    ];
+  }
+  if (kind === "journalist_companion") {
+    return [
+      "Welche Gegenposition sollte im nächsten Entwurf stärker sichtbar sein?",
+      "Welche Quelle ist für die Einordnung noch unklar?",
+    ];
+  }
+  return [
+    "Welche Konfliktlinie soll im Dossier als Nächstes geschärft werden?",
+    "Welche offene Frage braucht zuerst belastbare Quellen?",
+  ];
+}
+
+export function buildRouteBoundCompanionAnswer(params: {
+  context: RouteBoundCompanionContext;
+  userMessage: string;
+  resolved: RouteBoundCompanionResolved;
+}): RouteBoundCompanionAnswer {
+  const { context, resolved } = params;
+  const message = compactMessage(params.userMessage);
+  const title = context.title ? trimToSingleLine(context.title) : null;
+  const lead =
+    context.kind === "factcheck"
+      ? "Factcheck-Companion"
+      : context.kind === "guided_workspace"
+        ? "Guided-Workspace-Companion"
+        : context.kind === "journalist_companion"
+          ? "Journalistischer Companion"
+          : "Dossier-Companion";
+
+  const statusLine = resolved.workflowLabel
+    ? `Status: ${resolved.workflowLabel} · ${resolved.verificationLabel}.`
+    : `Status: ${resolved.verificationLabel}.`;
+  const researchLine =
+    resolved.lane === "sealed_factcheck"
+      ? `Recherchemodus: ${resolved.researchUsed}.`
+      : "Recherchemodus: none (Standard-Lane, keine stille Recherche).";
+  const titleLine = title ? `Kontext: ${title}.` : "";
+
+  const text = [
+    `${lead}: ${statusLine}`,
+    titleLine,
+    `Ihre Nachfrage: ${message}`,
+    researchLine,
+    "Hinweis: Diese Antwort ist ein Kontextdialog und kein Wahrheits- oder Siegelsystem.",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return {
+    text,
+    followUps: followUpsForContext(context.kind, resolved.verificationLabel),
+    disclaimers: [
+      "Kein impliziter Faktencheck.",
+      "Kein Siegel außerhalb sealed_factcheck.",
+      "Keine stille Recherche in Standard-Lanes.",
+    ],
+  };
+}
+
+function applyPresentationToneToCompanionAnswer(
+  answer: RouteBoundCompanionAnswer,
+): { payload: RouteBoundCompanionAnswer; changed: boolean; changedFields: string[] } {
+  let changed = false;
+  const changedFields: string[] = [];
+
+  const text = normalizePresentationText(answer.text);
+  if (text !== answer.text) {
+    changed = true;
+    changedFields.push("text");
+  }
+
+  const followUps = normalizePresentationTextList(answer.followUps);
+  if (JSON.stringify(followUps) !== JSON.stringify(answer.followUps)) {
+    changed = true;
+    changedFields.push("followUps");
+  }
+
+  const disclaimers = normalizePresentationTextList(answer.disclaimers);
+  if (JSON.stringify(disclaimers) !== JSON.stringify(answer.disclaimers)) {
+    changed = true;
+    changedFields.push("disclaimers");
+  }
+
+  return {
+    payload: {
+      text,
+      followUps,
+      disclaimers,
+    },
+    changed,
+    changedFields,
+  };
+}
+
+export function runRouteBoundCompanionPresentationPass(params: {
+  resolved: RouteBoundCompanionResolved;
+  answer: RouteBoundCompanionAnswer;
+  enabled?: boolean;
+}): {
+  answer: RouteBoundCompanionAnswer;
+  meta: PresentationPassExecutionMeta;
+} {
+  const result = runNonMutativePresentationPass({
+    provider: "openai",
+    enabled: params.enabled,
+    payload: params.answer,
+    snapshot: () => ({
+      claims: null,
+      evidence: null,
+      trust: null,
+      verificationMode: params.resolved.verificationMode,
+      researchUsed: params.resolved.researchUsed,
+      sealEligible: params.resolved.sealEligible,
+      sealGranted: params.resolved.sealGranted,
+      laneMeta: {
+        lane: params.resolved.lane,
+        journeyProfile: params.resolved.journeyProfile,
+        verificationLabel: params.resolved.verificationLabel,
+      },
+      providerMeta: {
+        provider: "openai",
+        role: "presentation_pass",
+      },
+    }),
+    apply: applyPresentationToneToCompanionAnswer,
+  });
+
+  return {
+    answer: result.payload,
+    meta: result.meta,
+  };
+}

--- a/features/analyze/analyzeContribution.ts
+++ b/features/analyze/analyzeContribution.ts
@@ -13,7 +13,15 @@ import {
   OrchestratorAllFailedError,
 } from "@features/ai/orchestratorE150";
 import { resolveJourneyProfile } from "@features/ai/e150/roleRouting";
+import { resolveAiRouteClassification } from "@features/ai/e150/routeClassification";
 import { deriveVerificationLabel } from "@features/ai/e150/verificationContract";
+import {
+  normalizePresentationText,
+  normalizePresentationTextList,
+  runNonMutativePresentationPass,
+  type PresentationPassApplyResult,
+  type PresentationPassProtectedSnapshot,
+} from "@features/ai/e150/presentationPass";
 import type { AiPipelineName } from "@core/telemetry/aiUsageTypes";
 import { EDITORIAL_DOMAIN_GUIDE } from "./domainLabels";
 export type { AnalyzeResult } from "./schemas";
@@ -33,6 +41,7 @@ export type AnalyzeInput = {
   domains?: string[];
   contextPackIds?: string[];
   contextPacks?: string[];
+  presentationPassEnabled?: boolean;
 };
 
 // Reduzierte Default-Anzahl, um JSON-Truncation zu vermeiden
@@ -658,14 +667,61 @@ export type AnalyzeResultWithMeta = AnalyzeResult & {
     fallbackUsed?: boolean;
     disagreement?: {
       present: boolean;
+      specialistAgreementScore?: number;
+      specialistAgreement?: "high" | "mixed" | "low";
+      missingSpecialists?: ("openai" | "anthropic" | "mistral" | "gemini" | "ari")[];
       successfulProviders: ("openai" | "anthropic" | "mistral" | "gemini" | "ari")[];
       failedProviders: ("openai" | "anthropic" | "mistral" | "gemini" | "ari")[];
+      fallbackReliance?: "none" | "full";
+      fallbackRelianceScore?: number;
+      coverage?: {
+        requiredPrimary: number;
+        successfulPrimary: number;
+        missingPrimary: number;
+      };
+    };
+    confidence?: {
+      score: number;
+      bucket: "low" | "medium" | "high";
+      reasons: string[];
     };
     verificationMode?: "none" | "precheck" | "sealed";
     researchUsed?: "none" | "lite" | "search" | "deep_search";
     sealEligible?: boolean;
     sealGranted?: boolean;
     verificationLabel?: "analysiert" | "geprueft" | "verifiziert";
+    tonePassUsed?: boolean;
+    presentationPass?: {
+      attempted: boolean;
+      enabled: boolean;
+      applied: boolean;
+      provider: "openai" | null;
+      reason:
+        | "disabled"
+        | "provider_not_allowed"
+        | "failed"
+        | "no_change"
+        | "guard_blocked"
+        | "applied";
+      nonMutativeGuardPassed: boolean;
+      changedFields: string[];
+      failure: string | null;
+      policy?: {
+        provider: "openai";
+        role: "presentation_pass";
+        nonMutative: true;
+        rules: readonly string[];
+      } | null;
+    };
+    routeClassification?: {
+      routePath: string;
+      routeProfile: "e150_canonical" | "sealed_factcheck" | "legacy_exception" | "diagnostic" | "unknown";
+      canonical: boolean;
+      notCanonical: boolean;
+      legacyExceptionPath: boolean;
+      directProviderPath: boolean;
+      note: string;
+    };
     trace?: { providerUsed?: string | null; jsonCoercion?: "none" | "fence" | "braces" | "backticks" | undefined };
   };
 };
@@ -691,6 +747,9 @@ export async function analyzeContribution(
     journeyHint: input.journeyHint ?? null,
     sealedFactcheck: input.sealedFactcheck === true,
   });
+  const routeClassification = resolveAiRouteClassification(
+    input.routePath ?? "/api/contributions/analyze",
+  );
 
   let orchestration;
   try {
@@ -977,7 +1036,7 @@ throw e;
     // ignore
   }
 
-  const meta = {
+  const metaBase = {
     provider: orchestration.best?.provider,
     model: orchestration.best?.modelName,
     durationMs: orchestration.best?.durationMs,
@@ -1000,6 +1059,11 @@ throw e;
       successfulProviders: [],
       failedProviders: [],
     },
+    confidence: orchestration.meta.confidence ?? {
+      score: 0.5,
+      bucket: "medium",
+      reasons: ["fallback_confidence_default"],
+    },
     verificationMode:
       orchestration.meta.verificationMode ?? journeyProfile.verificationDefaults.verificationMode,
     researchUsed:
@@ -1015,6 +1079,7 @@ throw e;
       sealGranted:
         orchestration.meta.sealGranted ?? journeyProfile.verificationDefaults.sealGranted,
     }),
+    routeClassification,
     trace: { providerUsed: orchestration.best?.provider ?? null, jsonCoercion },
   };
 
@@ -1025,14 +1090,50 @@ throw e;
     ...(runReceipt ? { runReceipt } : {}),
   };
 
+  const presentationPassEnabled = resolvePresentationPassEnabled(input);
+  const presentationPassResult = runNonMutativePresentationPass({
+    provider: "openai",
+    enabled: presentationPassEnabled,
+    payload: finalResult,
+    snapshot: (payload) =>
+      buildPresentationProtectedSnapshot({
+        result: payload,
+        verificationMode: metaBase.verificationMode,
+        researchUsed: metaBase.researchUsed,
+        sealEligible: metaBase.sealEligible,
+        sealGranted: metaBase.sealGranted,
+        trust: {
+          confidence: metaBase.confidence,
+          disagreement: metaBase.disagreement,
+        },
+        laneMeta: {
+          lane: metaBase.lane,
+          journeyProfile: metaBase.journeyProfile,
+        },
+        providerMeta: {
+          provider: metaBase.provider,
+          model: metaBase.model,
+          roleProviderMapping: metaBase.roleProviderMapping,
+        },
+      }),
+    apply: (payload) => applyPresentationToneToAnalyzeResult(payload),
+  });
+  const presentedResult = presentationPassResult.payload;
+
+  const meta = {
+    ...metaBase,
+    tonePassUsed: presentationPassResult.meta.applied,
+    presentationPass: presentationPassResult.meta,
+  };
+
   return {
-    ...finalResult,
-    claims: base.claims ?? [],
-    notes: base.notes ?? [],
-    questions: base.questions ?? [],
-    knots: base.knots ?? [],
-    eventualities: base.eventualities ?? [],
-    decisionTrees: base.decisionTrees ?? [],
+    ...presentedResult,
+    claims: presentedResult.claims ?? [],
+    notes: presentedResult.notes ?? [],
+    questions: presentedResult.questions ?? [],
+    knots: presentedResult.knots ?? [],
+    eventualities: presentedResult.eventualities ?? [],
+    decisionTrees: presentedResult.decisionTrees ?? [],
     _meta: meta,
   };
 }
@@ -1065,6 +1166,128 @@ function safeParseJson(payload: string): any {
       throw new Error("invalid-json");
     }
   }
+}
+
+function resolvePresentationPassEnabled(input: AnalyzeInput): boolean {
+  if (typeof input.presentationPassEnabled === "boolean") {
+    return input.presentationPassEnabled;
+  }
+  if (process.env.E150_PRESENTATION_PASS_DEFAULT !== "true") {
+    return false;
+  }
+  return input.analysisMode === "media" || input.analysisMode === "guided";
+}
+
+function buildPresentationProtectedSnapshot(params: {
+  result: AnalyzeResult;
+  verificationMode: "none" | "precheck" | "sealed";
+  researchUsed: "none" | "lite" | "search" | "deep_search";
+  sealEligible: boolean;
+  sealGranted: boolean;
+  trust: unknown;
+  laneMeta?: unknown;
+  providerMeta?: unknown;
+}): PresentationPassProtectedSnapshot {
+  return {
+    claims: params.result.claims ?? [],
+    evidence: {
+      findings: params.result.findings ?? [],
+      editorialAudit: params.result.editorialAudit ?? null,
+      evidenceGraph: params.result.evidenceGraph ?? null,
+      runReceipt: params.result.runReceipt ?? null,
+    },
+    trust: params.trust,
+    verificationMode: params.verificationMode,
+    researchUsed: params.researchUsed,
+    sealEligible: params.sealEligible,
+    sealGranted: params.sealGranted,
+    laneMeta: params.laneMeta ?? null,
+    providerMeta: params.providerMeta ?? null,
+  };
+}
+
+function applyPresentationToneToAnalyzeResult(
+  result: AnalyzeResult,
+): PresentationPassApplyResult<AnalyzeResult> {
+  const changedFields: string[] = [];
+  let changed = false;
+
+  const reportSummary = result.report?.summary;
+  const normalizedSummary =
+    typeof reportSummary === "string" ? normalizePresentationText(reportSummary) : reportSummary;
+  if (typeof reportSummary === "string" && normalizedSummary !== reportSummary) {
+    changed = true;
+    changedFields.push("report.summary");
+  }
+
+  const keyConflictsBefore = Array.isArray(result.report?.keyConflicts)
+    ? result.report.keyConflicts
+    : [];
+  const keyConflictsAfter = normalizePresentationTextList(keyConflictsBefore);
+  if (JSON.stringify(keyConflictsAfter) !== JSON.stringify(keyConflictsBefore)) {
+    changed = true;
+    changedFields.push("report.keyConflicts");
+  }
+
+  const openQuestionsBefore = Array.isArray(result.report?.openQuestions)
+    ? result.report.openQuestions
+    : [];
+  const openQuestionsAfter = normalizePresentationTextList(openQuestionsBefore);
+  if (JSON.stringify(openQuestionsAfter) !== JSON.stringify(openQuestionsBefore)) {
+    changed = true;
+    changedFields.push("report.openQuestions");
+  }
+
+  const takeawaysBefore = Array.isArray(result.report?.takeaways)
+    ? result.report.takeaways
+    : [];
+  const takeawaysAfter = normalizePresentationTextList(takeawaysBefore);
+  if (JSON.stringify(takeawaysAfter) !== JSON.stringify(takeawaysBefore)) {
+    changed = true;
+    changedFields.push("report.takeaways");
+  }
+
+  const notesBefore = Array.isArray(result.notes) ? result.notes : [];
+  const notesAfter = notesBefore.map((note) => {
+    const normalized = normalizePresentationText(note.text);
+    if (normalized !== note.text) {
+      changed = true;
+      if (!changedFields.includes("notes.text")) changedFields.push("notes.text");
+    }
+    return { ...note, text: normalized };
+  });
+
+  const questionsBefore = Array.isArray(result.questions) ? result.questions : [];
+  const questionsAfter = questionsBefore.map((question) => {
+    const normalized = normalizePresentationText(question.text);
+    if (normalized !== question.text) {
+      changed = true;
+      if (!changedFields.includes("questions.text")) changedFields.push("questions.text");
+    }
+    return { ...question, text: normalized };
+  });
+
+  const nextResult: AnalyzeResult = {
+    ...result,
+    notes: notesAfter,
+    questions: questionsAfter,
+    report: {
+      ...result.report,
+      summary: normalizedSummary ?? null,
+      keyConflicts: keyConflictsAfter,
+      openQuestions: openQuestionsAfter,
+      takeaways: takeawaysAfter,
+      facts: {
+        ...result.report.facts,
+      },
+    },
+  };
+
+  return {
+    payload: nextResult,
+    changed,
+    changedFields,
+  };
 }
 
 function sanitizeDecisionTree(tree: any, idx: number): DecisionTreeT | null {


### PR DESCRIPTION
## Ziel
Routegebundener Companion plus strikt non-mutative Presentation Pass:
- `/api/chat` als route-bound companion endpoint
- Journey-/Lane-Respekt aus Parent-Status
- optionaler presentation pass mit Guard (keine Claim/Evidence/Verification-Mutation)

## Scope
- `features/ai/e150/{routeBoundCompanion,presentationPass}.ts`
- `features/analyze/analyzeContribution.ts`
- analyze route/parse (`presentationPass` flag)
- `RouteBoundCompanionPanel` + Surface-Anbindungen (dossier/factcheck/guided/companion)
- passende Companion-/Presentation-Tests

## Abhängigkeit
Base ist der Frontend-Status-PR, damit Status-/Label-Panels wiederverwendet werden.

## Validierung
- `pnpm -C apps/web exec vitest run tests/e150-presentation-pass.guard.contract.test.ts tests/route-bound-companion.contract.test.ts tests/chat-route.contract.test.ts tests/create-mode.analyze-parse.test.ts tests/create-analyze.route.test.ts tests/analyze-contribution.null-hardening.test.ts` ✅