### PR TITLE
Limit OpenAI full contract smoke timeout

### DIFF
--- a/apps/web/src/app/api/admin/ai/orchestrator-smoke/route.ts
+++ b/apps/web/src/app/api/admin/ai/orchestrator-smoke/route.ts
@@ -206,8 +206,8 @@ function openAiSmokeModel(): string | undefined {
 }
 
 function openAiSmokeTimeoutMs(): number {
-  const raw = Number(process.env.OPENAI_SMOKE_TIMEOUT_MS ?? 60_000);
-  return Number.isFinite(raw) && raw > 0 ? raw : 60_000;
+  const raw = Number(process.env.OPENAI_SMOKE_TIMEOUT_MS ?? 30_000);
+  return Number.isFinite(raw) && raw > 0 ? raw : 30_000;
 }
 
 function openAiSmokeMaxOutputTokens(): number {


### PR DESCRIPTION
Limit OpenAI full contract smoke timeout

Reduces the default OpenAI direct Full Contract smoke timeout from 60s to 30s so the admin diagnostics do not block too long on OpenAI runtime failures.

Validated:
- pnpm -C apps/web typecheck
- pnpm -C apps/web exec vitest run tests/admin-ai-orchestrator-smoke.route.test.ts