### PR TITLE
Add OpenAI smoke overrides for provider diagnostics

### DIFF
--- a/apps/web/src/app/api/admin/ai/orchestrator-smoke/route.ts
+++ b/apps/web/src/app/api/admin/ai/orchestrator-smoke/route.ts
@@ -193,6 +193,25 @@ const FULL_CONTRACT_SYSTEM_PROMPT = [
   FULL_CONTRACT_EXAMPLE_JSON,
 ].join(" ");
 
+function openAiSmokeModel(): string | undefined {
+  return (
+    process.env.OPENAI_SMOKE_MODEL ||
+    process.env.OPENAI_MODEL2 ||
+    process.env.OPENAI_MODEL ||
+    undefined
+  );
+}
+
+function openAiSmokeTimeoutMs(): number {
+  const raw = Number(process.env.OPENAI_SMOKE_TIMEOUT_MS ?? 60_000);
+  return Number.isFinite(raw) && raw > 0 ? raw : 60_000;
+}
+
+function openAiSmokeMaxOutputTokens(): number {
+  const raw = Number(process.env.OPENAI_SMOKE_MAX_OUTPUT_TOKENS ?? 2_200);
+  return Number.isFinite(raw) && raw > 0 ? raw : 2_200;
+}
+
 type ProviderSmokeState =
   | "ok"
   | "failed"
@@ -894,7 +913,9 @@ async function runDirectFullContractProvider(provider: E150ProviderName): Promis
         prompt,
         asJson: true,
         forceJsonFormat: true,
-        maxOutputTokens: 2600,
+        model: openAiSmokeModel(),
+        timeoutMs: openAiSmokeTimeoutMs(),
+        maxOutputTokens: openAiSmokeMaxOutputTokens(),
       });
       text = res.text;
       model = res.model;


### PR DESCRIPTION
Adds OpenAI-specific smoke overrides for admin provider diagnostics.

Why:
The admin Full Contract smoke should not be blocked by heavier production/reasoning model settings. This separates the diagnostic smoke configuration from the normal product model path.

Changes:
- Adds OpenAI smoke model override via OPENAI_SMOKE_MODEL
- Falls back to OPENAI_MODEL2, OPENAI_MODEL, then provider default
- Adds smoke-specific timeout and max output token helpers
- Applies these only to the direct OpenAI Full Contract smoke call

Validated:
- pnpm -C apps/web typecheck
- pnpm -C apps/web exec vitest run tests/admin-ai-orchestrator-smoke.route.test.ts
- NODE_ENV=production NEXT_TELEMETRY_DISABLED=1 pnpm --filter @vog/web build