### PR TITLE
GOV-AI-ORCH-05 split: AI usage operational insights and admin controls

### DIFF
--- a/apps/web/src/app/admin/telemetry/ai/page.tsx
+++ b/apps/web/src/app/admin/telemetry/ai/page.tsx
@@ -197,6 +197,38 @@ export default function AdminAiHubPage() {
         />
       </section>
 
+      {!loading && usage && (usage.attentionFlags?.length ?? 0) > 0 && (
+        <section className="rounded-3xl bg-[rgb(var(--card))] p-4 shadow ring-1 ring-[rgb(var(--border))]">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-[rgb(var(--fg))]">Attention Needed</h2>
+            <Link
+              href="/admin/telemetry/ai/usage"
+              className="text-sm font-semibold text-sky-700 underline-offset-2 hover:underline"
+            >
+              Details öffnen
+            </Link>
+          </div>
+          <div className="mt-3 grid gap-2 md:grid-cols-2">
+            {usage.attentionFlags.slice(0, 4).map((flag) => (
+              <div
+                key={flag.id}
+                className={`rounded-2xl px-3 py-2 text-sm ${
+                  flag.severity === "critical"
+                    ? "border border-rose-300 bg-rose-50 text-rose-800"
+                    : flag.severity === "warning"
+                      ? "border border-amber-300 bg-amber-50 text-amber-800"
+                      : "border border-[rgb(var(--border))] bg-[rgb(var(--bg))] text-[rgb(var(--fg))]"
+                }`}
+              >
+                <p className="text-xs font-semibold uppercase tracking-wide">{flag.title}</p>
+                <p className="mt-1 font-semibold">{flag.value}</p>
+                <p className="mt-1 text-xs opacity-90">{flag.hint}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
       <section className="grid gap-4 lg:grid-cols-3">
         <div className="lg:col-span-2 space-y-3 rounded-3xl bg-[rgb(var(--card))] p-4 shadow ring-1 ring-[rgb(var(--border))]">
           <div className="flex items-center justify-between">

--- a/apps/web/src/app/admin/telemetry/ai/usage/page.tsx
+++ b/apps/web/src/app/admin/telemetry/ai/usage/page.tsx
@@ -1,10 +1,131 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import type { AiUsageBreakdownSnapshot } from "@core/telemetry/aiUsageSnapshot";
+import { useEffect, useMemo, useState } from "react";
+import {
+  buildAiUsageQueryParams,
+  hasMeaningfulUsageData,
+  rowErrorRate,
+  toPositiveNumberInput,
+  type AiUsageThresholdInputMap,
+} from "@/features/admin/aiUsageView";
+
+type AiUsageProviderName = "openai" | "anthropic" | "mistral" | "gemini" | "ari" | "youcom";
+type AiUsagePipelineName =
+  | "contribution_analyze"
+  | "feeds_analyze"
+  | "feeds_to_statementCandidate"
+  | "factcheck"
+  | "news_factcheck"
+  | "report_summarize"
+  | "content_translate"
+  | "content_summarize_news"
+  | "admin_orchestrate"
+  | "orchestrator_smoke"
+  | "provider_probe"
+  | "other";
+
+type AiUsageBreakdownRow = {
+  key: string;
+  label: string;
+  tokens: number;
+  costEur: number;
+  calls: number;
+  errors: number;
+  errorRatePct?: number;
+  successRatePct?: number;
+  avgDurationMs?: number;
+  costPerCallEur?: number;
+};
+
+type AiUsageErrorKindRow = {
+  key: string;
+  label: string;
+  calls: number;
+  ratePct: number;
+};
+
+type AiUsageInsight = {
+  id: string;
+  title: string;
+  value: string;
+  hint: string;
+};
+
+type AiUsageThresholds = {
+  budgetMonthlyEur: number;
+  projectedBudgetWarnPct: number;
+  errorRateWarnPct: number;
+  avgDurationWarnMs: number;
+  costPerCallWarnEur: number;
+  fallbackRelianceWarnSharePct: number;
+  researchHeavyWarnSharePct: number;
+  sealedCostFootprintWarnSharePct: number;
+  timeoutWarnSharePct: number;
+  badJsonWarnSharePct: number;
+};
+
+type AiUsageDerivedMetrics = {
+  costPerCallEur: number;
+  avgDurationMs: number;
+  errorRatePct: number;
+  timeoutSharePct: number;
+  badJsonSharePct: number;
+  researchHeavyWorkloadSharePct: number;
+  fallbackRelianceSharePct: number;
+  sealedFactcheckCostFootprintPct: number;
+  projectedMonthlyCostEur: number;
+  projectedBudgetUtilizationPct: number;
+};
+
+type AiUsageAttentionFlag = {
+  id: string;
+  title: string;
+  severity: "info" | "warning" | "critical";
+  value: string;
+  threshold: string;
+  hint: string;
+};
+
+type AiUsageBreakdownSnapshot = {
+  totals: {
+    tokens: number;
+    costEur: number;
+    calls: number;
+    errors: number;
+  };
+  performance: {
+    avgDurationMs: number;
+    successRatePct: number;
+    errorRatePct: number;
+    costPerCallEur: number;
+  };
+  byProvider: AiUsageBreakdownRow[];
+  byPipeline: AiUsageBreakdownRow[];
+  byLane: AiUsageBreakdownRow[];
+  byJourney: AiUsageBreakdownRow[];
+  byErrorKind: AiUsageErrorKindRow[];
+  recent: Array<{
+    timestamp: string;
+    provider: string;
+    pipeline: string;
+    tokens: number;
+    costEur: number;
+    durationMs: number;
+    success: boolean;
+    errorKind?: string | null;
+  }>;
+  insights: AiUsageInsight[];
+  thresholds: AiUsageThresholds;
+  derivedMetrics: AiUsageDerivedMetrics;
+  attentionFlags: AiUsageAttentionFlag[];
+  optimization: {
+    savingsCandidates: AiUsageInsight[];
+    qualityCandidates: AiUsageInsight[];
+    stabilityCandidates: AiUsageInsight[];
+  };
+};
 
 type ApiResponse = { ok: boolean; snapshot?: AiUsageBreakdownSnapshot; error?: string };
-
 type RangeOption = { value: string; label: string };
 
 const RANGE_OPTIONS: RangeOption[] = [
@@ -12,6 +133,64 @@ const RANGE_OPTIONS: RangeOption[] = [
   { value: "30", label: "Letzte 30 Tage" },
   { value: "90", label: "Letzte 90 Tage" },
 ];
+
+const PROVIDERS: AiUsageProviderName[] = [
+  "openai",
+  "anthropic",
+  "mistral",
+  "gemini",
+  "ari",
+  "youcom",
+];
+
+const PROVIDER_LABELS: Record<AiUsageProviderName, string> = {
+  openai: "GPT-4 / OpenAI",
+  anthropic: "Claude / Anthropic",
+  mistral: "Mistral",
+  gemini: "Gemini",
+  ari: "ARI",
+  youcom: "ARI / You.com",
+};
+
+const PIPELINE_LABELS: Record<AiUsagePipelineName, string> = {
+  contribution_analyze: "Beiträge",
+  feeds_analyze: "Feeds",
+  feeds_to_statementCandidate: "Feeds → Statements",
+  factcheck: "Factcheck",
+  news_factcheck: "News Factcheck",
+  report_summarize: "Reports",
+  content_translate: "Übersetzung",
+  content_summarize_news: "News-Summary",
+  admin_orchestrate: "Admin Orchestrate",
+  orchestrator_smoke: "Orchestrator Smoke",
+  provider_probe: "Provider Probe",
+  other: "Andere",
+};
+
+const PIPELINES = Object.keys(PIPELINE_LABELS) as AiUsagePipelineName[];
+
+const PROVIDER_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "all", label: "Alle Provider" },
+  ...PROVIDERS.map((provider) => ({ value: provider, label: PROVIDER_LABELS[provider] })),
+];
+
+const PIPELINE_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "all", label: "Alle Pipelines" },
+  ...PIPELINES.map((pipeline) => ({ value: pipeline, label: PIPELINE_LABELS[pipeline] })),
+];
+
+const DEFAULT_THRESHOLD_INPUTS = {
+  budgetMonthlyEur: "150",
+  projectedBudgetWarnPct: "85",
+  errorRateWarnPct: "8",
+  avgDurationWarnMs: "12000",
+  costPerCallWarnEur: "0.05",
+  fallbackRelianceWarnSharePct: "40",
+  researchHeavyWarnSharePct: "35",
+  sealedCostFootprintWarnSharePct: "45",
+  timeoutWarnSharePct: "5",
+  badJsonWarnSharePct: "3",
+};
 
 function formatNumber(value: number) {
   return value.toLocaleString("de-DE");
@@ -21,27 +200,47 @@ function formatCurrency(value: number) {
   return value.toLocaleString("de-DE", { style: "currency", currency: "EUR" });
 }
 
+function formatPercent(value: number) {
+  return `${value.toFixed(1)}%`;
+}
+
 export default function AiUsageTelemetryPage() {
-  const [range, setRange] = useState<RangeOption>(RANGE_OPTIONS[1]);
+  const [range, setRange] = useState<string>("30");
+  const [provider, setProvider] = useState<string>("all");
+  const [pipeline, setPipeline] = useState<string>("all");
+  const [region, setRegion] = useState<string>("");
+  const [thresholdInputs, setThresholdInputs] = useState<AiUsageThresholdInputMap>({
+    ...DEFAULT_THRESHOLD_INPUTS,
+  });
   const [snapshot, setSnapshot] = useState<AiUsageBreakdownSnapshot | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const hasData = snapshot !== null && (snapshot.totals.calls > 0 || snapshot.totals.tokens > 0);
+  const hasData = hasMeaningfulUsageData(snapshot);
 
   useEffect(() => {
     async function fetchData() {
       setLoading(true);
       setError(null);
       try {
-        const res = await fetch(`/api/admin/telemetry/ai/usage?range=${range.value}`);
+        const query = buildAiUsageQueryParams({
+          range,
+          provider,
+          pipeline,
+          region,
+          thresholdInputs,
+        });
+
+        const res = await fetch(`/api/admin/telemetry/ai/usage?${query.toString()}`, {
+          cache: "no-store",
+        });
         const body = (await res.json().catch(() => null)) as ApiResponse | null;
         if (!res.ok || !body?.ok || !body.snapshot) {
           throw new Error(body?.error || res.statusText);
         }
         setSnapshot(body.snapshot);
       } catch (err: any) {
-        setError(err?.message ?? "Usage-Daten konnten nicht geladen werden");
+        setError(err?.message ?? "Usage-Daten konnten nicht geladen werden.");
         setSnapshot(null);
       } finally {
         setLoading(false);
@@ -49,80 +248,376 @@ export default function AiUsageTelemetryPage() {
     }
 
     fetchData();
-  }, [range]);
+  }, [range, provider, pipeline, region, thresholdInputs]);
+
+  const effectiveInsights = useMemo<AiUsageInsight[]>(() => {
+    if (!snapshot) return [];
+    return snapshot.insights ?? [];
+  }, [snapshot]);
+  const effectiveAttentionFlags = useMemo<AiUsageAttentionFlag[]>(() => {
+    if (!snapshot) return [];
+    return snapshot.attentionFlags ?? [];
+  }, [snapshot]);
+  const optimization = snapshot?.optimization ?? {
+    savingsCandidates: [],
+    qualityCandidates: [],
+    stabilityCandidates: [],
+  };
 
   return (
-    <main className="mx-auto flex max-w-5xl flex-col gap-6 px-4 py-8">
+    <main className="mx-auto flex max-w-7xl flex-col gap-6 px-4 py-8">
       <header className="space-y-1">
-        <p className="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">Admin · Telemetry · AI</p>
-        <h1 className="text-2xl font-bold text-[rgb(var(--fg))]">AI Usage</h1>
+        <p className="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">
+          Admin · Telemetry · AI
+        </p>
+        <h1 className="text-2xl font-bold text-[rgb(var(--fg))]">AI Usage & Operations</h1>
         <p className="text-sm text-[rgb(var(--muted))]">
-          Kosten-, Token- und Call-Übersicht pro Provider und Pipeline. Daten basieren auf den täglichen Aggregaten im Core.
+          Verbrauch, Kosten, Performance und Fehlerbilder pro Provider, Pipeline, Lane und Journey.
         </p>
       </header>
 
-      <section className="flex flex-wrap items-center gap-3">
-        <label className="text-sm font-medium text-[rgb(var(--fg))]" htmlFor="range">
-          Zeitraum
-        </label>
-        <select
-          id="range"
-          value={range.value}
-          onChange={(event) => {
-            const next = RANGE_OPTIONS.find((opt) => opt.value === event.target.value) ?? RANGE_OPTIONS[1];
-            setRange(next);
-          }}
-          className="rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] px-3 py-2 text-sm text-[rgb(var(--fg))] shadow-sm focus:border-sky-400 focus:ring-2 focus:ring-sky-100"
-        >
-          {RANGE_OPTIONS.map((option) => (
-            <option key={option.value} value={option.value}>
-              {option.label}
-            </option>
-          ))}
-        </select>
-        {loading && <span className="text-sm text-[rgb(var(--muted))]">Lädt …</span>}
-        {error && <span className="text-sm text-rose-600">{error}</span>}
+      <section className="grid gap-3 rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-4 md:grid-cols-4">
+        <FilterSelect
+          id="usage-range"
+          label="Zeitraum"
+          value={range}
+          onChange={setRange}
+          options={RANGE_OPTIONS}
+        />
+        <FilterSelect
+          id="usage-provider"
+          label="Provider"
+          value={provider}
+          onChange={setProvider}
+          options={PROVIDER_OPTIONS}
+        />
+        <FilterSelect
+          id="usage-pipeline"
+          label="Pipeline"
+          value={pipeline}
+          onChange={setPipeline}
+          options={PIPELINE_OPTIONS}
+        />
+        <FilterInput
+          id="usage-region"
+          label="Region (optional)"
+          value={region}
+          onChange={setRegion}
+          placeholder="z. B. DE-BE"
+        />
       </section>
 
-      {!loading && !error && snapshot === null && (
-        <section className="rounded-2xl border border-dashed border-[rgb(var(--border))] bg-[rgb(var(--bg))] px-4 py-6 text-sm text-[rgb(var(--muted))]">
-          <p className="font-semibold text-[rgb(var(--fg))]">Noch kein Snapshot geladen</p>
-          <p>Wähle einen Zeitraum, um die AI-Nutzungsdaten abzurufen.</p>
-        </section>
-      )}
-
-      {snapshot && hasData && (
-        <section className="grid grid-cols-1 gap-4 md:grid-cols-4">
-          <UsageTile label="Tokens" value={formatNumber(snapshot.totals.tokens)} />
-          <UsageTile label="Kosten" value={formatCurrency(snapshot.totals.costEur)} />
-          <UsageTile label="Calls" value={formatNumber(snapshot.totals.calls)} />
-          <UsageTile label="Fehler" value={formatNumber(snapshot.totals.errors)} />
-        </section>
-      )}
-
-      {snapshot && hasData && (
-        <section className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-          <UsageTable title="Nach Provider" rows={snapshot.byProvider} />
-          <UsageTable title="Nach Pipeline" rows={snapshot.byPipeline} />
-        </section>
-      )}
-
-      {snapshot && !hasData && (
-        <section className="rounded-2xl border border-dashed border-[rgb(var(--border))] bg-[rgb(var(--card))] px-4 py-6 text-sm text-[rgb(var(--muted))]">
-          <p className="font-semibold text-[rgb(var(--fg))]">Keine Events im Zeitraum</p>
-          <p>Es wurden keine AI-Usage-Events für den gewählten Zeitraum gefunden.</p>
-        </section>
-      )}
-
-      <section className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] p-4 text-sm text-[rgb(var(--muted))]">
-        <p className="font-semibold text-[rgb(var(--fg))]">Hinweise</p>
-        <ul className="list-disc space-y-1 pl-5">
-          <li>Basis sind Tages-Aggregate (`ai_usage_daily`). Einzelne Ausreißer in den Raw-Events können daher geglättet sein.</li>
-          <li>Fehler zählen alle Events mit `success = false` im gewählten Zeitraum.</li>
-          <li>Region-Filter kann über den API-Aufruf gesetzt werden (`region` Query-Param), UI folgt später.</li>
-        </ul>
+      <section className="grid gap-3 rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-4 md:grid-cols-2 xl:grid-cols-5">
+        <ThresholdInput
+          id="threshold-budget-monthly"
+          label="Budget (Monat, EUR)"
+          value={thresholdInputs.budgetMonthlyEur}
+          onChange={(value) =>
+            setThresholdInputs((prev) => ({ ...prev, budgetMonthlyEur: value }))
+          }
+        />
+        <ThresholdInput
+          id="threshold-error-rate"
+          label="Warnung Fehlerquote (%)"
+          value={thresholdInputs.errorRateWarnPct}
+          onChange={(value) =>
+            setThresholdInputs((prev) => ({ ...prev, errorRateWarnPct: value }))
+          }
+        />
+        <ThresholdInput
+          id="threshold-latency"
+          label="Warnung Ø Latenz (ms)"
+          value={thresholdInputs.avgDurationWarnMs}
+          onChange={(value) =>
+            setThresholdInputs((prev) => ({ ...prev, avgDurationWarnMs: value }))
+          }
+        />
+        <ThresholdInput
+          id="threshold-cost-per-call"
+          label="Warnung Cost/Call (EUR)"
+          value={thresholdInputs.costPerCallWarnEur}
+          onChange={(value) =>
+            setThresholdInputs((prev) => ({ ...prev, costPerCallWarnEur: value }))
+          }
+        />
+        <ThresholdInput
+          id="threshold-fallback-share"
+          label="Warnung Fallback-Share (%)"
+          value={thresholdInputs.fallbackRelianceWarnSharePct}
+          onChange={(value) =>
+            setThresholdInputs((prev) => ({
+              ...prev,
+              fallbackRelianceWarnSharePct: value,
+            }))
+          }
+        />
+        <ThresholdInput
+          id="threshold-projected-budget"
+          label="Warnung Budget-Projektion (%)"
+          value={thresholdInputs.projectedBudgetWarnPct}
+          onChange={(value) =>
+            setThresholdInputs((prev) => ({ ...prev, projectedBudgetWarnPct: value }))
+          }
+        />
+        <ThresholdInput
+          id="threshold-research-share"
+          label="Warnung Research-Share (%)"
+          value={thresholdInputs.researchHeavyWarnSharePct}
+          onChange={(value) =>
+            setThresholdInputs((prev) => ({ ...prev, researchHeavyWarnSharePct: value }))
+          }
+        />
+        <ThresholdInput
+          id="threshold-sealed-cost"
+          label="Warnung Sealed-Kosten (%)"
+          value={thresholdInputs.sealedCostFootprintWarnSharePct}
+          onChange={(value) =>
+            setThresholdInputs((prev) => ({
+              ...prev,
+              sealedCostFootprintWarnSharePct: value,
+            }))
+          }
+        />
+        <ThresholdInput
+          id="threshold-timeout-share"
+          label="Warnung Timeout-Share (%)"
+          value={thresholdInputs.timeoutWarnSharePct}
+          onChange={(value) =>
+            setThresholdInputs((prev) => ({ ...prev, timeoutWarnSharePct: value }))
+          }
+        />
+        <ThresholdInput
+          id="threshold-bad-json-share"
+          label="Warnung BAD_JSON-Share (%)"
+          value={thresholdInputs.badJsonWarnSharePct}
+          onChange={(value) =>
+            setThresholdInputs((prev) => ({ ...prev, badJsonWarnSharePct: value }))
+          }
+        />
       </section>
+
+      {loading && (
+        <section className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] px-4 py-3 text-sm text-[rgb(var(--muted))]">
+          Lädt AI-Usage-Snapshot …
+        </section>
+      )}
+
+      {error && (
+        <section className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+          {error}
+        </section>
+      )}
+
+      {!loading && !error && snapshot && (
+        <>
+          <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-6">
+            <UsageTile label="Calls" value={formatNumber(snapshot.totals.calls)} />
+            <UsageTile label="Tokens gesamt" value={formatNumber(snapshot.totals.tokens)} />
+            <UsageTile label="Kosten gesamt" value={formatCurrency(snapshot.totals.costEur)} />
+            <UsageTile label="Fehlerquote" value={formatPercent(snapshot.performance.errorRatePct)} />
+            <UsageTile label="Erfolgsquote" value={formatPercent(snapshot.performance.successRatePct)} />
+            <UsageTile label="Ø Latenz" value={`${formatNumber(snapshot.performance.avgDurationMs)} ms`} />
+          </section>
+
+          <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-5">
+            <UsageTile
+              label="Cost / Call"
+              value={`${snapshot.derivedMetrics.costPerCallEur.toFixed(4)} €/Call`}
+            />
+            <UsageTile
+              label="Fallback-Reliance (Proxy)"
+              value={formatPercent(snapshot.derivedMetrics.fallbackRelianceSharePct)}
+            />
+            <UsageTile
+              label="Research-heavy Share"
+              value={formatPercent(snapshot.derivedMetrics.researchHeavyWorkloadSharePct)}
+            />
+            <UsageTile
+              label="Sealed Cost Footprint"
+              value={formatPercent(snapshot.derivedMetrics.sealedFactcheckCostFootprintPct)}
+            />
+            <UsageTile
+              label="Budget-Projektion (Monat)"
+              value={formatCurrency(snapshot.derivedMetrics.projectedMonthlyCostEur)}
+            />
+          </section>
+
+          <section className="grid gap-4 xl:grid-cols-3">
+            <section className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-4 xl:col-span-2">
+              <h2 className="text-sm font-semibold text-[rgb(var(--fg))]">Operative Hinweise</h2>
+              {effectiveInsights.length === 0 ? (
+                <p className="mt-2 text-sm text-[rgb(var(--muted))]">Keine Hinweise verfügbar.</p>
+              ) : (
+                <div className="mt-3 grid gap-3 md:grid-cols-2">
+                  {effectiveInsights.map((insight) => (
+                    <div key={insight.id} className="rounded-xl bg-[rgb(var(--bg))] p-3">
+                      <p className="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">
+                        {insight.title}
+                      </p>
+                      <p className="mt-1 text-sm font-semibold text-[rgb(var(--fg))]">{insight.value}</p>
+                      <p className="mt-1 text-xs text-[rgb(var(--muted))]">{insight.hint}</p>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
+
+            <section className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-4">
+              <h2 className="text-sm font-semibold text-[rgb(var(--fg))]">Error Hotspots</h2>
+              <ErrorKindList rows={snapshot.byErrorKind ?? []} />
+            </section>
+          </section>
+
+          <section className="grid gap-4 xl:grid-cols-3">
+            <SignalList
+              title="Einsparungskandidaten"
+              rows={optimization.savingsCandidates}
+              emptyText="Keine Einsparungskandidaten aus dem aktuellen Filter ableitbar."
+            />
+            <SignalList
+              title="Qualitätskandidaten"
+              rows={optimization.qualityCandidates}
+              emptyText="Keine Qualitätskandidaten aus dem aktuellen Filter ableitbar."
+            />
+            <SignalList
+              title="Stabilitätskandidaten"
+              rows={optimization.stabilityCandidates}
+              emptyText="Keine Stabilitätskandidaten aus dem aktuellen Filter ableitbar."
+            />
+          </section>
+
+          <section className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-4">
+            <h2 className="text-sm font-semibold text-[rgb(var(--fg))]">Attention Needed</h2>
+            {effectiveAttentionFlags.length === 0 ? (
+              <p className="mt-2 text-sm text-[rgb(var(--muted))]">
+                Keine aktiven Warnflags im aktuellen Filter.
+              </p>
+            ) : (
+              <div className="mt-3 grid gap-3 md:grid-cols-2">
+                {effectiveAttentionFlags.map((flag) => (
+                  <div
+                    key={flag.id}
+                    className={`rounded-xl px-3 py-3 ${
+                      flag.severity === "critical"
+                        ? "border border-rose-300 bg-rose-50 text-rose-800"
+                        : flag.severity === "warning"
+                          ? "border border-amber-300 bg-amber-50 text-amber-800"
+                          : "border border-[rgb(var(--border))] bg-[rgb(var(--bg))] text-[rgb(var(--fg))]"
+                    }`}
+                  >
+                    <p className="text-xs font-semibold uppercase tracking-wide">{flag.title}</p>
+                    <p className="mt-1 text-sm font-semibold">{flag.value}</p>
+                    <p className="mt-1 text-xs">Schwelle: {flag.threshold}</p>
+                    <p className="mt-1 text-xs opacity-90">{flag.hint}</p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+
+          {hasData ? (
+            <>
+              <section className="grid gap-4 lg:grid-cols-2">
+                <UsageTable title="Breakdown nach Provider" rows={snapshot.byProvider} />
+                <UsageTable title="Breakdown nach Pipeline" rows={snapshot.byPipeline} />
+              </section>
+
+              <section className="grid gap-4 lg:grid-cols-2">
+                <UsageTable title="Breakdown nach Lane" rows={snapshot.byLane} />
+                <UsageTable title="Breakdown nach Journey" rows={snapshot.byJourney} />
+              </section>
+            </>
+          ) : (
+            <section className="rounded-2xl border border-dashed border-[rgb(var(--border))] bg-[rgb(var(--bg))] px-4 py-6 text-sm text-[rgb(var(--muted))]">
+              <p className="font-semibold text-[rgb(var(--fg))]">Keine AI-Usage im gewählten Filter</p>
+              <p className="mt-1">
+                Der Snapshot enthält aktuell keine Calls/Tokens/Kosten für die gesetzten Filter.
+              </p>
+            </section>
+          )}
+
+          <section className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-4">
+            <h2 className="text-sm font-semibold text-[rgb(var(--fg))]">Recent Events</h2>
+            <RecentEventsTable rows={snapshot.recent ?? []} />
+          </section>
+        </>
+      )}
     </main>
+  );
+}
+
+function FilterSelect(props: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: Array<{ value: string; label: string }>;
+}) {
+  return (
+    <label className="flex flex-col gap-1" htmlFor={props.id}>
+      <span className="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">
+        {props.label}
+      </span>
+      <select
+        id={props.id}
+        value={props.value}
+        onChange={(event) => props.onChange(event.target.value)}
+        className="rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] px-3 py-2 text-sm text-[rgb(var(--fg))]"
+      >
+        {props.options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function FilterInput(props: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <label className="flex flex-col gap-1" htmlFor={props.id}>
+      <span className="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">
+        {props.label}
+      </span>
+      <input
+        id={props.id}
+        value={props.value}
+        onChange={(event) => props.onChange(event.target.value)}
+        placeholder={props.placeholder}
+        className="rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] px-3 py-2 text-sm text-[rgb(var(--fg))]"
+      />
+    </label>
+  );
+}
+
+function ThresholdInput(props: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label className="flex flex-col gap-1" htmlFor={props.id}>
+      <span className="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">
+        {props.label}
+      </span>
+      <input
+        id={props.id}
+        type="number"
+        min={0}
+        step="any"
+        value={props.value}
+        onChange={(event) => props.onChange(event.target.value)}
+        className="rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] px-3 py-2 text-sm text-[rgb(var(--fg))]"
+      />
+    </label>
   );
 }
 
@@ -130,17 +625,12 @@ function UsageTile({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-4 shadow-sm">
       <p className="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">{label}</p>
-      <p className="text-3xl font-bold text-[rgb(var(--fg))]">{value}</p>
+      <p className="mt-1 text-xl font-bold text-[rgb(var(--fg))]">{value}</p>
     </div>
   );
 }
 
-type UsageTableProps = {
-  title: string;
-  rows: AiUsageBreakdownSnapshot["byProvider"];
-};
-
-function UsageTable({ title, rows }: UsageTableProps) {
+function UsageTable({ title, rows }: { title: string; rows: AiUsageBreakdownRow[] }) {
   return (
     <section className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] shadow-sm">
       <div className="border-b border-[rgb(var(--border))] px-4 py-3">
@@ -151,35 +641,139 @@ function UsageTable({ title, rows }: UsageTableProps) {
           <thead className="bg-[rgb(var(--bg))] text-left text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">
             <tr>
               <th className="px-4 py-2">Name</th>
+              <th className="px-4 py-2">Calls</th>
               <th className="px-4 py-2">Tokens</th>
               <th className="px-4 py-2">Kosten</th>
-              <th className="px-4 py-2">Calls</th>
+              <th className="px-4 py-2">Cost/Call</th>
               <th className="px-4 py-2">Fehlerquote</th>
+              <th className="px-4 py-2">Ø Latenz</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-[rgb(var(--border))]">
-            {rows.length === 0 && (
+            {rows.length === 0 ? (
               <tr>
-                <td className="px-4 py-3 text-sm text-[rgb(var(--muted))]" colSpan={5}>
-                  Keine Zeilen für den gewählten Zeitraum.
+                <td className="px-4 py-3 text-sm text-[rgb(var(--muted))]" colSpan={7}>
+                  Keine Zeilen im gewählten Filter.
                 </td>
               </tr>
-            )}
-            {rows.map((row) => {
-              const errorRate = row.calls ? (row.errors / row.calls) * 100 : 0;
-              return (
+            ) : (
+              rows.map((row) => (
                 <tr key={row.key}>
                   <td className="px-4 py-2 font-semibold text-[rgb(var(--fg))]">{row.label}</td>
+                  <td className="px-4 py-2">{formatNumber(row.calls)}</td>
                   <td className="px-4 py-2">{formatNumber(row.tokens)}</td>
                   <td className="px-4 py-2">{formatCurrency(row.costEur)}</td>
-                  <td className="px-4 py-2">{formatNumber(row.calls)}</td>
-                  <td className="px-4 py-2">{errorRate.toFixed(1)}%</td>
+                  <td className="px-4 py-2">
+                    {typeof row.costPerCallEur === "number"
+                      ? `${row.costPerCallEur.toFixed(4)} €/Call`
+                      : "—"}
+                  </td>
+                  <td className="px-4 py-2">{formatPercent(rowErrorRate(row))}</td>
+                  <td className="px-4 py-2">
+                    {typeof row.avgDurationMs === "number"
+                      ? `${formatNumber(row.avgDurationMs)} ms`
+                      : "—"}
+                  </td>
                 </tr>
-              );
-            })}
+              ))
+            )}
           </tbody>
         </table>
       </div>
     </section>
+  );
+}
+
+function ErrorKindList({ rows }: { rows: AiUsageErrorKindRow[] }) {
+  if (rows.length === 0) {
+    return <p className="mt-2 text-sm text-[rgb(var(--muted))]">Keine Error-Kinds im Zeitraum.</p>;
+  }
+  return (
+    <div className="mt-2 space-y-2">
+      {rows.slice(0, 6).map((row) => (
+        <div key={row.key} className="rounded-xl bg-[rgb(var(--bg))] px-3 py-2 text-sm">
+          <p className="font-semibold text-[rgb(var(--fg))]">{row.label}</p>
+          <p className="text-xs text-[rgb(var(--muted))]">
+            {formatNumber(row.calls)} Events · {formatPercent(row.ratePct)}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SignalList(props: {
+  title: string;
+  rows: AiUsageInsight[];
+  emptyText: string;
+}) {
+  return (
+    <section className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-4">
+      <h2 className="text-sm font-semibold text-[rgb(var(--fg))]">{props.title}</h2>
+      {props.rows.length === 0 ? (
+        <p className="mt-2 text-sm text-[rgb(var(--muted))]">{props.emptyText}</p>
+      ) : (
+        <div className="mt-3 space-y-2">
+          {props.rows.map((row) => (
+            <div key={row.id} className="rounded-xl bg-[rgb(var(--bg))] px-3 py-2">
+              <p className="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">
+                {row.title}
+              </p>
+              <p className="mt-1 text-sm font-semibold text-[rgb(var(--fg))]">{row.value}</p>
+              <p className="mt-1 text-xs text-[rgb(var(--muted))]">{row.hint}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function RecentEventsTable({ rows }: { rows: AiUsageBreakdownSnapshot["recent"] }) {
+  return (
+    <div className="mt-3 overflow-x-auto">
+      <table className="min-w-full divide-y divide-[rgb(var(--border))] text-sm">
+        <thead className="bg-[rgb(var(--bg))] text-left text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">
+          <tr>
+            <th className="px-3 py-2">Zeit</th>
+            <th className="px-3 py-2">Provider</th>
+            <th className="px-3 py-2">Pipeline</th>
+            <th className="px-3 py-2">Tokens</th>
+            <th className="px-3 py-2">Kosten</th>
+            <th className="px-3 py-2">Latenz</th>
+            <th className="px-3 py-2">Status</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-[rgb(var(--border))]">
+          {rows.length === 0 ? (
+            <tr>
+              <td className="px-3 py-3 text-sm text-[rgb(var(--muted))]" colSpan={7}>
+                Keine Recent Events im Filter.
+              </td>
+            </tr>
+          ) : (
+            rows.map((row) => (
+              <tr key={`${row.timestamp}-${row.provider}-${row.pipeline}`}>
+                <td className="px-3 py-2 whitespace-nowrap">
+                  {new Date(row.timestamp).toLocaleString("de-DE")}
+                </td>
+                <td className="px-3 py-2">{row.provider}</td>
+                <td className="px-3 py-2">{row.pipeline}</td>
+                <td className="px-3 py-2">{formatNumber(row.tokens)}</td>
+                <td className="px-3 py-2">{formatCurrency(row.costEur)}</td>
+                <td className="px-3 py-2">{formatNumber(row.durationMs)} ms</td>
+                <td className="px-3 py-2">
+                  {row.success ? (
+                    <span className="text-emerald-600">OK</span>
+                  ) : (
+                    <span className="text-rose-600">{row.errorKind ?? "Fehler"}</span>
+                  )}
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/apps/web/src/app/api/admin/telemetry/ai/route.ts
+++ b/apps/web/src/app/api/admin/telemetry/ai/route.ts
@@ -11,14 +11,17 @@ export const dynamic = "force-dynamic";
 
 function parseRange(value: string | null): number {
   switch (value) {
+    case "7":
     case "week":
       return 7;
+    case "30":
     case "month":
       return 30;
+    case "90":
     case "quarter":
       return 90;
     default:
-      return 1;
+      return 30;
   }
 }
 

--- a/apps/web/src/app/api/admin/telemetry/ai/usage/route.ts
+++ b/apps/web/src/app/api/admin/telemetry/ai/usage/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAiUsageSnapshot } from "@core/telemetry/aiUsageSnapshot";
+import type { AiPipelineName, AiProviderName } from "@core/telemetry/aiUsageTypes";
 import { requireAdminOrResponse } from "@/lib/server/auth/admin";
 
 export const runtime = "nodejs";
@@ -20,6 +21,23 @@ function parseRange(value: string | null): number {
   }
 }
 
+function parseProvider(value: string | null): AiProviderName | null {
+  if (!value || value === "all") return null;
+  return value as AiProviderName;
+}
+
+function parsePipeline(value: string | null): AiPipelineName | null {
+  if (!value || value === "all") return null;
+  return value as AiPipelineName;
+}
+
+function parsePositiveNumber(value: string | null): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return undefined;
+  return parsed;
+}
+
 export async function GET(req: NextRequest) {
   const gate = await requireAdminOrResponse(req);
   if (gate instanceof Response) return gate;
@@ -28,7 +46,28 @@ export async function GET(req: NextRequest) {
     const { searchParams } = new URL(req.url);
     const rangeDays = parseRange(searchParams.get("range"));
     const region = searchParams.get("region");
-    const snapshot = await getAiUsageSnapshot(rangeDays, region);
+    const provider = parseProvider(searchParams.get("provider"));
+    const pipeline = parsePipeline(searchParams.get("pipeline"));
+    const snapshot = await getAiUsageSnapshot(rangeDays, region, provider, pipeline, {
+      budgetMonthlyEur: parsePositiveNumber(searchParams.get("budgetMonthlyEur")),
+      projectedBudgetWarnPct: parsePositiveNumber(
+        searchParams.get("projectedBudgetWarnPct"),
+      ),
+      errorRateWarnPct: parsePositiveNumber(searchParams.get("errorRateWarnPct")),
+      avgDurationWarnMs: parsePositiveNumber(searchParams.get("avgDurationWarnMs")),
+      costPerCallWarnEur: parsePositiveNumber(searchParams.get("costPerCallWarnEur")),
+      fallbackRelianceWarnSharePct: parsePositiveNumber(
+        searchParams.get("fallbackRelianceWarnSharePct"),
+      ),
+      researchHeavyWarnSharePct: parsePositiveNumber(
+        searchParams.get("researchHeavyWarnSharePct"),
+      ),
+      sealedCostFootprintWarnSharePct: parsePositiveNumber(
+        searchParams.get("sealedCostFootprintWarnSharePct"),
+      ),
+      timeoutWarnSharePct: parsePositiveNumber(searchParams.get("timeoutWarnSharePct")),
+      badJsonWarnSharePct: parsePositiveNumber(searchParams.get("badJsonWarnSharePct")),
+    });
 
     return NextResponse.json({ ok: true, snapshot });
   } catch (error) {

--- a/apps/web/src/features/admin/aiUsageView.ts
+++ b/apps/web/src/features/admin/aiUsageView.ts
@@ -1,0 +1,54 @@
+export type AiUsageThresholdInputKey =
+  | "budgetMonthlyEur"
+  | "projectedBudgetWarnPct"
+  | "errorRateWarnPct"
+  | "avgDurationWarnMs"
+  | "costPerCallWarnEur"
+  | "fallbackRelianceWarnSharePct"
+  | "researchHeavyWarnSharePct"
+  | "sealedCostFootprintWarnSharePct"
+  | "timeoutWarnSharePct"
+  | "badJsonWarnSharePct";
+
+export type AiUsageThresholdInputMap = Record<AiUsageThresholdInputKey, string>;
+
+export function toPositiveNumberInput(value: string): number | null {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return parsed;
+}
+
+export function rowErrorRate(row: { calls: number; errors: number }): number {
+  if (!row.calls) return 0;
+  return (row.errors / row.calls) * 100;
+}
+
+export function hasMeaningfulUsageData(snapshot: {
+  totals: { calls: number; tokens: number; costEur: number };
+} | null): boolean {
+  if (!snapshot) return false;
+  return snapshot.totals.calls > 0 || snapshot.totals.tokens > 0 || snapshot.totals.costEur > 0;
+}
+
+export function buildAiUsageQueryParams(args: {
+  range: string;
+  provider: string;
+  pipeline: string;
+  region: string;
+  thresholdInputs: AiUsageThresholdInputMap;
+}): URLSearchParams {
+  const query = new URLSearchParams({ range: args.range });
+  if (args.provider !== "all") query.set("provider", args.provider);
+  if (args.pipeline !== "all") query.set("pipeline", args.pipeline);
+  const region = args.region.trim();
+  if (region) query.set("region", region);
+
+  (Object.entries(args.thresholdInputs) as Array<[AiUsageThresholdInputKey, string]>).forEach(
+    ([key, rawValue]) => {
+      const parsed = toPositiveNumberInput(rawValue);
+      if (parsed !== null) query.set(key, String(parsed));
+    },
+  );
+
+  return query;
+}

--- a/apps/web/tests/admin-ai-usage.route.test.ts
+++ b/apps/web/tests/admin-ai-usage.route.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  requireAdminOrResponse: vi.fn(),
+  getAiUsageSnapshot: vi.fn(),
+}));
+
+vi.mock("@/lib/server/auth/admin", () => ({
+  requireAdminOrResponse: (...args: unknown[]) => mocks.requireAdminOrResponse(...args),
+}));
+
+vi.mock("@core/telemetry/aiUsageSnapshot", () => ({
+  getAiUsageSnapshot: (...args: unknown[]) => mocks.getAiUsageSnapshot(...args),
+}));
+
+import { GET as USAGE_GET } from "@/app/api/admin/telemetry/ai/usage/route";
+
+describe("/api/admin/telemetry/ai/usage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireAdminOrResponse.mockResolvedValue({ userId: "admin-1" });
+    mocks.getAiUsageSnapshot.mockResolvedValue({
+      totals: { calls: 0, tokens: 0, costEur: 0, errors: 0 },
+      byProvider: [],
+      byPipeline: [],
+      byLane: [],
+      byJourney: [],
+      byErrorKind: [],
+      recent: [],
+      insights: [],
+      attentionFlags: [],
+      optimization: {
+        savingsCandidates: [],
+        qualityCandidates: [],
+        stabilityCandidates: [],
+      },
+      thresholds: {
+        budgetMonthlyEur: 150,
+        projectedBudgetWarnPct: 85,
+        errorRateWarnPct: 8,
+        avgDurationWarnMs: 12_000,
+        costPerCallWarnEur: 0.05,
+        fallbackRelianceWarnSharePct: 40,
+        researchHeavyWarnSharePct: 35,
+        sealedCostFootprintWarnSharePct: 45,
+        timeoutWarnSharePct: 5,
+        badJsonWarnSharePct: 3,
+      },
+      derivedMetrics: {
+        costPerCallEur: 0,
+        avgDurationMs: 0,
+        errorRatePct: 0,
+        timeoutSharePct: 0,
+        badJsonSharePct: 0,
+        researchHeavyWorkloadSharePct: 0,
+        fallbackRelianceSharePct: 0,
+        sealedFactcheckCostFootprintPct: 0,
+        projectedMonthlyCostEur: 0,
+        projectedBudgetUtilizationPct: 0,
+      },
+    });
+  });
+
+  it("passes parsed filters and threshold overrides to snapshot", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/admin/telemetry/ai/usage?range=week&provider=openai&pipeline=factcheck&region=DE-BE&budgetMonthlyEur=300&errorRateWarnPct=9&costPerCallWarnEur=0.2&timeoutWarnSharePct=6&badJsonWarnSharePct=2",
+    );
+
+    const res = await USAGE_GET(req);
+    expect(res.status).toBe(200);
+    expect(mocks.getAiUsageSnapshot).toHaveBeenCalledWith(
+      7,
+      "DE-BE",
+      "openai",
+      "factcheck",
+      expect.objectContaining({
+        budgetMonthlyEur: 300,
+        errorRateWarnPct: 9,
+        costPerCallWarnEur: 0.2,
+        timeoutWarnSharePct: 6,
+        badJsonWarnSharePct: 2,
+      }),
+    );
+  });
+
+  it("falls back to defaults and strips invalid threshold values", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/admin/telemetry/ai/usage?range=unknown&provider=all&pipeline=all&budgetMonthlyEur=-10&errorRateWarnPct=abc",
+    );
+
+    const res = await USAGE_GET(req);
+    expect(res.status).toBe(200);
+    expect(mocks.getAiUsageSnapshot).toHaveBeenCalledWith(
+      30,
+      null,
+      null,
+      null,
+      expect.objectContaining({
+        budgetMonthlyEur: undefined,
+        errorRateWarnPct: undefined,
+      }),
+    );
+  });
+
+  it("passes through auth gate failures", async () => {
+    mocks.requireAdminOrResponse.mockResolvedValue(new Response("forbidden", { status: 403 }));
+    const req = new NextRequest("http://localhost/api/admin/telemetry/ai/usage");
+
+    const res = await USAGE_GET(req);
+    expect(res.status).toBe(403);
+    expect(mocks.getAiUsageSnapshot).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/ai-usage-operational-signals.contract.test.ts
+++ b/apps/web/tests/ai-usage-operational-signals.contract.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  deriveAiUsageOperationalSignals,
+  type AiUsageBreakdownRow,
+  type AiUsageErrorKindRow,
+} from "@core/telemetry/aiUsageSnapshot";
+import type { AiUsageDailyRow } from "@core/telemetry/aiUsageTypes";
+
+function makeRow(overrides: Partial<AiUsageBreakdownRow>): AiUsageBreakdownRow {
+  return {
+    key: "row",
+    label: "Row",
+    tokens: 0,
+    costEur: 0,
+    calls: 0,
+    errors: 0,
+    errorRatePct: 0,
+    successRatePct: 100,
+    avgDurationMs: 0,
+    costPerCallEur: 0,
+    ...overrides,
+  };
+}
+
+function makeErrorRow(overrides: Partial<AiUsageErrorKindRow>): AiUsageErrorKindRow {
+  return {
+    key: "none",
+    label: "Ohne Fehler",
+    calls: 0,
+    ratePct: 0,
+    ...overrides,
+  } as AiUsageErrorKindRow;
+}
+
+describe("ai usage operational signals", () => {
+  it("derives cost/error/latency/research/fallback metrics with optimization candidates", () => {
+    const rows: AiUsageDailyRow[] = [
+      {
+        date: "2026-04-20",
+        provider: "openai",
+        pipeline: "contribution_analyze",
+        tokensTotal: 1_000,
+        costTotalEur: 20,
+        callsTotal: 40,
+        callsError: 4,
+        region: "DE-BE",
+      },
+      {
+        date: "2026-04-20",
+        provider: "anthropic",
+        pipeline: "contribution_analyze",
+        tokensTotal: 800,
+        costTotalEur: 16,
+        callsTotal: 40,
+        callsError: 2,
+        region: "DE-BE",
+      },
+      {
+        date: "2026-04-20",
+        provider: "ari",
+        pipeline: "factcheck",
+        tokensTotal: 1_200,
+        costTotalEur: 24,
+        callsTotal: 20,
+        callsError: 1,
+        region: "DE-BE",
+      },
+      {
+        date: "2026-04-20",
+        provider: "openai",
+        pipeline: "provider_probe",
+        tokensTotal: 0,
+        costTotalEur: 0,
+        callsTotal: 12,
+        callsError: 0,
+        region: "DE-BE",
+      },
+    ];
+
+    const result = deriveAiUsageOperationalSignals({
+      rangeDays: 30,
+      totals: { tokens: 3_000, costEur: 60, calls: 100, errors: 7 },
+      performance: {
+        avgDurationMs: 14_000,
+        successRatePct: 93,
+        errorRatePct: 7,
+        costPerCallEur: 0.6,
+      },
+      byProvider: [
+        makeRow({
+          key: "openai",
+          label: "OpenAI",
+          calls: 52,
+          errors: 4,
+          costEur: 20,
+          errorRatePct: 7.7,
+          avgDurationMs: 13_500,
+          costPerCallEur: 0.3846,
+        }),
+        makeRow({
+          key: "anthropic",
+          label: "Anthropic",
+          calls: 40,
+          errors: 2,
+          costEur: 16,
+          errorRatePct: 5,
+          avgDurationMs: 8_000,
+          costPerCallEur: 0.4,
+        }),
+        makeRow({
+          key: "ari",
+          label: "ARI",
+          calls: 20,
+          errors: 1,
+          costEur: 24,
+          errorRatePct: 5,
+          avgDurationMs: 15_000,
+          costPerCallEur: 1.2,
+        }),
+      ],
+      byPipeline: [
+        makeRow({
+          key: "contribution_analyze",
+          label: "Beiträge",
+          calls: 80,
+          errors: 6,
+          costEur: 36,
+          avgDurationMs: 9_000,
+          costPerCallEur: 0.45,
+        }),
+        makeRow({
+          key: "factcheck",
+          label: "Factcheck",
+          calls: 20,
+          errors: 1,
+          costEur: 24,
+          avgDurationMs: 18_000,
+          costPerCallEur: 1.2,
+        }),
+      ],
+      byLane: [
+        makeRow({ key: "standard", label: "Standard", calls: 80, costEur: 36 }),
+        makeRow({
+          key: "sealed_factcheck",
+          label: "Sealed",
+          calls: 20,
+          costEur: 24,
+        }),
+      ],
+      byErrorKind: [
+        makeErrorRow({ key: "TIMEOUT", label: "Timeout", calls: 5, ratePct: 8 }),
+        makeErrorRow({ key: "BAD_JSON", label: "Bad JSON", calls: 2, ratePct: 3.5 }),
+      ],
+      rows,
+    });
+
+    expect(result.derivedMetrics.fallbackRelianceSharePct).toBe(40);
+    expect(result.derivedMetrics.researchHeavyWorkloadSharePct).toBe(20);
+    expect(result.derivedMetrics.sealedFactcheckCostFootprintPct).toBe(40);
+    expect(result.derivedMetrics.projectedMonthlyCostEur).toBe(60);
+    expect(result.optimization.savingsCandidates.length).toBeGreaterThan(0);
+    expect(result.optimization.qualityCandidates.length).toBeGreaterThan(0);
+    expect(result.optimization.stabilityCandidates.length).toBeGreaterThan(0);
+    expect(
+      result.attentionFlags.some((flag) => flag.id === "cost_per_call"),
+    ).toBe(true);
+    expect(result.attentionFlags.some((flag) => flag.id === "latency")).toBe(true);
+  });
+
+  it("supports threshold overrides for budget and fallback warnings", () => {
+    const result = deriveAiUsageOperationalSignals({
+      rangeDays: 10,
+      totals: { tokens: 100, costEur: 50, calls: 50, errors: 0 },
+      performance: {
+        avgDurationMs: 500,
+        successRatePct: 100,
+        errorRatePct: 0,
+        costPerCallEur: 1,
+      },
+      byProvider: [makeRow({ key: "openai", label: "OpenAI", calls: 40, costEur: 40 })],
+      byPipeline: [makeRow({ key: "factcheck", label: "Factcheck", calls: 50, costEur: 50 })],
+      byLane: [makeRow({ key: "sealed_factcheck", label: "Sealed", calls: 50, costEur: 50 })],
+      byErrorKind: [],
+      rows: [
+        {
+          date: "2026-04-20",
+          provider: "openai",
+          pipeline: "factcheck",
+          tokensTotal: 100,
+          costTotalEur: 50,
+          callsTotal: 50,
+          callsError: 0,
+          region: "DE-BE",
+        },
+      ],
+      thresholds: {
+        budgetMonthlyEur: 1000,
+        projectedBudgetWarnPct: 200,
+        fallbackRelianceWarnSharePct: 95,
+      },
+    });
+
+    expect(result.thresholds.budgetMonthlyEur).toBe(1000);
+    expect(result.attentionFlags.some((flag) => flag.id === "budget_projection")).toBe(
+      false,
+    );
+    expect(result.attentionFlags.some((flag) => flag.id === "fallback_reliance")).toBe(
+      true,
+    );
+  });
+
+  it("stays defensive with empty inputs", () => {
+    const result = deriveAiUsageOperationalSignals({
+      rangeDays: 30,
+      totals: { tokens: 0, costEur: 0, calls: 0, errors: 0 },
+      performance: {
+        avgDurationMs: 0,
+        successRatePct: 0,
+        errorRatePct: 0,
+        costPerCallEur: 0,
+      },
+      byProvider: [],
+      byPipeline: [],
+      byLane: [],
+      byErrorKind: [],
+      rows: [],
+    });
+
+    expect(result.derivedMetrics.fallbackRelianceSharePct).toBe(0);
+    expect(result.derivedMetrics.researchHeavyWorkloadSharePct).toBe(0);
+    expect(result.derivedMetrics.sealedFactcheckCostFootprintPct).toBe(0);
+    expect(result.attentionFlags.length).toBe(0);
+  });
+});

--- a/apps/web/tests/ai-usage-view.contract.test.ts
+++ b/apps/web/tests/ai-usage-view.contract.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAiUsageQueryParams,
+  hasMeaningfulUsageData,
+  rowErrorRate,
+  toPositiveNumberInput,
+  type AiUsageThresholdInputMap,
+} from "@/features/admin/aiUsageView";
+
+const BASE_THRESHOLDS: AiUsageThresholdInputMap = {
+  budgetMonthlyEur: "150",
+  projectedBudgetWarnPct: "85",
+  errorRateWarnPct: "8",
+  avgDurationWarnMs: "12000",
+  costPerCallWarnEur: "0.05",
+  fallbackRelianceWarnSharePct: "40",
+  researchHeavyWarnSharePct: "35",
+  sealedCostFootprintWarnSharePct: "45",
+  timeoutWarnSharePct: "5",
+  badJsonWarnSharePct: "3",
+};
+
+describe("ai usage view helper contract", () => {
+  it("builds filter query with trimmed region and numeric thresholds", () => {
+    const query = buildAiUsageQueryParams({
+      range: "7",
+      provider: "openai",
+      pipeline: "factcheck",
+      region: "  DE-BE  ",
+      thresholdInputs: {
+        ...BASE_THRESHOLDS,
+        badJsonWarnSharePct: "3.5",
+      },
+    });
+
+    expect(query.get("range")).toBe("7");
+    expect(query.get("provider")).toBe("openai");
+    expect(query.get("pipeline")).toBe("factcheck");
+    expect(query.get("region")).toBe("DE-BE");
+    expect(query.get("badJsonWarnSharePct")).toBe("3.5");
+    expect(query.get("budgetMonthlyEur")).toBe("150");
+  });
+
+  it("omits all-filter and invalid threshold values", () => {
+    const query = buildAiUsageQueryParams({
+      range: "30",
+      provider: "all",
+      pipeline: "all",
+      region: "   ",
+      thresholdInputs: {
+        ...BASE_THRESHOLDS,
+        budgetMonthlyEur: "-1",
+        errorRateWarnPct: "abc",
+      },
+    });
+
+    expect(query.get("provider")).toBeNull();
+    expect(query.get("pipeline")).toBeNull();
+    expect(query.get("region")).toBeNull();
+    expect(query.get("budgetMonthlyEur")).toBeNull();
+    expect(query.get("errorRateWarnPct")).toBeNull();
+    expect(query.get("costPerCallWarnEur")).toBe("0.05");
+  });
+
+  it("computes defensive helper metrics for empty snapshots", () => {
+    expect(hasMeaningfulUsageData(null)).toBe(false);
+    expect(
+      hasMeaningfulUsageData({
+        totals: { calls: 0, tokens: 0, costEur: 0 },
+      }),
+    ).toBe(false);
+    expect(
+      hasMeaningfulUsageData({
+        totals: { calls: 1, tokens: 0, costEur: 0 },
+      }),
+    ).toBe(true);
+    expect(rowErrorRate({ calls: 0, errors: 10 })).toBe(0);
+    expect(rowErrorRate({ calls: 20, errors: 5 })).toBe(25);
+  });
+
+  it("parses positive number inputs only", () => {
+    expect(toPositiveNumberInput("12.5")).toBe(12.5);
+    expect(toPositiveNumberInput("-1")).toBeNull();
+    expect(toPositiveNumberInput("not-a-number")).toBeNull();
+  });
+});

--- a/core/telemetry/aiUsageSnapshot.ts
+++ b/core/telemetry/aiUsageSnapshot.ts
@@ -66,19 +66,99 @@ export interface AiUsageBreakdownRow {
   costEur: number;
   calls: number;
   errors: number;
+  errorRatePct?: number;
+  successRatePct?: number;
+  avgDurationMs?: number;
+  costPerCallEur?: number;
+}
+
+export type AiUsageLane = "standard" | "sealed_factcheck" | "other";
+export type AiUsageJourney = "analyze" | "media" | "guided" | "factcheck" | "other";
+
+export interface AiUsageErrorKindRow {
+  key: AiErrorKind | "none";
+  label: string;
+  calls: number;
+  ratePct: number;
+}
+
+export interface AiUsagePerformanceSummary {
+  avgDurationMs: number;
+  successRatePct: number;
+  errorRatePct: number;
+  costPerCallEur: number;
+}
+
+export interface AiUsageInsight {
+  id: string;
+  title: string;
+  value: string;
+  hint: string;
+}
+
+export interface AiUsageThresholds {
+  budgetMonthlyEur: number;
+  projectedBudgetWarnPct: number;
+  errorRateWarnPct: number;
+  avgDurationWarnMs: number;
+  costPerCallWarnEur: number;
+  fallbackRelianceWarnSharePct: number;
+  researchHeavyWarnSharePct: number;
+  sealedCostFootprintWarnSharePct: number;
+  timeoutWarnSharePct: number;
+  badJsonWarnSharePct: number;
+}
+
+export interface AiUsageDerivedMetrics {
+  costPerCallEur: number;
+  avgDurationMs: number;
+  errorRatePct: number;
+  timeoutSharePct: number;
+  badJsonSharePct: number;
+  researchHeavyWorkloadSharePct: number;
+  fallbackRelianceSharePct: number;
+  sealedFactcheckCostFootprintPct: number;
+  projectedMonthlyCostEur: number;
+  projectedBudgetUtilizationPct: number;
+}
+
+export interface AiUsageAttentionFlag {
+  id: string;
+  title: string;
+  severity: "info" | "warning" | "critical";
+  value: string;
+  threshold: string;
+  hint: string;
+}
+
+export interface AiUsageOptimizationSignals {
+  savingsCandidates: AiUsageInsight[];
+  qualityCandidates: AiUsageInsight[];
+  stabilityCandidates: AiUsageInsight[];
 }
 
 export interface AiUsageBreakdownSnapshot {
   fromDate: string;
   toDate: string;
+  filters: UsageSnapshotFilters;
   totals: {
     tokens: number;
     costEur: number;
     calls: number;
     errors: number;
   };
+  performance: AiUsagePerformanceSummary;
   byProvider: AiUsageBreakdownRow[];
   byPipeline: AiUsageBreakdownRow[];
+  byLane: AiUsageBreakdownRow[];
+  byJourney: AiUsageBreakdownRow[];
+  byErrorKind: AiUsageErrorKindRow[];
+  recent: UsageEventSummary[];
+  insights: AiUsageInsight[];
+  thresholds: AiUsageThresholds;
+  derivedMetrics: AiUsageDerivedMetrics;
+  attentionFlags: AiUsageAttentionFlag[];
+  optimization: AiUsageOptimizationSignals;
 }
 
 const COLLECTION_USAGE = "ai_usage";
@@ -86,7 +166,20 @@ const COLLECTION_DAILY = "ai_usage_daily";
 const MONTHLY_BUDGET_EUR = 150;
 const DAY_MS = 86_400_000;
 
-const PROVIDERS: AiProviderName[] = [
+const DEFAULT_USAGE_THRESHOLDS: AiUsageThresholds = {
+  budgetMonthlyEur: MONTHLY_BUDGET_EUR,
+  projectedBudgetWarnPct: 85,
+  errorRateWarnPct: 8,
+  avgDurationWarnMs: 12_000,
+  costPerCallWarnEur: 0.05,
+  fallbackRelianceWarnSharePct: 40,
+  researchHeavyWarnSharePct: 35,
+  sealedCostFootprintWarnSharePct: 45,
+  timeoutWarnSharePct: 5,
+  badJsonWarnSharePct: 3,
+};
+
+export const PROVIDERS: AiProviderName[] = [
   "openai",
   "anthropic",
   "mistral",
@@ -95,7 +188,7 @@ const PROVIDERS: AiProviderName[] = [
   "youcom",
 ];
 
-const PROVIDER_LABELS: Record<AiProviderName, string> = {
+export const PROVIDER_LABELS: Record<AiProviderName, string> = {
   openai: "GPT‑4 / OpenAI",
   anthropic: "Claude / Anthropic",
   mistral: "Mistral",
@@ -104,7 +197,7 @@ const PROVIDER_LABELS: Record<AiProviderName, string> = {
   youcom: "ARI / You.com",
 };
 
-const PIPELINE_LABELS: Record<AiPipelineName, string> = {
+export const PIPELINE_LABELS: Record<AiPipelineName, string> = {
   contribution_analyze: "Beiträge",
   feeds_analyze: "Feeds",
   feeds_to_statementCandidate: "Feeds → Statements",
@@ -117,6 +210,35 @@ const PIPELINE_LABELS: Record<AiPipelineName, string> = {
   orchestrator_smoke: "Orchestrator Smoke",
   provider_probe: "Provider Probe",
   other: "Andere",
+};
+
+export const PIPELINES = Object.keys(PIPELINE_LABELS) as AiPipelineName[];
+
+export const LANE_LABELS: Record<AiUsageLane, string> = {
+  standard: "Standard-Lane",
+  sealed_factcheck: "Sealed Factcheck-Lane",
+  other: "Weitere Lane",
+};
+
+export const JOURNEY_LABELS: Record<AiUsageJourney, string> = {
+  analyze: "Analyze",
+  media: "Media",
+  guided: "Guided",
+  factcheck: "Factcheck",
+  other: "Weitere Journeys",
+};
+
+const ERROR_KIND_LABELS: Record<AiErrorKind | "none", string> = {
+  MODEL_NOT_FOUND: "Model not found",
+  INVALID_API_KEY: "Invalid API key",
+  UNAUTHORIZED: "Unauthorized",
+  BAD_JSON: "Bad JSON",
+  TIMEOUT: "Timeout",
+  RATE_LIMIT: "Rate limit",
+  INTERNAL: "Internal",
+  CANCELLED: "Cancelled",
+  UNKNOWN: "Unknown",
+  none: "Ohne Fehler",
 };
 
 function formatNumber(value: number): string {
@@ -358,9 +480,567 @@ function startOfDay(date: Date) {
   return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
 }
 
+function toRate(value: number, total: number): number {
+  if (!total) return 0;
+  return Math.round((value / total) * 1000) / 10;
+}
+
+function toUsageEventSummary(event: any): UsageEventSummary {
+  return {
+    timestamp: event.createdAt.toISOString(),
+    provider: event.provider,
+    pipeline: event.pipeline,
+    model: event.model ?? null,
+    region: event.region ?? null,
+    tokens: (event.tokensInput ?? 0) + (event.tokensOutput ?? 0),
+    tokensInput: event.tokensInput ?? 0,
+    tokensOutput: event.tokensOutput ?? 0,
+    costEur: event.costEur ?? 0,
+    durationMs: event.durationMs ?? 0,
+    success: Boolean(event.success),
+    errorKind: event.errorKind ?? null,
+    strictJson: event.strictJson ?? false,
+    promptSnippet: event.promptSnippet,
+    responseSnippet: event.responseSnippet,
+    rawError: event.rawError,
+  };
+}
+
+export function mapPipelineToLane(pipeline: AiPipelineName): AiUsageLane {
+  if (pipeline === "factcheck" || pipeline === "news_factcheck") {
+    return "sealed_factcheck";
+  }
+  if (pipeline === "other") return "other";
+  return "standard";
+}
+
+export function mapPipelineToJourney(pipeline: AiPipelineName): AiUsageJourney {
+  if (pipeline === "factcheck" || pipeline === "news_factcheck") return "factcheck";
+  if (pipeline === "report_summarize") return "media";
+  if (pipeline === "admin_orchestrate") return "guided";
+  if (pipeline === "contribution_analyze") return "analyze";
+  return "other";
+}
+
+function aggregateRows<TKey extends string>(
+  rows: AiUsageDailyRow[],
+  keyResolver: (row: AiUsageDailyRow) => TKey,
+  labelResolver: (key: TKey) => string,
+): AiUsageBreakdownRow[] {
+  const map = new Map<TKey, AiUsageBreakdownRow>();
+  rows.forEach((row) => {
+    const key = keyResolver(row);
+    const previous = map.get(key) ?? {
+      key,
+      label: labelResolver(key),
+      tokens: 0,
+      costEur: 0,
+      calls: 0,
+      errors: 0,
+    };
+    previous.tokens += row.tokensTotal ?? 0;
+    previous.costEur += row.costTotalEur ?? 0;
+    previous.calls += row.callsTotal ?? 0;
+    previous.errors += row.callsError ?? 0;
+    map.set(key, previous);
+  });
+  return [...map.values()].map((row) => ({
+    ...row,
+    errorRatePct: toRate(row.errors, row.calls),
+    successRatePct: toRate(row.calls - row.errors, row.calls),
+    costPerCallEur: row.calls > 0 ? row.costEur / row.calls : 0,
+  }));
+}
+
+function aggregateAverageDuration<TKey extends string>(
+  rows: UsageEventSummary[],
+  keyResolver: (event: UsageEventSummary) => TKey,
+): Map<TKey, number> {
+  const sums = new Map<TKey, { total: number; calls: number }>();
+  rows.forEach((event) => {
+    const key = keyResolver(event);
+    const previous = sums.get(key) ?? { total: 0, calls: 0 };
+    previous.total += event.durationMs ?? 0;
+    previous.calls += 1;
+    sums.set(key, previous);
+  });
+  const out = new Map<TKey, number>();
+  sums.forEach((value, key) => {
+    out.set(key, value.calls > 0 ? Math.round(value.total / value.calls) : 0);
+  });
+  return out;
+}
+
+function aggregateErrorKinds(events: UsageEventSummary[]): AiUsageErrorKindRow[] {
+  const total = events.length;
+  const counters = new Map<AiErrorKind | "none", number>();
+  events.forEach((event) => {
+    const key = event.success ? "none" : event.errorKind ?? "UNKNOWN";
+    counters.set(key, (counters.get(key) ?? 0) + 1);
+  });
+  return [...counters.entries()]
+    .map(([key, calls]) => ({
+      key,
+      label: ERROR_KIND_LABELS[key],
+      calls,
+      ratePct: toRate(calls, total),
+    }))
+    .sort((a, b) => b.calls - a.calls);
+}
+
+function sortBreakdownRows(rows: AiUsageBreakdownRow[]): AiUsageBreakdownRow[] {
+  return [...rows].sort((a, b) => {
+    if (b.costEur !== a.costEur) return b.costEur - a.costEur;
+    if (b.calls !== a.calls) return b.calls - a.calls;
+    return b.tokens - a.tokens;
+  });
+}
+
+type DeriveAiUsageInsightsArgs = {
+  byProvider: AiUsageBreakdownRow[];
+  byPipeline: AiUsageBreakdownRow[];
+  performance: AiUsagePerformanceSummary;
+  byErrorKind: AiUsageErrorKindRow[];
+};
+
+type DeriveAiUsageOperationalSignalsArgs = {
+  rangeDays: number;
+  totals: {
+    tokens: number;
+    costEur: number;
+    calls: number;
+    errors: number;
+  };
+  performance: AiUsagePerformanceSummary;
+  byProvider: AiUsageBreakdownRow[];
+  byPipeline: AiUsageBreakdownRow[];
+  byLane: AiUsageBreakdownRow[];
+  byErrorKind: AiUsageErrorKindRow[];
+  rows: AiUsageDailyRow[];
+  thresholds?: Partial<AiUsageThresholds> | null;
+};
+
+function formatEur(value: number): string {
+  return `${value.toFixed(4)} €/Call`;
+}
+
+function formatPercentValue(value: number): string {
+  return `${value.toFixed(1)}%`;
+}
+
+function thresholdPercent(value: number): string {
+  return `>${value.toFixed(1)}%`;
+}
+
+function thresholdEur(value: number): string {
+  return `>${value.toFixed(4)} €/Call`;
+}
+
+function asFinitePositiveNumber(value: unknown): number | null {
+  if (typeof value !== "number") return null;
+  if (!Number.isFinite(value) || value < 0) return null;
+  return value;
+}
+
+function resolveUsageThresholds(
+  overrides?: Partial<AiUsageThresholds> | null,
+): AiUsageThresholds {
+  const input = overrides ?? {};
+  return {
+    budgetMonthlyEur:
+      asFinitePositiveNumber(input.budgetMonthlyEur) ??
+      DEFAULT_USAGE_THRESHOLDS.budgetMonthlyEur,
+    projectedBudgetWarnPct:
+      asFinitePositiveNumber(input.projectedBudgetWarnPct) ??
+      DEFAULT_USAGE_THRESHOLDS.projectedBudgetWarnPct,
+    errorRateWarnPct:
+      asFinitePositiveNumber(input.errorRateWarnPct) ??
+      DEFAULT_USAGE_THRESHOLDS.errorRateWarnPct,
+    avgDurationWarnMs:
+      asFinitePositiveNumber(input.avgDurationWarnMs) ??
+      DEFAULT_USAGE_THRESHOLDS.avgDurationWarnMs,
+    costPerCallWarnEur:
+      asFinitePositiveNumber(input.costPerCallWarnEur) ??
+      DEFAULT_USAGE_THRESHOLDS.costPerCallWarnEur,
+    fallbackRelianceWarnSharePct:
+      asFinitePositiveNumber(input.fallbackRelianceWarnSharePct) ??
+      DEFAULT_USAGE_THRESHOLDS.fallbackRelianceWarnSharePct,
+    researchHeavyWarnSharePct:
+      asFinitePositiveNumber(input.researchHeavyWarnSharePct) ??
+      DEFAULT_USAGE_THRESHOLDS.researchHeavyWarnSharePct,
+    sealedCostFootprintWarnSharePct:
+      asFinitePositiveNumber(input.sealedCostFootprintWarnSharePct) ??
+      DEFAULT_USAGE_THRESHOLDS.sealedCostFootprintWarnSharePct,
+    timeoutWarnSharePct:
+      asFinitePositiveNumber(input.timeoutWarnSharePct) ??
+      DEFAULT_USAGE_THRESHOLDS.timeoutWarnSharePct,
+    badJsonWarnSharePct:
+      asFinitePositiveNumber(input.badJsonWarnSharePct) ??
+      DEFAULT_USAGE_THRESHOLDS.badJsonWarnSharePct,
+  };
+}
+
+function bestBy<T>(items: T[], scorer: (item: T) => number): T | null {
+  let best: T | null = null;
+  let bestScore = -Infinity;
+  items.forEach((item) => {
+    const score = scorer(item);
+    if (score > bestScore) {
+      best = item;
+      bestScore = score;
+    }
+  });
+  return best;
+}
+
+export function deriveAiUsageInsights(args: DeriveAiUsageInsightsArgs): AiUsageInsight[] {
+  const providerRows = args.byProvider.filter((row) => row.calls > 0);
+  const pipelineRows = args.byPipeline.filter((row) => row.calls > 0);
+  if (providerRows.length === 0 && pipelineRows.length === 0) {
+    return [
+      {
+        id: "empty",
+        title: "Noch keine belastbaren Usage-Daten",
+        value: "0 Events",
+        hint: "Sobald AI-Calls geloggt sind, erscheinen Kosten-/Fehler-/Latenz-Hinweise hier.",
+      },
+    ];
+  }
+
+  const highestCostProvider = bestBy(providerRows, (row) => row.costEur);
+  const mostErrorProneProvider = bestBy(
+    providerRows.filter((row) => row.calls >= 3),
+    (row) => row.errorRatePct ?? 0,
+  );
+  const slowestPipeline = bestBy(pipelineRows, (row) => row.avgDurationMs ?? 0);
+  const highCostPerCall = bestBy(
+    providerRows.filter((row) => row.calls >= 3),
+    (row) => row.costPerCallEur ?? 0,
+  );
+  const timeoutHotspot = args.byErrorKind.find((row) => row.key === "TIMEOUT");
+  const badJsonHotspot = args.byErrorKind.find((row) => row.key === "BAD_JSON");
+
+  const insights: AiUsageInsight[] = [];
+
+  if (highestCostProvider) {
+    insights.push({
+      id: "highest_cost_provider",
+      title: "Teuerster Provider im Zeitraum",
+      value: highestCostProvider.label,
+      hint: `${formatCurrency(highestCostProvider.costEur)} bei ${formatNumber(highestCostProvider.calls)} Calls`,
+    });
+  }
+
+  if (mostErrorProneProvider) {
+    insights.push({
+      id: "most_error_prone_provider",
+      title: "Fehleranfälligster Provider",
+      value: `${mostErrorProneProvider.label} (${(mostErrorProneProvider.errorRatePct ?? 0).toFixed(1)}%)`,
+      hint: `${mostErrorProneProvider.errors} Fehler bei ${mostErrorProneProvider.calls} Calls`,
+    });
+  }
+
+  if (slowestPipeline) {
+    insights.push({
+      id: "slowest_pipeline",
+      title: "Langsamste Pipeline",
+      value: slowestPipeline.label,
+      hint: `${formatNumber(slowestPipeline.avgDurationMs ?? 0)} ms Ø Latenz`,
+    });
+  }
+
+  if (highCostPerCall) {
+    insights.push({
+      id: "high_cost_per_call",
+      title: "High Cost-per-Call Kandidat",
+      value: `${highCostPerCall.label} (${formatEur(highCostPerCall.costPerCallEur ?? 0)})`,
+      hint: "Candidate für Prompt-/Routing-Optimierung",
+    });
+  }
+
+  if (timeoutHotspot && timeoutHotspot.calls > 0) {
+    insights.push({
+      id: "timeout_hotspot",
+      title: "Timeout-Hotspot",
+      value: `${timeoutHotspot.calls} Timeout-Events`,
+      hint: `${timeoutHotspot.ratePct.toFixed(1)}% aller Events im Filter`,
+    });
+  }
+
+  if (badJsonHotspot && badJsonHotspot.calls > 0) {
+    insights.push({
+      id: "bad_json_hotspot",
+      title: "BAD_JSON-Hotspot",
+      value: `${badJsonHotspot.calls} BAD_JSON-Events`,
+      hint: `${badJsonHotspot.ratePct.toFixed(1)}% aller Events im Filter`,
+    });
+  }
+
+  insights.push({
+    id: "overall_success_rate",
+    title: "Gesamte Erfolgsquote",
+    value: `${args.performance.successRatePct.toFixed(1)}%`,
+    hint: `Ø Latenz ${formatNumber(args.performance.avgDurationMs)} ms`,
+  });
+
+  return insights;
+}
+
+export function deriveAiUsageOperationalSignals(
+  args: DeriveAiUsageOperationalSignalsArgs,
+): {
+  thresholds: AiUsageThresholds;
+  derivedMetrics: AiUsageDerivedMetrics;
+  attentionFlags: AiUsageAttentionFlag[];
+  optimization: AiUsageOptimizationSignals;
+} {
+  const thresholds = resolveUsageThresholds(args.thresholds);
+  const timeoutRow = args.byErrorKind.find((row) => row.key === "TIMEOUT");
+  const badJsonRow = args.byErrorKind.find((row) => row.key === "BAD_JSON");
+  const sealedLane = args.byLane.find((row) => row.key === "sealed_factcheck");
+
+  const nonProbeCalls = sumRows(
+    args.rows.filter((row) => row.pipeline !== "provider_probe"),
+    (row) => row.callsTotal,
+  );
+  const openAiNonProbeCalls = sumRows(
+    args.rows.filter(
+      (row) => row.provider === "openai" && row.pipeline !== "provider_probe",
+    ),
+    (row) => row.callsTotal,
+  );
+
+  const projectedMonthlyCostEur =
+    args.rangeDays > 0 ? (args.totals.costEur / args.rangeDays) * 30 : 0;
+  const projectedBudgetUtilizationPct =
+    thresholds.budgetMonthlyEur > 0
+      ? (projectedMonthlyCostEur / thresholds.budgetMonthlyEur) * 100
+      : 0;
+
+  const derivedMetrics: AiUsageDerivedMetrics = {
+    costPerCallEur: args.performance.costPerCallEur ?? 0,
+    avgDurationMs: args.performance.avgDurationMs ?? 0,
+    errorRatePct: args.performance.errorRatePct ?? 0,
+    timeoutSharePct: timeoutRow?.ratePct ?? 0,
+    badJsonSharePct: badJsonRow?.ratePct ?? 0,
+    researchHeavyWorkloadSharePct: toRate(sealedLane?.calls ?? 0, args.totals.calls),
+    fallbackRelianceSharePct: toRate(openAiNonProbeCalls, nonProbeCalls),
+    sealedFactcheckCostFootprintPct: toRate(
+      sealedLane?.costEur ?? 0,
+      args.totals.costEur,
+    ),
+    projectedMonthlyCostEur,
+    projectedBudgetUtilizationPct,
+  };
+
+  const attentionFlags: AiUsageAttentionFlag[] = [];
+
+  if (derivedMetrics.projectedBudgetUtilizationPct >= thresholds.projectedBudgetWarnPct) {
+    attentionFlags.push({
+      id: "budget_projection",
+      title: "Budget-Projektion",
+      severity:
+        derivedMetrics.projectedBudgetUtilizationPct >= 100 ? "critical" : "warning",
+      value: `${formatCurrency(derivedMetrics.projectedMonthlyCostEur)} / Monat`,
+      threshold: thresholdPercent(thresholds.projectedBudgetWarnPct),
+      hint: `Projektion aus ${args.rangeDays} Tagen auf Monatsbasis.`,
+    });
+  }
+  if (derivedMetrics.errorRatePct >= thresholds.errorRateWarnPct) {
+    attentionFlags.push({
+      id: "error_rate",
+      title: "Fehlerquote erhöht",
+      severity: "warning",
+      value: formatPercentValue(derivedMetrics.errorRatePct),
+      threshold: thresholdPercent(thresholds.errorRateWarnPct),
+      hint: "Top-Error-Kinds und betroffene Provider prüfen.",
+    });
+  }
+  if (derivedMetrics.avgDurationMs >= thresholds.avgDurationWarnMs) {
+    attentionFlags.push({
+      id: "latency",
+      title: "Latenz erhöht",
+      severity: "warning",
+      value: `${formatNumber(derivedMetrics.avgDurationMs)} ms`,
+      threshold: `>${formatNumber(thresholds.avgDurationWarnMs)} ms`,
+      hint: "Langsame Pipelines und Timeout-Quellen priorisieren.",
+    });
+  }
+  if (derivedMetrics.costPerCallEur >= thresholds.costPerCallWarnEur) {
+    attentionFlags.push({
+      id: "cost_per_call",
+      title: "Kosten pro Call erhöht",
+      severity: "warning",
+      value: formatEur(derivedMetrics.costPerCallEur),
+      threshold: thresholdEur(thresholds.costPerCallWarnEur),
+      hint: "Promptgröße, Modellmix und Fallback-Strategie prüfen.",
+    });
+  }
+  if (
+    derivedMetrics.fallbackRelianceSharePct >=
+    thresholds.fallbackRelianceWarnSharePct
+  ) {
+    attentionFlags.push({
+      id: "fallback_reliance",
+      title: "Fallback-Reliance (OpenAI-Proxy) hoch",
+      severity: "warning",
+      value: formatPercentValue(derivedMetrics.fallbackRelianceSharePct),
+      threshold: thresholdPercent(thresholds.fallbackRelianceWarnSharePct),
+      hint: "Proxy auf Basis OpenAI-Anteil außerhalb Provider-Probe.",
+    });
+  }
+  if (
+    derivedMetrics.researchHeavyWorkloadSharePct >=
+    thresholds.researchHeavyWarnSharePct
+  ) {
+    attentionFlags.push({
+      id: "research_share",
+      title: "Research-heavy Workload hoch",
+      severity: "info",
+      value: formatPercentValue(derivedMetrics.researchHeavyWorkloadSharePct),
+      threshold: thresholdPercent(thresholds.researchHeavyWarnSharePct),
+      hint: "Anteil sealed Factcheck an allen Calls.",
+    });
+  }
+  if (
+    derivedMetrics.sealedFactcheckCostFootprintPct >=
+    thresholds.sealedCostFootprintWarnSharePct
+  ) {
+    attentionFlags.push({
+      id: "sealed_cost_footprint",
+      title: "Sealed-Factcheck Kostenanteil hoch",
+      severity: "info",
+      value: formatPercentValue(derivedMetrics.sealedFactcheckCostFootprintPct),
+      threshold: thresholdPercent(thresholds.sealedCostFootprintWarnSharePct),
+      hint: "Kostenanteil der sealed_factcheck-Lane im Filter.",
+    });
+  }
+  if (derivedMetrics.timeoutSharePct >= thresholds.timeoutWarnSharePct) {
+    attentionFlags.push({
+      id: "timeout_hotspot",
+      title: "Timeout-Hotspot",
+      severity: "warning",
+      value: formatPercentValue(derivedMetrics.timeoutSharePct),
+      threshold: thresholdPercent(thresholds.timeoutWarnSharePct),
+      hint: "Timeout-Häufigkeit über alle Event-Fehler.",
+    });
+  }
+  if (derivedMetrics.badJsonSharePct >= thresholds.badJsonWarnSharePct) {
+    attentionFlags.push({
+      id: "bad_json_hotspot",
+      title: "BAD_JSON-Hotspot",
+      severity: "warning",
+      value: formatPercentValue(derivedMetrics.badJsonSharePct),
+      threshold: thresholdPercent(thresholds.badJsonWarnSharePct),
+      hint: "Schema-/Prompt-Härtung für betroffene Provider prüfen.",
+    });
+  }
+
+  const providerRows = args.byProvider.filter((row) => row.calls > 0);
+  const pipelineRows = args.byPipeline.filter((row) => row.calls > 0);
+  const mostExpensiveProvider = bestBy(providerRows, (row) => row.costEur);
+  const highCostPerCallProvider = bestBy(
+    providerRows.filter((row) => row.calls >= 3),
+    (row) => row.costPerCallEur ?? 0,
+  );
+  const mostErrorProneProvider = bestBy(
+    providerRows.filter((row) => row.calls >= 3),
+    (row) => row.errorRatePct ?? 0,
+  );
+  const slowestPipeline = bestBy(pipelineRows, (row) => row.avgDurationMs ?? 0);
+
+  const savingsCandidates: AiUsageInsight[] = [];
+  if (mostExpensiveProvider) {
+    savingsCandidates.push({
+      id: "candidate_savings_expensive_provider",
+      title: "Einsparungskandidat: teuerster Provider",
+      value: mostExpensiveProvider.label,
+      hint: `${formatCurrency(mostExpensiveProvider.costEur)} im Zeitraum`,
+    });
+  }
+  if (highCostPerCallProvider) {
+    savingsCandidates.push({
+      id: "candidate_savings_cost_per_call",
+      title: "Einsparungskandidat: hoher Cost/Call",
+      value: `${highCostPerCallProvider.label} (${formatEur(
+        highCostPerCallProvider.costPerCallEur ?? 0,
+      )})`,
+      hint: "Promptumfang, Modellwahl und Batchability prüfen.",
+    });
+  }
+  if ((sealedLane?.costEur ?? 0) > 0) {
+    savingsCandidates.push({
+      id: "candidate_savings_sealed_lane",
+      title: "Einsparungskandidat: sealed Factcheck Footprint",
+      value: `${formatPercentValue(derivedMetrics.sealedFactcheckCostFootprintPct)} Kostenanteil`,
+      hint: `${formatCurrency(sealedLane?.costEur ?? 0)} in sealed_factcheck`,
+    });
+  }
+
+  const qualityCandidates: AiUsageInsight[] = [];
+  if (mostErrorProneProvider) {
+    qualityCandidates.push({
+      id: "candidate_quality_error_provider",
+      title: "Qualitätskandidat: fehleranfälliger Provider",
+      value: `${mostErrorProneProvider.label} (${formatPercentValue(
+        mostErrorProneProvider.errorRatePct ?? 0,
+      )})`,
+      hint: `${mostErrorProneProvider.errors} Fehler bei ${mostErrorProneProvider.calls} Calls`,
+    });
+  }
+  if ((badJsonRow?.calls ?? 0) > 0) {
+    qualityCandidates.push({
+      id: "candidate_quality_bad_json",
+      title: "Qualitätskandidat: BAD_JSON",
+      value: `${badJsonRow?.calls ?? 0} Events`,
+      hint: "Response-Format und Schema-Guards nachschärfen.",
+    });
+  }
+
+  const stabilityCandidates: AiUsageInsight[] = [];
+  if (slowestPipeline) {
+    stabilityCandidates.push({
+      id: "candidate_stability_slowest_pipeline",
+      title: "Stabilitätskandidat: langsame Pipeline",
+      value: slowestPipeline.label,
+      hint: `${formatNumber(slowestPipeline.avgDurationMs ?? 0)} ms Ø`,
+    });
+  }
+  if ((timeoutRow?.calls ?? 0) > 0) {
+    stabilityCandidates.push({
+      id: "candidate_stability_timeout",
+      title: "Stabilitätskandidat: Timeout-Cluster",
+      value: `${timeoutRow?.calls ?? 0} Timeout-Events`,
+      hint: `${formatPercentValue(timeoutRow?.ratePct ?? 0)} Anteil`,
+    });
+  }
+  if (derivedMetrics.fallbackRelianceSharePct > 0) {
+    stabilityCandidates.push({
+      id: "candidate_stability_fallback_reliance",
+      title: "Stabilitätskandidat: Fallback-Reliance",
+      value: `${formatPercentValue(derivedMetrics.fallbackRelianceSharePct)} OpenAI-Proxy`,
+      hint: "Hoher Fallback-Anteil kann auf Instabilität der Primärprovider hindeuten.",
+    });
+  }
+
+  return {
+    thresholds,
+    derivedMetrics,
+    attentionFlags,
+    optimization: {
+      savingsCandidates,
+      qualityCandidates,
+      stabilityCandidates,
+    },
+  };
+}
+
 export async function getAiUsageSnapshot(
   rangeDays = 30,
   region?: string | null,
+  provider?: AiProviderName | null,
+  pipeline?: AiPipelineName | null,
+  thresholds?: Partial<AiUsageThresholds> | null,
 ): Promise<AiUsageBreakdownSnapshot> {
   const today = new Date();
   const toDateIso = today.toISOString().slice(0, 10);
@@ -368,9 +1048,16 @@ export async function getAiUsageSnapshot(
   const fromDateIso = fromDate.toISOString().slice(0, 10);
 
   const dailyCol = await coreCol<AiUsageDailyRow>(COLLECTION_DAILY);
+  const usageCol = await coreCol<AiUsageEvent>(COLLECTION_USAGE);
   const match: Record<string, any> = { date: { $gte: fromDateIso, $lte: toDateIso } };
   if (typeof region === "string" && region.trim()) {
     match.region = region.trim();
+  }
+  if (provider) {
+    match.provider = provider;
+  }
+  if (pipeline) {
+    match.pipeline = pipeline;
   }
 
   const rows = await dailyCol.find(match).toArray();
@@ -382,37 +1069,161 @@ export async function getAiUsageSnapshot(
     errors: sumRows(rows, (row) => row.callsError),
   };
 
-  const byProvider: AiUsageBreakdownRow[] = PROVIDERS.map((provider) => {
-    const subset = rows.filter((row) => row.provider === provider);
+  const normalizedByProvider: AiUsageBreakdownRow[] = PROVIDERS.map((providerKey) => {
+    const subset = rows.filter((row) => row.provider === providerKey);
+    const calls = sumRows(subset, (row) => row.callsTotal);
+    const errors = sumRows(subset, (row) => row.callsError);
+    const costEur = sumRows(subset, (row) => row.costTotalEur);
     return {
-      key: provider,
-      label: PROVIDER_LABELS[provider],
+      key: providerKey,
+      label: PROVIDER_LABELS[providerKey],
       tokens: sumRows(subset, (row) => row.tokensTotal),
-      costEur: sumRows(subset, (row) => row.costTotalEur),
-      calls: sumRows(subset, (row) => row.callsTotal),
-      errors: sumRows(subset, (row) => row.callsError),
+      costEur,
+      calls,
+      errors,
+      errorRatePct: toRate(errors, calls),
+      successRatePct: toRate(calls - errors, calls),
+      costPerCallEur: calls > 0 ? costEur / calls : 0,
     };
   });
 
-  const byPipeline: AiUsageBreakdownRow[] = Object.entries(PIPELINE_LABELS).map(
-    ([pipeline, label]) => {
-      const subset = rows.filter((row) => row.pipeline === pipeline);
+  const normalizedByPipeline: AiUsageBreakdownRow[] = Object.entries(PIPELINE_LABELS).map(
+    ([pipelineKey, label]) => {
+      const subset = rows.filter((row) => row.pipeline === pipelineKey);
+      const calls = sumRows(subset, (row) => row.callsTotal);
+      const errors = sumRows(subset, (row) => row.callsError);
+      const costEur = sumRows(subset, (row) => row.costTotalEur);
       return {
-        key: pipeline,
+        key: pipelineKey,
         label,
         tokens: sumRows(subset, (row) => row.tokensTotal),
-        costEur: sumRows(subset, (row) => row.costTotalEur),
-        calls: sumRows(subset, (row) => row.callsTotal),
-        errors: sumRows(subset, (row) => row.callsError),
+        costEur,
+        calls,
+        errors,
+        errorRatePct: toRate(errors, calls),
+        successRatePct: toRate(calls - errors, calls),
+        costPerCallEur: calls > 0 ? costEur / calls : 0,
       };
     },
   );
 
+  const byLane = aggregateRows(
+    rows,
+    (row) => mapPipelineToLane(row.pipeline),
+    (lane) => LANE_LABELS[lane],
+  );
+  const byJourney = aggregateRows(
+    rows,
+    (row) => mapPipelineToJourney(row.pipeline),
+    (journey) => JOURNEY_LABELS[journey],
+  );
+
+  const eventMatch: Record<string, any> = {
+    createdAt: { $gte: startOfDay(fromDate) },
+  };
+  if (typeof region === "string" && region.trim()) {
+    eventMatch.region = region.trim();
+  }
+  if (provider) {
+    eventMatch.provider = provider;
+  }
+  if (pipeline) {
+    eventMatch.pipeline = pipeline;
+  }
+
+  const recentEventsRaw = await usageCol
+    .find(eventMatch, { sort: { createdAt: -1 }, limit: 40 })
+    .project({
+      createdAt: 1,
+      provider: 1,
+      pipeline: 1,
+      region: 1,
+      model: 1,
+      tokensInput: 1,
+      tokensOutput: 1,
+      costEur: 1,
+      durationMs: 1,
+      success: 1,
+      errorKind: 1,
+      strictJson: 1,
+      promptSnippet: 1,
+      responseSnippet: 1,
+      rawError: 1,
+    })
+    .toArray();
+
+  const recent = recentEventsRaw.map(toUsageEventSummary);
+
+  const eventCalls = recent.length;
+  const eventErrors = recent.filter((event) => !event.success).length;
+  const avgDurationMs =
+    eventCalls > 0
+      ? Math.round(recent.reduce((sum, event) => sum + (event.durationMs ?? 0), 0) / eventCalls)
+      : 0;
+  const performance: AiUsagePerformanceSummary = {
+    avgDurationMs,
+    successRatePct: toRate(eventCalls - eventErrors, eventCalls),
+    errorRatePct: toRate(eventErrors, eventCalls),
+    costPerCallEur: totals.calls > 0 ? totals.costEur / totals.calls : 0,
+  };
+
+  const byErrorKind = aggregateErrorKinds(recent);
+
+  const durationByProvider = aggregateAverageDuration(recent, (event) => event.provider);
+  const durationByPipeline = aggregateAverageDuration(recent, (event) => event.pipeline);
+  const byProvider = normalizedByProvider.map((row) => ({
+    ...row,
+    avgDurationMs: durationByProvider.get(row.key as AiProviderName),
+  }));
+  const byPipeline = normalizedByPipeline.map((row) => ({
+    ...row,
+    avgDurationMs: durationByPipeline.get(row.key as AiPipelineName),
+  }));
+
+  const insights = deriveAiUsageInsights({
+    byProvider,
+    byPipeline,
+    performance,
+    byErrorKind,
+  });
+  const operational = deriveAiUsageOperationalSignals({
+    rangeDays: Math.max(1, rangeDays),
+    totals,
+    performance,
+    byProvider,
+    byPipeline,
+    byLane,
+    byErrorKind,
+    rows,
+    thresholds,
+  });
+
+  const sortedByProvider = sortBreakdownRows(byProvider);
+  const sortedByPipeline = sortBreakdownRows(byPipeline);
+  const sortedByLane = sortBreakdownRows(byLane);
+  const sortedByJourney = sortBreakdownRows(byJourney);
+
   return {
     fromDate: fromDate.toISOString(),
     toDate: today.toISOString(),
+    filters: {
+      rangeDays: Math.max(1, rangeDays),
+      provider: provider ?? undefined,
+      pipeline: pipeline ?? undefined,
+      region: typeof region === "string" && region.trim() ? region.trim() : null,
+    },
     totals,
-    byProvider,
-    byPipeline,
+    performance,
+    byProvider: sortedByProvider,
+    byPipeline: sortedByPipeline,
+    byLane: sortedByLane,
+    byJourney: sortedByJourney,
+    byErrorKind,
+    recent: recent.slice(0, 20),
+    insights,
+    thresholds: operational.thresholds,
+    derivedMetrics: operational.derivedMetrics,
+    attentionFlags: operational.attentionFlags,
+    optimization: operational.optimization,
   };
 }


### PR DESCRIPTION
## Ziel
AI-Usage von reiner Sichtbarkeit zu operativen Steuerungssignalen erweitern.

## Scope
- derived metrics: cost/call, avg duration, error/hotspot shares, fallback/research/sealed footprint
- attention flags + optimization candidates
- threshold controls in usage route/page
- admin overview teaser (`Attention Needed`)
- tests für snapshot/route/view helpers

## Dateien (Kern)
- `core/telemetry/aiUsageSnapshot.ts`
- `apps/web/src/app/api/admin/telemetry/ai/{route.ts,usage/route.ts}`
- `apps/web/src/app/admin/telemetry/ai/{page.tsx,usage/page.tsx}`
- `apps/web/src/features/admin/aiUsageView.ts`
- `apps/web/tests/{ai-usage-operational-signals.contract.test.ts,ai-usage-view.contract.test.ts,admin-ai-usage.route.test.ts}`

## Validierung
- `pnpm -C apps/web exec vitest run tests/ai-usage-operational-signals.contract.test.ts tests/ai-usage-view.contract.test.ts tests/admin-ai-usage.route.test.ts` ✅