### PR TITLE
Add direct provider full contract probes

### DIFF
--- a/apps/web/src/app/admin/telemetry/ai/orchestrator/page.tsx
+++ b/apps/web/src/app/admin/telemetry/ai/orchestrator/page.tsx
@@ -44,6 +44,7 @@ type SmokeResponse = {
   bestProviderId?: string | null;
   orchestratorOk: boolean;
   rows: ProviderDiagnostic[];
+  directContractRows?: ProviderDiagnostic[];
   error?: string;
   createAnalyzeApi: {
     state: "ok" | "failed" | "skipped";
@@ -219,6 +220,83 @@ export default function OrchestratorTelemetryPage() {
                 </div>
               )}
 
+              {data && card.mode === "full_contract" && (data.directContractRows?.length ?? 0) > 0 && (
+                <div className="mt-4 rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] p-3">
+                  <h3 className="text-sm font-semibold text-[rgb(var(--fg))]">Direkter Provider-Contract</h3>
+                  <p className="mt-1 text-xs text-[rgb(var(--muted))]">
+                    Prüft OpenAI/GPT, Anthropic, Mistral, Gemini und ARI direkt gegen den AnalyzeResultSchema-Contract – unabhängig vom Journey-Plan.
+                  </p>
+                  <div className="mt-3 overflow-x-auto">
+                    <table className="min-w-full divide-y divide-[rgb(var(--border))] text-sm">
+                      <thead className="bg-[rgb(var(--card))] text-left text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">
+                        <tr>
+                          <th className="px-3 py-2">Provider</th>
+                          <th className="px-3 py-2">Modell</th>
+                          <th className="px-3 py-2">Result</th>
+                          <th className="px-3 py-2">Root Cause</th>
+                          <th className="px-3 py-2">Next Action</th>
+                          <th className="px-3 py-2">Diagnose</th>
+                          <th className="px-3 py-2">Dauer</th>
+                          <th className="px-3 py-2">Tokens in/out</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-[rgb(var(--border))]">
+                        {data.directContractRows?.map((row) => {
+                          const rowKey = `${card.mode}-direct-${row.provider}`;
+                          const expanded = expandedRows[rowKey] ?? false;
+                          return (
+                            <Fragment key={rowKey}>
+                              <tr>
+                                <td className="px-3 py-2">
+                                  <div className="font-semibold text-[rgb(var(--fg))]">{row.provider}</div>
+                                  <div className="text-xs text-[rgb(var(--muted))]">{row.displayName}</div>
+                                </td>
+                                <td className="px-3 py-2 text-[rgb(var(--muted))]">{row.model ?? "unknown"}</td>
+                                <td className="px-3 py-2">
+                                  <span className={`rounded-full border px-2 py-1 text-xs font-semibold ${statusChipClass(row.status)}`}>
+                                    {row.status}
+                                  </span>
+                                  <div className="mt-1 text-xs text-[rgb(var(--muted))]">
+                                    provider={row.providerStatus} · adapter={row.adapterStatus} · parse={row.parseStatus} · schema={row.schemaStatus}
+                                  </div>
+                                </td>
+                                <td className="px-3 py-2 text-xs font-semibold text-[rgb(var(--fg))]">{row.rootCause}</td>
+                                <td className="px-3 py-2 text-xs text-[rgb(var(--muted))]">{row.nextAction}</td>
+                                <td className="px-3 py-2 text-xs text-[rgb(var(--muted))]">{compactReason(row)}</td>
+                                <td className="px-3 py-2">{typeof row.durationMs === "number" ? `${row.durationMs} ms` : "n/a"}</td>
+                                <td className="px-3 py-2">{formatTokens(row)}</td>
+                              </tr>
+                              {hasDetail(row) && (
+                                <tr>
+                                  <td className="px-3 pb-3" colSpan={8}>
+                                    <button
+                                      type="button"
+                                      className="text-xs font-semibold text-sky-700 underline"
+                                      onClick={() => setExpandedRows((prev) => ({ ...prev, [rowKey]: !expanded }))}
+                                    >
+                                      {expanded ? "Details ausblenden" : "Details anzeigen"}
+                                    </button>
+                                    {expanded && (
+                                      <div className="mt-2 rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-3 text-xs text-[rgb(var(--muted))]">
+                                        <div>mode={formatModeLabel(row.mode)} · stage=direct_provider_contract · journeyDecision={row.journeyDecision} · validationMode={row.validationMode}</div>
+                                        <div>errorKind={row.errorKind ?? "none"} · providerCode={row.providerErrorCode ?? "none"} · httpStatus={row.httpStatus ?? "none"}</div>
+                                        <div>parseError={row.parseError ?? "none"} · schemaError={row.schemaError ?? "none"} · schemaPath={row.schemaPath ?? "none"}</div>
+                                        <div>fallbackUsed={String(row.fallbackUsed)} · fallbackReason={row.fallbackReason ?? "none"}</div>
+                                        <div className="mt-1">rawExcerpt: {row.rawExcerpt ?? "none"}</div>
+                                      </div>
+                                    )}
+                                  </td>
+                                </tr>
+                              )}
+                            </Fragment>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+
               {rows.length > 0 && (
                 <div className="mt-4 overflow-x-auto">
                   <table className="min-w-full divide-y divide-[rgb(var(--border))] text-sm">
@@ -236,7 +314,7 @@ export default function OrchestratorTelemetryPage() {
                     </thead>
                     <tbody className="divide-y divide-[rgb(var(--border))]">
                       {rows.map((row) => {
-                        const rowKey = `${card.mode}-${row.provider}`;
+                        const rowKey = `${card.mode}-${row.stage}-${row.provider}`;
                         const expanded = expandedRows[rowKey] ?? false;
                         return (
                           <Fragment key={rowKey}>

--- a/apps/web/src/app/api/admin/ai/orchestrator-smoke/route.ts
+++ b/apps/web/src/app/api/admin/ai/orchestrator-smoke/route.ts
@@ -109,6 +109,7 @@ type OrchestratorSmokeResponse = {
   bestProviderId?: E150ProviderName | null;
   bestRawText?: string | null;
   rows: ProviderDiagnostic[];
+  directContractRows?: ProviderDiagnostic[];
   results: LegacyProviderSmokeResult[];
   error?: string;
   probeStatus?: Record<string, { ok: boolean; errorKind: string | null; durationMs: number }>;
@@ -625,6 +626,231 @@ async function runDirectProviderProbe(provider: E150ProviderName): Promise<Provi
   }
 }
 
+function validateFullContractPayload(rawText: string): {
+  status: ProviderDiagnostic["status"];
+  errorKind: AiErrorKind | null;
+  providerErrorCode: string | null;
+  errorMessage: string | null;
+  reason: string | null;
+  adapterStatus: ProviderDiagnostic["adapterStatus"];
+  parseStatus: ProviderDiagnostic["parseStatus"];
+  schemaStatus: ProviderDiagnostic["schemaStatus"];
+  parseError: string | null;
+  schemaError: string | null;
+  schemaPath: string | null;
+  rawExcerpt: string | null;
+} {
+  const candidate = extractJsonCandidate(rawText) ?? cleanJson(rawText);
+  const cleaned = candidate.trim();
+
+  if (!cleaned) {
+    return {
+      status: "failed",
+      errorKind: "BAD_JSON",
+      providerErrorCode: "BAD_JSON",
+      errorMessage: "no_json_object_found",
+      reason: "no_json_object_found",
+      adapterStatus: "failed",
+      parseStatus: "failed",
+      schemaStatus: "not_started",
+      parseError: "no_json_object_found",
+      schemaError: null,
+      schemaPath: null,
+      rawExcerpt: null,
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = normalizeFullContractPayload(JSON.parse(cleaned));
+  } catch (error: any) {
+    const parseError = error?.message ?? "json_parse_failed";
+    return {
+      status: "failed",
+      errorKind: "BAD_JSON",
+      providerErrorCode: "BAD_JSON",
+      errorMessage: parseError,
+      reason: parseError,
+      adapterStatus: "failed",
+      parseStatus: "failed",
+      schemaStatus: "not_started",
+      parseError,
+      schemaError: null,
+      schemaPath: null,
+      rawExcerpt: cleaned.slice(0, 500),
+    };
+  }
+
+  const schema = AnalyzeResultSchema.safeParse(parsed);
+  if (!schema.success) {
+    const first = schema.error.issues[0];
+    const schemaError = first?.message ?? "schema_validation_failed";
+    return {
+      status: "failed",
+      errorKind: "INTERNAL",
+      providerErrorCode: "SCHEMA_INVALID",
+      errorMessage: schemaError,
+      reason: schemaError,
+      adapterStatus: "failed",
+      parseStatus: "ok",
+      schemaStatus: "failed",
+      parseError: null,
+      schemaError,
+      schemaPath: Array.isArray(first?.path) ? first.path.join(".") || "$" : null,
+      rawExcerpt: cleaned.slice(0, 500),
+    };
+  }
+
+  return {
+    status: "ok",
+    errorKind: null,
+    providerErrorCode: null,
+    errorMessage: null,
+    reason: null,
+    adapterStatus: "ok",
+    parseStatus: "ok",
+    schemaStatus: "ok",
+    parseError: null,
+    schemaError: null,
+    schemaPath: null,
+    rawExcerpt: cleaned.slice(0, 500),
+  };
+}
+
+async function runDirectFullContractProvider(provider: E150ProviderName): Promise<ProviderDiagnostic> {
+  const missingReason = configMissingReason(provider);
+  if (missingReason) {
+    return baseDiagnostic({
+      provider,
+      mode: "full_contract",
+      stage: "analyze_contract",
+      pipeline: "provider_probe",
+      model: defaultModelForProvider(provider),
+      status: "config_missing",
+      errorKind: "INVALID_API_KEY",
+      providerErrorCode: "CONFIG_MISSING",
+      httpStatus: null,
+      errorMessage: missingReason,
+      reason: missingReason,
+      validationMode: "analyze_schema",
+      providerStatus: "unknown",
+      adapterStatus: "not_started",
+      parseStatus: "not_started",
+      schemaStatus: "not_started",
+      rawExcerpt: missingReason,
+      durationMs: 0,
+      journeyDecision: "selected",
+    });
+  }
+
+  const started = Date.now();
+  const prompt = `${FULL_CONTRACT_SYSTEM_PROMPT}\n\nInput:\n${FULL_SAMPLE_TEXT}`;
+
+  try {
+    let text = "";
+    let model: string | undefined;
+    let tokensIn: number | undefined;
+    let tokensOut: number | undefined;
+
+    if (provider === "openai") {
+      const res = await callOpenAI({
+        prompt,
+        asJson: true,
+        forceJsonFormat: true,
+        maxOutputTokens: 2600,
+      });
+      text = res.text;
+      model = res.model;
+      tokensIn = res.tokensIn;
+      tokensOut = res.tokensOut;
+    } else if (provider === "anthropic") {
+      const res = await callAnthropic({ prompt, maxOutputTokens: 2600 });
+      text = res.text;
+      model = res.model;
+      tokensIn = res.tokensIn;
+      tokensOut = res.tokensOut;
+    } else if (provider === "mistral") {
+      const res = await callMistral({ prompt, maxOutputTokens: 2600 });
+      text = res.text;
+      model = res.model;
+      tokensIn = res.tokensIn;
+      tokensOut = res.tokensOut;
+    } else if (provider === "gemini") {
+      const res = await callGemini({ prompt, maxOutputTokens: 2600, expectJson: true });
+      text = res.text;
+      model = res.model;
+      tokensIn = res.tokensIn;
+      tokensOut = res.tokensOut;
+    } else {
+      const res = await callAriLLM({ prompt, asJson: true, maxOutputTokens: 2600 });
+      text = res.text;
+      model = res.model;
+      tokensIn = res.tokensIn;
+      tokensOut = res.tokensOut;
+    }
+
+    const validation = validateFullContractPayload(text ?? "");
+
+    return baseDiagnostic({
+      provider,
+      mode: "full_contract",
+      stage: "analyze_contract",
+      pipeline: "provider_probe",
+      model: model ?? defaultModelForProvider(provider),
+      status: validation.status,
+      errorKind: validation.errorKind,
+      providerErrorCode: validation.providerErrorCode,
+      httpStatus: 200,
+      errorMessage: validation.errorMessage,
+      reason: validation.reason,
+      validationMode: "analyze_schema",
+      providerStatus: "reachable",
+      adapterStatus: validation.adapterStatus,
+      parseStatus: validation.parseStatus,
+      schemaStatus: validation.schemaStatus,
+      parseError: validation.parseError,
+      schemaError: validation.schemaError,
+      schemaPath: validation.schemaPath,
+      rawExcerpt: validation.rawExcerpt ?? text,
+      durationMs: Date.now() - started,
+      tokensIn,
+      tokensOut,
+      journeyDecision: "selected",
+    });
+  } catch (error: any) {
+    const errorKind = mapErrorToKind(error);
+    const providerCode = extractProviderErrorCode(error);
+    const status = typeof error?.status === "number" ? error.status : null;
+
+    return baseDiagnostic({
+      provider,
+      mode: "full_contract",
+      stage: "analyze_contract",
+      pipeline: "provider_probe",
+      model: error?.meta?.model ?? defaultModelForProvider(provider),
+      status: looksConfigMissing(error?.message) ? "config_missing" : "failed",
+      errorKind,
+      providerErrorCode: providerCode,
+      httpStatus: status,
+      errorMessage: error?.message ?? "direct_full_contract_failed",
+      reason: error?.message ?? "direct_full_contract_failed",
+      validationMode: "analyze_schema",
+      providerStatus: deriveProviderStatus(errorKind, "failed"),
+      adapterStatus: "failed",
+      parseStatus: "not_started",
+      schemaStatus: "not_started",
+      rawExcerpt: error?.payload ?? error?.message,
+      durationMs: Date.now() - started,
+      journeyDecision: "selected",
+    });
+  }
+}
+
+async function runDirectFullContractProviders(): Promise<ProviderDiagnostic[]> {
+  const rows = await Promise.all(PROVIDER_ORDER.map((provider) => runDirectFullContractProvider(provider)));
+  return sortProviderDiagnostics(rows);
+}
+
 async function runCreateAnalyzeApiSmoke(): Promise<CreateAnalyzeApiSmoke> {
   const started = Date.now();
   try {
@@ -984,6 +1210,7 @@ function buildResponse(params: {
   startedAt: number;
   finishedAt: number;
   rows: ProviderDiagnostic[];
+  directContractRows?: ProviderDiagnostic[];
   orchestratorOk: boolean;
   bestProviderId: E150ProviderName | null;
   bestRawText: string | null;
@@ -1008,6 +1235,7 @@ function buildResponse(params: {
     bestProviderId: params.bestProviderId,
     bestRawText: params.bestRawText,
     rows: sortedRows,
+    directContractRows: params.directContractRows ? sortProviderDiagnostics(params.directContractRows) : undefined,
     results: sortedRows.map(toLegacyResult),
     error: params.error,
     ...(params.probeMaps ?? {}),
@@ -1157,7 +1385,10 @@ async function runFullMode(base: {
     orchestratorError = error;
   }
 
-  const createAnalyzeApi = await runCreateAnalyzeApiSmoke();
+  const [createAnalyzeApi, directContractRows] = await Promise.all([
+    runCreateAnalyzeApiSmoke(),
+    runDirectFullContractProviders(),
+  ]);
 
   if (!orchestratorResult) {
     const meta = extractOrchestratorMeta(orchestratorError);
@@ -1176,6 +1407,7 @@ async function runFullMode(base: {
       startedAt: base.startedAt,
       finishedAt: Date.now(),
       rows,
+      directContractRows,
       orchestratorOk: false,
       bestProviderId: null,
       bestRawText: null,
@@ -1201,6 +1433,7 @@ async function runFullMode(base: {
     startedAt: base.startedAt,
     finishedAt: Date.now(),
     rows: validatedRows,
+    directContractRows,
     orchestratorOk: validatedRows.some((entry) => entry.status === "ok") && createAnalyzeApi.ok,
     bestProviderId: orchestratorResult.best.provider,
     bestRawText: orchestratorResult.best.rawText,
@@ -1244,6 +1477,7 @@ export async function POST(req: NextRequest) {
       bestProviderId: null,
       bestRawText: null,
       rows: [],
+      directContractRows: [],
       results: [],
       error: message,
       createAnalyzeApi: {


### PR DESCRIPTION
Adds direct provider-level Full Analyze Contract diagnostics.

- Adds directContractRows to the admin orchestrator smoke response
- Runs OpenAI, Anthropic, Mistral, Gemini and ARI directly against the AnalyzeResultSchema contract
- Keeps Journey Full Contract separate from Direct Provider Contract
- Keeps ARI not_in_journey_plan behavior unchanged for runtime/journey smoke
- Shows Direct Provider Contract rows in the admin UI

Validated:
- pnpm -C apps/web typecheck
- pnpm -C apps/web exec vitest run tests/admin-ai-orchestrator-smoke.route.test.ts
- NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 pnpm --filter @vog/web build