### PR TITLE
fix(create): polish visual follow-up light mode and swipe handoff

### DIFF
--- a/apps/web/src/app/create/CreateClient.tsx
+++ b/apps/web/src/app/create/CreateClient.tsx
@@ -1025,6 +1025,7 @@ export default function CreateClient({
           ) : null
         }
         minRows={8}
+        collapseModeSelector
       />
 
       {showTooShortHint ? (

--- a/apps/web/src/app/swipes/SwipesClient.tsx
+++ b/apps/web/src/app/swipes/SwipesClient.tsx
@@ -18,6 +18,7 @@ import {
 import {
   derivePreferredSwipeTopics,
   filterSwipeItemsByDiscoverySegment,
+  prioritizeSwipeItemsForCreateSeed,
   SWIPE_DISCOVERY_SEGMENTS,
   type SwipeDiscoverySegment,
 } from "@/features/surfaces/swipes/discoveryContract";
@@ -129,6 +130,9 @@ function buildTransitionHint(decision: SwipeDecision, remainingToAnalysis: numbe
 
 type SwipesClientProps = {
   initialTopic?: string;
+  initialClaim?: string;
+  initialStance?: string;
+  fromCreate?: boolean;
   fromDraftId?: string | null;
   focusStatementId?: string;
   variant?: "full" | "solo";
@@ -147,6 +151,9 @@ type LastVoteSnapshot = {
 
 export function SwipesClient({
   initialTopic = "",
+  initialClaim = "",
+  initialStance = "",
+  fromCreate = false,
   fromDraftId = null,
   focusStatementId,
   variant = "full",
@@ -172,6 +179,8 @@ export function SwipesClient({
   const [savedTopicHints, setSavedTopicHints] = useState<string[]>([]);
   const [pendingNeutralReasonStatementId, setPendingNeutralReasonStatementId] = useState<string | null>(null);
   const [lastVote, setLastVote] = useState<LastVoteSnapshot | null>(null);
+  const [seededClaimMatchCount, setSeededClaimMatchCount] = useState(0);
+  const [seededTopicMatchCount, setSeededTopicMatchCount] = useState(0);
 
   const [screenFlash, setScreenFlash] = useState<SwipeDecision | null>(null);
   const [liveMessage, setLiveMessage] = useState("");
@@ -197,6 +206,9 @@ export function SwipesClient({
   const isSwipeFocusMode = !isSolo;
   const fromDraftArrivalEnabled = !isSolo && Boolean(fromDraftId);
   const showingFromDraftOnly = fromDraftArrivalEnabled && arrivalMode === "from_draft";
+  const seededClaim = initialClaim.trim();
+  const seededTopic = initialTopic.trim();
+  const hasCreateSeed = fromCreate && (seededClaim.length > 0 || seededTopic.length > 0);
 
   const freeVote = useFreeVoteLimit({
     enabled: requireAuthAfterFreeVotes && mode === "live" && !isSolo,
@@ -365,12 +377,25 @@ export function SwipesClient({
         null,
       );
       if (!cancelled) {
-        const nextItems = filterSwipeItemsByDiscoverySegment({
+        let nextItems = filterSwipeItemsByDiscoverySegment({
           items: resp.items,
           segment: activeSegment,
           savedIds,
           preferredTopics,
         });
+        if (hasCreateSeed) {
+          const seeded = prioritizeSwipeItemsForCreateSeed({
+            items: nextItems,
+            topic: seededTopic,
+            claim: seededClaim,
+          });
+          nextItems = seeded.items;
+          setSeededClaimMatchCount(seeded.claimMatchCount);
+          setSeededTopicMatchCount(seeded.topicMatchCount);
+        } else {
+          setSeededClaimMatchCount(0);
+          setSeededTopicMatchCount(0);
+        }
         setItems(nextItems);
         setDeckSize(nextItems.length);
         setCompletedCount(0);
@@ -394,11 +419,15 @@ export function SwipesClient({
     savedIds,
     savedIdsKey,
     showingFromDraftOnly,
+    hasCreateSeed,
+    seededClaim,
+    seededTopic,
     topicQuery,
     variant,
   ]);
 
   const activeItem = useMemo(() => items[0] ?? null, [items]);
+  const seededMatchFound = seededClaimMatchCount > 0 || seededTopicMatchCount > 0;
   const fromDraftFocusCount = useMemo(() => countFromDraftFocusItems(items), [items]);
   const thematicContextHref = useMemo(() => resolveThematicContextHref(activeItem), [activeItem]);
   const showArrivalContextReminder = useMemo(
@@ -714,6 +743,42 @@ export function SwipesClient({
       {!isSolo && showWelcomeHint ? (
         <section className="rounded-2xl border border-sky-200/80 bg-sky-50/70 px-3 py-2 text-xs text-sky-900 dark:border-sky-400/30 dark:bg-sky-500/10 dark:text-sky-100">
           Willkommen. Starte mit bestehenden Themen oder bringe ein eigenes Anliegen ein.
+        </section>
+      ) : null}
+
+      {!isSolo && hasCreateSeed ? (
+        <section className="rounded-2xl border border-cyan-200 bg-cyan-50/80 px-3 py-3 text-sm text-cyan-950 dark:border-cyan-400/30 dark:bg-cyan-500/10 dark:text-cyan-100">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-cyan-800 dark:text-cyan-200">Aus deinem Beitrag</p>
+          {seededClaim ? <p className="mt-1 font-semibold">{seededClaim}</p> : null}
+          <div className="mt-1 flex flex-wrap gap-2 text-xs">
+            {seededTopic ? <span className="vog-chip">{seededTopic}</span> : null}
+            {initialStance ? <span className="vog-chip">Vermutete Haltung: {initialStance}</span> : null}
+          </div>
+          <div className="mt-2 flex flex-wrap gap-2">
+            <button
+              type="button"
+              className="btn-secondary min-h-[40px] px-3 py-2 text-sm"
+              onClick={() => setTransitionHint("Du entscheidest aktiv. Es wird keine Stimme automatisch abgegeben.")}
+            >
+              Dazu abstimmen
+            </button>
+            <button
+              type="button"
+              className="btn-secondary min-h-[40px] px-3 py-2 text-sm"
+              onClick={() => {
+                setActiveSegment("all");
+                setSearchOpen(false);
+              }}
+            >
+              Erst ähnliche Positionen ansehen
+            </button>
+          </div>
+          {!seededMatchFound && !loading ? (
+            <p className="mt-2 text-xs text-cyan-900 dark:text-cyan-100">
+              Wir haben noch keine passende Abstimmung gefunden. Du kannst das Thema als neue Abstimmung vorschlagen.
+            </p>
+          ) : null}
+          <p className="mt-1 text-xs text-cyan-900 dark:text-cyan-100">Keine automatische Stimme.</p>
         </section>
       ) : null}
 

--- a/apps/web/src/app/swipes/page.tsx
+++ b/apps/web/src/app/swipes/page.tsx
@@ -12,11 +12,21 @@ type Props = {
   searchParams?: Record<string, string | string[] | undefined>;
 };
 
+function firstParam(value: string | string[] | undefined): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value) && typeof value[0] === "string") return value[0];
+  return "";
+}
+
 export default async function SwipesPage({ searchParams }: Props) {
   const cookieStore = await cookies();
   const session = await readSession();
   const userId = cookieStore.get("u_id")?.value || session?.uid;
 
+  const initialTopic = firstParam(searchParams?.topic);
+  const initialClaim = firstParam(searchParams?.claim);
+  const initialStance = firstParam(searchParams?.stance);
+  const fromCreate = firstParam(searchParams?.from) === "create";
   if (!userId) {
     const context = resolveSurfaceContext({ mode: "live", audience: "none", viewerRole: "public", dataSource: "live" });
     const fromDraftId = parseFromDraftParam(searchParams?.fromDraft);
@@ -26,7 +36,10 @@ export default async function SwipesPage({ searchParams }: Props) {
         <h1 className="sr-only">Swipes</h1>
         <SwipesSurface
           context={context}
-          initialTopic={typeof searchParams?.topic === "string" ? searchParams.topic : ""}
+          initialTopic={initialTopic}
+          initialClaim={initialClaim}
+          initialStance={initialStance}
+          fromCreate={fromCreate}
           fromDraftId={fromDraftId}
           requireAuthAfterFreeVotes
           showWelcomeHint={showWelcomeHint}
@@ -35,7 +48,6 @@ export default async function SwipesPage({ searchParams }: Props) {
     );
   }
 
-  const initialTopic = typeof searchParams?.topic === "string" ? searchParams.topic : "";
   const fromDraftId = parseFromDraftParam(searchParams?.fromDraft);
   const showWelcomeHint = searchParams?.welcome === "1";
   const context = resolveSurfaceContext({ mode: "live", audience: "none", dataSource: "live" });
@@ -46,6 +58,9 @@ export default async function SwipesPage({ searchParams }: Props) {
       <SwipesSurface
         context={context}
         initialTopic={initialTopic}
+        initialClaim={initialClaim}
+        initialStance={initialStance}
+        fromCreate={fromCreate}
         fromDraftId={fromDraftId}
         requireAuthAfterFreeVotes={false}
         showWelcomeHint={showWelcomeHint}

--- a/apps/web/src/features/create/CreateVisualFollowup.tsx
+++ b/apps/web/src/features/create/CreateVisualFollowup.tsx
@@ -382,6 +382,26 @@ export default function CreateVisualFollowup({
         <p className="text-sm text-[rgb(var(--muted))] md:text-base">
           Du kannst bestätigen, einzelne Punkte ändern oder erst passende Dossiers und Abstimmungen ansehen.
         </p>
+        <div className="grid gap-2 md:grid-cols-2">
+          <div className="rounded-lg border border-emerald-300/45 bg-emerald-50 px-3 py-2 dark:border-emerald-300/35 dark:bg-emerald-500/10">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-emerald-900 dark:text-emerald-100">
+              Kostenlose nächste Schritte
+            </p>
+            <ul className="mt-1 list-disc pl-4 text-xs text-emerald-900/90 dark:text-emerald-100/90">
+              <li>Dossiers lesen und abstimmbare Claims prüfen</li>
+              <li>In Swipes aktiv zustimmen, ablehnen oder offen bleiben</li>
+              <li>Als neues Thema vorschlagen</li>
+            </ul>
+          </div>
+          <div className="rounded-lg border border-slate-300/55 bg-slate-50 px-3 py-2 dark:border-slate-300/30 dark:bg-slate-500/10">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-900 dark:text-slate-100">
+              Zusatzservice (optional)
+            </p>
+            <p className="mt-1 text-xs text-slate-800 dark:text-slate-200">
+              Erweiterte Prüfung oder Begleitung startest du nur bewusst im nächsten Schritt. Keine automatische Kostenbuchung.
+            </p>
+          </div>
+        </div>
         <div className="flex flex-wrap gap-2">
           <button type="button" className="btn-primary min-h-[40px] px-3 py-2 text-sm" onClick={onConfirm}>
             Ja, so einordnen

--- a/apps/web/src/features/create/CreateVisualFollowup.tsx
+++ b/apps/web/src/features/create/CreateVisualFollowup.tsx
@@ -6,9 +6,14 @@ import {
   buildCreateVisualMap,
   buildCreateVisualSections,
   deriveDominantUnderstandingStance,
+  type CreateConnectionSuggestion,
   type CreateIntelligentFollowupResult,
   type CreateVisualNode,
 } from "@/features/create/intelligentFollowupContract";
+import {
+  buildCreateFollowupPrimaryCtaHref,
+  buildCreateFollowupTargetHref,
+} from "@/features/create/followupTargetHref";
 
 type CreateVisualFollowupProps = {
   result: CreateIntelligentFollowupResult;
@@ -32,14 +37,28 @@ export const CREATE_VISUAL_FOLLOWUP_COPY = {
 } as const;
 
 function resolveNodeTone(kind: CreateVisualNode["kind"]): string {
-  if (kind === "source_text") return "border-cyan-300/60 bg-cyan-500/15";
-  if (kind === "statement") return "border-sky-300/45 bg-sky-500/10";
-  if (kind === "topic") return "border-violet-300/45 bg-violet-500/10";
-  if (kind === "stance") return "border-emerald-300/45 bg-emerald-500/10";
-  if (kind === "scope") return "border-amber-300/45 bg-amber-500/10";
-  if (kind === "dossier" || kind === "anlassraum") return "border-blue-300/45 bg-blue-500/10";
-  if (kind === "vote") return "border-fuchsia-300/45 bg-fuchsia-500/10";
-  return "border-slate-300/45 bg-slate-500/10";
+  if (kind === "source_text") {
+    return "border-cyan-500/35 bg-cyan-50 text-cyan-950 dark:border-cyan-300/60 dark:bg-cyan-500/15 dark:text-cyan-50";
+  }
+  if (kind === "statement") {
+    return "border-sky-500/30 bg-sky-50 text-sky-950 dark:border-sky-300/45 dark:bg-sky-500/10 dark:text-sky-50";
+  }
+  if (kind === "topic") {
+    return "border-violet-500/30 bg-violet-50 text-violet-950 dark:border-violet-300/45 dark:bg-violet-500/10 dark:text-violet-50";
+  }
+  if (kind === "stance") {
+    return "border-emerald-500/30 bg-emerald-50 text-emerald-950 dark:border-emerald-300/45 dark:bg-emerald-500/10 dark:text-emerald-50";
+  }
+  if (kind === "scope") {
+    return "border-amber-500/35 bg-amber-50 text-amber-950 dark:border-amber-300/45 dark:bg-amber-500/10 dark:text-amber-50";
+  }
+  if (kind === "dossier" || kind === "anlassraum") {
+    return "border-blue-500/30 bg-blue-50 text-blue-950 dark:border-blue-300/45 dark:bg-blue-500/10 dark:text-blue-50";
+  }
+  if (kind === "vote") {
+    return "border-fuchsia-500/30 bg-fuchsia-50 text-fuchsia-950 dark:border-fuchsia-300/45 dark:bg-fuchsia-500/10 dark:text-fuchsia-50";
+  }
+  return "border-slate-300/45 bg-slate-50 text-slate-900 dark:border-slate-300/45 dark:bg-slate-500/10 dark:text-slate-100";
 }
 
 function resolveStanceLead(label: string): string {
@@ -59,7 +78,7 @@ function resolveScopeLabel(scope: string): string {
   return "unklar";
 }
 
-function resolveSuggestionBadge(kind: CreateVisualNode["kind"]): string {
+function resolveSuggestionBadge(kind: CreateConnectionSuggestion["kind"]): string {
   if (kind === "dossier") return "Dossier";
   if (kind === "vote") return "Abstimmung";
   if (kind === "anlassraum") return "Anlassraum";
@@ -67,8 +86,8 @@ function resolveSuggestionBadge(kind: CreateVisualNode["kind"]): string {
   return "Thema";
 }
 
-function resolveSuggestionCta(kind: CreateVisualNode["kind"]): string {
-  if (kind === "dossier") return "Dossier ansehen";
+function resolveSuggestionCta(kind: CreateConnectionSuggestion["kind"]): string {
+  if (kind === "dossier") return "Ansehen";
   if (kind === "vote") return "Abstimmung ansehen";
   if (kind === "anlassraum") return "Anlassraum ansehen";
   if (kind === "new_anlassraum") return "Vorschlagen";
@@ -106,15 +125,11 @@ function resolveAssistantLead(params: {
     lowered.includes("sanktionen") &&
     lowered.includes("gesetzgebung")
   ) {
-    return "Ich erkenne eine Forderung nach klareren Mindestanforderungen und Konsequenzen für gewählte oder ernannte Amtsträger. Dein Beitrag berührt außerdem Gesetzgebung und die Frage, ob gestrichene Entwürfe als Optionen sichtbar bleiben sollten.";
+    return "Ich erkenne darin eine Forderung nach klareren Mindestanforderungen und Konsequenzen für Amtsträger. Außerdem berührt dein Text Gesetzgebung und mögliche Abstimmungsoptionen.";
   }
   const topicSentence = toSentenceList(params.topicLabels.slice(0, 4).map((label) => label.toLowerCase()));
-  if (topicSentence) {
-    return `Ich erkenne darin vor allem ${topicSentence}.`;
-  }
-  if (params.summary.trim().length > 0) {
-    return params.summary.trim();
-  }
+  if (topicSentence) return `Ich erkenne darin vor allem ${topicSentence}.`;
+  if (params.summary.trim().length > 0) return params.summary.trim();
   return params.statementText.trim();
 }
 
@@ -123,24 +138,23 @@ function resolveCoreClaim(params: {
   fallback: string;
 }): string {
   const lowered = params.topicLabels.join(" ").toLowerCase();
-  if (
-    lowered.includes("amtsträger") &&
-    lowered.includes("qualifikation") &&
-    lowered.includes("sanktionen")
-  ) {
+  if (lowered.includes("amtsträger") && lowered.includes("qualifikation") && lowered.includes("sanktionen")) {
     return "Du forderst klare Mindestanforderungen und Konsequenzen für Amtsträger.";
   }
   return params.fallback;
 }
 
-function sortConnectionNodes(nodes: CreateVisualNode[]): CreateVisualNode[] {
-  const priority: Record<string, number> = {
+function sortSuggestions(
+  suggestions: CreateConnectionSuggestion[],
+): CreateConnectionSuggestion[] {
+  const priority: Record<CreateConnectionSuggestion["kind"], number> = {
     dossier: 0,
     vote: 1,
     anlassraum: 2,
-    new_anlassraum: 3,
+    topic: 3,
+    new_anlassraum: 4,
   };
-  return [...nodes].sort((a, b) => (priority[a.kind] ?? 9) - (priority[b.kind] ?? 9));
+  return [...suggestions].sort((a, b) => priority[a.kind] - priority[b.kind]);
 }
 
 export default function CreateVisualFollowup({
@@ -156,21 +170,12 @@ export default function CreateVisualFollowup({
   const sections = React.useMemo(() => buildCreateVisualSections(result, 4), [result]);
   const [showCorrectionRow, setShowCorrectionRow] = React.useState(false);
   const [correctionFocus, setCorrectionFocus] = React.useState<string | null>(null);
+
   const topicLabels = result.understanding.topics.slice(0, 6).map((topic) => topic.label);
-  const topicLead = topicLabels.slice(0, 3).map((label) => label.toLowerCase()).join(", ");
   const dominantStance = deriveDominantUnderstandingStance(result.understanding);
-  const categoryNode = visualMap.nodes.find((node) => node.kind === "statement");
   const statementNodes = visualMap.nodes.filter((node) => node.kind === "statement").slice(0, 4);
   const topicNodes = visualMap.nodes.filter((node) => node.kind === "topic").slice(0, 6);
-  const connectionNodes = sortConnectionNodes(
-    visualMap.nodes.filter(
-      (node) =>
-        node.kind === "dossier" ||
-        node.kind === "anlassraum" ||
-        node.kind === "vote" ||
-        node.kind === "new_anlassraum",
-    ),
-  );
+  const sortedSuggestions = sortSuggestions(result.suggestions).slice(0, 3);
   const scopeChip = result.understanding.scopes[0] ?? "unclear";
   const assistantLead = resolveAssistantLead({
     topicLabels,
@@ -185,6 +190,12 @@ export default function CreateVisualFollowup({
   });
   const rootTopic = topicNodes[0]?.label ?? "Öffentliches Thema";
   const branchTopics = topicNodes.slice(1);
+  const primaryActionHref = buildCreateFollowupPrimaryCtaHref({
+    ctaHref,
+    topics: result.understanding.topics,
+    statements: result.understanding.statements,
+    suggestions: result.suggestions,
+  });
 
   const openCorrection = React.useCallback(
     (focus: string) => {
@@ -196,162 +207,155 @@ export default function CreateVisualFollowup({
   );
 
   return (
-    <section className="relative space-y-5 rounded-2xl border border-cyan-300/45 bg-cyan-500/10 p-4 pb-20 md:space-y-6 md:p-6 md:pb-24">
+    <section className="relative space-y-5 rounded-2xl border border-cyan-500/30 bg-cyan-50/80 p-4 pb-24 md:space-y-6 md:p-6 md:pb-20 dark:border-cyan-300/45 dark:bg-cyan-500/10">
       {showCompactUserBubble ? (
-        <div className="ml-auto max-w-3xl rounded-2xl rounded-tr-md border border-[rgb(var(--border))] bg-[rgb(var(--card))] px-4 py-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[rgb(var(--muted))]">Du</p>
-          <p className="mt-2 text-sm text-[rgb(var(--fg))] md:text-base">
+        <div className="ml-auto max-w-3xl rounded-2xl rounded-tr-md border border-slate-200 bg-white px-4 py-3 shadow-sm dark:border-[rgb(var(--border))] dark:bg-[rgb(var(--card))] dark:shadow-none">
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-600 dark:text-[rgb(var(--muted))]">Du</p>
+          <p className="mt-2 text-sm text-slate-900 md:text-base dark:text-[rgb(var(--fg))]">
             {result.sourceText.slice(0, 260)}
             {result.sourceText.length > 260 ? " …" : ""}
           </p>
         </div>
       ) : (
-        <div className="ml-auto max-w-3xl rounded-2xl rounded-tr-md border border-[rgb(var(--border))] bg-[rgb(var(--card))] px-4 py-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[rgb(var(--muted))]">Du</p>
-          <p className="mt-2 text-sm text-[rgb(var(--fg))] md:text-base">Dein Beitrag wurde aufgenommen.</p>
+        <div className="ml-auto max-w-3xl rounded-2xl rounded-tr-md border border-slate-200 bg-white px-4 py-3 shadow-sm dark:border-[rgb(var(--border))] dark:bg-[rgb(var(--card))] dark:shadow-none">
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-600 dark:text-[rgb(var(--muted))]">Du</p>
+          <p className="mt-2 text-sm text-slate-900 md:text-base dark:text-[rgb(var(--fg))]">Dein Beitrag wurde aufgenommen.</p>
           <details className="mt-2">
-            <summary className="cursor-pointer text-sm text-[rgb(var(--muted))]">Originaltext anzeigen</summary>
-            <pre className="mt-2 whitespace-pre-wrap rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--bg))] px-3 py-2 text-sm text-[rgb(var(--fg))]">
+            <summary className="cursor-pointer text-sm text-slate-700 dark:text-[rgb(var(--muted))]">Originaltext anzeigen</summary>
+            <pre className="mt-2 whitespace-pre-wrap rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-900 dark:border-[rgb(var(--border))] dark:bg-[rgb(var(--bg))] dark:text-[rgb(var(--fg))]">
               {result.sourceText}
             </pre>
           </details>
         </div>
       )}
 
-      <div className="mr-auto max-w-4xl rounded-2xl rounded-tl-md border border-cyan-300/45 bg-[rgb(var(--card))] px-4 py-4">
-        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-cyan-200">{CREATE_VISUAL_FOLLOWUP_COPY.structureTitle}</p>
-        <p className="mt-1 text-base font-semibold text-cyan-50 md:text-lg">{CREATE_VISUAL_FOLLOWUP_COPY.headline}</p>
-        <p className="mt-3 text-base text-cyan-100 md:text-lg">
-          {assistantLead || `Du sprichst vor allem über ${topicLead || "öffentliche Verantwortung und offene Fragen"}.`}
-        </p>
-        <div className="mt-4 rounded-xl border border-cyan-300/40 bg-cyan-500/10 px-4 py-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-cyan-200">{CREATE_VISUAL_FOLLOWUP_COPY.coreTitle}</p>
-          <p className="mt-1 text-base font-semibold text-cyan-50 md:text-xl">{keyStatement}</p>
+      <div className="mr-auto max-w-4xl rounded-2xl rounded-tl-md border border-cyan-500/30 bg-white px-4 py-4 shadow-sm dark:border-cyan-300/45 dark:bg-[rgb(var(--card))] dark:shadow-none">
+        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-cyan-800 dark:text-cyan-200">{CREATE_VISUAL_FOLLOWUP_COPY.structureTitle}</p>
+        <p className="mt-1 text-base font-semibold text-cyan-950 md:text-lg dark:text-cyan-50">{CREATE_VISUAL_FOLLOWUP_COPY.headline}</p>
+        <p className="mt-3 text-base text-cyan-900 md:text-lg dark:text-cyan-100">{assistantLead}</p>
+        <div className="mt-4 rounded-xl border border-cyan-500/35 bg-cyan-50 px-4 py-3 dark:border-cyan-300/40 dark:bg-cyan-500/10">
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-cyan-800 dark:text-cyan-200">{CREATE_VISUAL_FOLLOWUP_COPY.coreTitle}</p>
+          <p className="mt-1 text-base font-semibold text-cyan-950 md:text-xl dark:text-cyan-50">{keyStatement}</p>
         </div>
         <div className="mt-3 flex flex-wrap gap-2">
-          {categoryNode ? (
-            <span className="rounded-full border border-sky-300/40 bg-sky-500/10 px-3 py-1 text-sm text-[rgb(var(--fg))]">
-              Kategorie: {categoryNode.label}
-            </span>
-          ) : null}
-          <span className="rounded-full border border-emerald-300/40 bg-emerald-500/10 px-3 py-1 text-sm text-[rgb(var(--fg))]">
+          <span className="rounded-full border border-emerald-500/30 bg-emerald-50 px-3 py-1 text-sm text-emerald-950 dark:border-emerald-300/40 dark:bg-emerald-500/10 dark:text-emerald-50">
             Haltung: {resolveStanceLead(dominantStance)}
           </span>
-          <span className="rounded-full border border-amber-300/40 bg-amber-500/10 px-3 py-1 text-sm text-[rgb(var(--fg))]">
+          <span className="rounded-full border border-amber-500/35 bg-amber-50 px-3 py-1 text-sm text-amber-950 dark:border-amber-300/40 dark:bg-amber-500/10 dark:text-amber-50">
             Ebene: {resolveScopeLabel(scopeChip)}
           </span>
         </div>
       </div>
 
-      <div className="space-y-4 rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] px-3 py-3 md:px-4 md:py-4">
+      <div className="space-y-4 rounded-xl border border-slate-200 bg-white px-3 py-3 shadow-sm md:px-4 md:py-4 dark:border-[rgb(var(--border))] dark:bg-[rgb(var(--card))] dark:shadow-none">
         <p className="text-sm font-semibold text-[rgb(var(--fg))] md:text-base">{CREATE_VISUAL_FOLLOWUP_COPY.graphTitle}</p>
 
         <div className="space-y-3 md:hidden">
-          <div className="rounded-lg border border-cyan-300/35 bg-cyan-500/10 px-3 py-2 text-sm font-semibold text-cyan-100">
-            1. Dein Beitrag
-          </div>
+          <div className="rounded-lg border border-cyan-500/35 bg-cyan-50 px-3 py-2 text-sm font-semibold text-cyan-900 dark:border-cyan-300/35 dark:bg-cyan-500/10 dark:text-cyan-100">1. Dein Beitrag</div>
           <div className={`rounded-xl border px-3 py-2 ${resolveNodeTone(visualMap.center.kind)}`}>
-            <p className="text-sm font-semibold text-[rgb(var(--fg))]">{visualMap.center.label}</p>
-            <p className="mt-1 text-sm text-[rgb(var(--muted))]">{visualMap.center.detail}</p>
+            <p className="text-sm font-semibold">{visualMap.center.label}</p>
+            <p className="mt-1 text-sm opacity-80">{visualMap.center.detail}</p>
           </div>
-          <div className="rounded-lg border border-cyan-300/35 bg-cyan-500/10 px-3 py-2 text-sm font-semibold text-cyan-100">
-            2. Kern erkannt
+          <div className="rounded-lg border border-cyan-500/35 bg-cyan-50 px-3 py-2 text-sm font-semibold text-cyan-900 dark:border-cyan-300/35 dark:bg-cyan-500/10 dark:text-cyan-100">2. Kern erkannt</div>
+          <div className={`rounded-xl border px-3 py-2 ${resolveNodeTone("statement")}`}>
+            <p className="text-sm font-semibold">{keyStatement}</p>
           </div>
-          <div className="ml-3 border-l border-cyan-300/45 pl-3">
-            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">Erkannte Aussage</p>
-            <div className={`mt-2 rounded-xl border px-3 py-2 ${resolveNodeTone(statementNodes[0]?.kind ?? "statement")}`}>
-              <p className="text-sm font-semibold text-[rgb(var(--fg))]">{keyStatement}</p>
-            </div>
+          <div className="rounded-lg border border-cyan-500/35 bg-cyan-50 px-3 py-2 text-sm font-semibold text-cyan-900 dark:border-cyan-300/35 dark:bg-cyan-500/10 dark:text-cyan-100">3. Themen</div>
+          <div className="flex flex-wrap gap-2">
+            {topicNodes.map((node) => (
+              <span key={node.id} className={`rounded-full border px-2.5 py-1 text-sm ${resolveNodeTone(node.kind)}`}>
+                {node.label}
+              </span>
+            ))}
           </div>
-          <div className="rounded-lg border border-cyan-300/35 bg-cyan-500/10 px-3 py-2 text-sm font-semibold text-cyan-100">
-            3. Themen
-          </div>
-          <div className="ml-3 border-l border-cyan-300/45 pl-3">
-            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">Themen</p>
-            <div className="mt-2 flex flex-wrap gap-2">
-              {topicNodes.map((node) => (
-                <span key={node.id} className={`rounded-full border px-2 py-1 text-sm ${resolveNodeTone(node.kind)}`}>
-                  {node.label}
-                </span>
-              ))}
-            </div>
-          </div>
-          <div className="rounded-lg border border-cyan-300/35 bg-cyan-500/10 px-3 py-2 text-sm font-semibold text-cyan-100">
-            4. Anschluss
-          </div>
+          <div className="rounded-lg border border-cyan-500/35 bg-cyan-50 px-3 py-2 text-sm font-semibold text-cyan-900 dark:border-cyan-300/35 dark:bg-cyan-500/10 dark:text-cyan-100">4. Anschluss</div>
         </div>
 
         <div className="hidden md:block">
-          <div className="grid gap-4 xl:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]">
-            <div className="space-y-3">
-              <div className={`rounded-xl border px-4 py-3 ${resolveNodeTone(visualMap.center.kind)}`}>
-                <p className="text-sm font-semibold text-[rgb(var(--fg))]">Dein Beitrag</p>
-                <p className="mt-1 text-sm text-[rgb(var(--muted))]">{visualMap.center.detail}</p>
-              </div>
-              <div className="ml-6 border-l border-cyan-300/45 pl-4">
-                <div className={`rounded-xl border px-4 py-3 ${resolveNodeTone(statementNodes[0]?.kind ?? "statement")}`}>
-                  <p className="text-sm font-semibold text-[rgb(var(--fg))]">Kernforderung</p>
-                  <p className="mt-1 text-base font-semibold text-[rgb(var(--fg))]">{keyStatement}</p>
-                </div>
-                <div className="ml-6 mt-3 border-l border-violet-300/45 pl-4">
-                  <div className={`rounded-xl border px-4 py-3 ${resolveNodeTone(topicNodes[0]?.kind ?? "topic")}`}>
-                    <p className="text-sm font-semibold text-[rgb(var(--fg))]">Hauptthema</p>
-                    <p className="mt-1 text-base font-semibold text-[rgb(var(--fg))]">{rootTopic}</p>
-                  </div>
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    {branchTopics.map((node) => (
-                      <span key={node.id} className={`rounded-full border px-3 py-1 text-sm ${resolveNodeTone(node.kind)}`}>
-                        {node.label}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              </div>
+          <div className="space-y-3">
+            <div className={`max-w-2xl rounded-xl border px-4 py-3 ${resolveNodeTone("source_text")}`}>
+              <p className="text-sm font-semibold">Dein Beitrag</p>
+              <p className="mt-1 text-sm opacity-85">{visualMap.center.detail}</p>
             </div>
-            <div className="rounded-xl border border-blue-300/35 bg-blue-500/10 px-4 py-3">
-              <p className="text-sm font-semibold text-[rgb(var(--fg))]">{CREATE_VISUAL_FOLLOWUP_COPY.impactTitle}</p>
-              <div className="mt-3 grid gap-3 lg:grid-cols-2">
-                {connectionNodes.slice(0, 3).map((node, index) => (
-                  <article key={`${node.id}-${index}`} className={`rounded-xl border px-3 py-3 ${resolveNodeTone(node.kind)}`}>
-                    <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">
-                      {resolveSuggestionBadge(node.kind)}
-                    </p>
-                    <p className="mt-1 text-base font-semibold text-[rgb(var(--fg))]">{node.label}</p>
-                    {node.detail ? (
-                      <p className="mt-1 text-sm text-[rgb(var(--muted))]">Warum passt das? {node.detail}</p>
-                    ) : null}
-                    <div className="mt-3 flex flex-wrap gap-2">
-                      {node.kind === "new_anlassraum" ? (
-                        <button type="button" className="btn-secondary text-xs" onClick={onOpenNewAnlassraum}>
-                          {resolveSuggestionCta(node.kind)}
-                        </button>
-                      ) : (
-                        <Link href={ctaHref} className="btn-secondary text-xs">
-                          {resolveSuggestionCta(node.kind)}
-                        </Link>
-                      )}
-                      <button type="button" className="btn-secondary text-xs" onClick={() => openCorrection("Anschluss") }>
-                        Nicht passend
-                      </button>
-                    </div>
-                  </article>
-                ))}
+            <div className="ml-5 border-l-2 border-cyan-500/35 pl-4 dark:border-cyan-300/40">
+              <div className={`max-w-2xl rounded-xl border px-4 py-3 ${resolveNodeTone("statement")}`}>
+                <p className="text-sm font-semibold">Kernforderung</p>
+                <p className="mt-1 text-base font-semibold">{keyStatement}</p>
+              </div>
+              <div className="ml-6 mt-3 border-l-2 border-violet-500/30 pl-4 dark:border-violet-300/35">
+                <div className={`max-w-2xl rounded-xl border px-4 py-3 ${resolveNodeTone("topic")}`}>
+                  <p className="text-sm font-semibold">Hauptthema</p>
+                  <p className="mt-1 text-base font-semibold">{rootTopic}</p>
+                </div>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {branchTopics.map((node) => (
+                    <span key={node.id} className={`rounded-full border px-3 py-1 text-sm ${resolveNodeTone(node.kind)}`}>
+                      {node.label}
+                    </span>
+                  ))}
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
 
+      <div className="space-y-2 rounded-xl border border-slate-200 bg-white px-3 py-3 shadow-sm dark:border-[rgb(var(--border))] dark:bg-[rgb(var(--card))] dark:shadow-none">
+        <p className="text-sm font-semibold text-[rgb(var(--fg))] md:text-base">{CREATE_VISUAL_FOLLOWUP_COPY.impactTitle}</p>
+        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+          {sortedSuggestions.map((suggestion) => {
+            const href = buildCreateFollowupTargetHref({
+              kind: suggestion.kind,
+              ctaHref,
+              topics: result.understanding.topics,
+              statements: result.understanding.statements,
+              stance: suggestion.suggestedStance ?? null,
+              suggestionTitle: suggestion.title,
+              suggestionHref: suggestion.href ?? null,
+            });
+            const toneKind: CreateVisualNode["kind"] =
+              suggestion.kind === "dossier"
+                ? "dossier"
+                : suggestion.kind === "vote"
+                  ? "vote"
+                  : suggestion.kind === "anlassraum"
+                    ? "anlassraum"
+                    : suggestion.kind === "new_anlassraum"
+                      ? "new_anlassraum"
+                      : "topic";
+            return (
+              <article key={suggestion.id} className={`rounded-xl border px-3 py-3 ${resolveNodeTone(toneKind)}`}>
+                <p className="text-xs font-semibold uppercase tracking-[0.14em] opacity-80">{resolveSuggestionBadge(suggestion.kind)}</p>
+                <p className="mt-1 text-sm font-semibold md:text-base">{suggestion.title}</p>
+                <p className="mt-1 text-sm opacity-85">Warum passt das? {suggestion.reason}</p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {suggestion.kind === "new_anlassraum" ? (
+                    <button type="button" className="btn-secondary min-h-[40px] px-3 py-2 text-sm" onClick={onOpenNewAnlassraum}>
+                      {resolveSuggestionCta(suggestion.kind)}
+                    </button>
+                  ) : (
+                    <Link href={href} className="btn-secondary min-h-[40px] px-3 py-2 text-sm">
+                      {resolveSuggestionCta(suggestion.kind)}
+                    </Link>
+                  )}
+                  <button type="button" className="btn-secondary min-h-[40px] px-3 py-2 text-sm" onClick={() => openCorrection("Anschluss")}>
+                    Nicht passend
+                  </button>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      </div>
+
       {showSectionFlow ? (
-        <div className="space-y-3 rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] px-3 py-3">
-          <p className="text-sm font-semibold text-[rgb(var(--fg))] md:text-base">
-            Wir haben deinen Text in {sections.length} Teile gegliedert.
-          </p>
+        <div className="space-y-3 rounded-xl border border-slate-200 bg-white px-3 py-3 shadow-sm dark:border-[rgb(var(--border))] dark:bg-[rgb(var(--card))] dark:shadow-none">
+          <p className="text-sm font-semibold text-[rgb(var(--fg))] md:text-base">Wir haben deinen Text in {sections.length} Teile gegliedert.</p>
           <div className="space-y-2">
             {sections.map((section, sectionIndex) => (
               <details
                 key={section.id}
-                className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--bg))] px-3 py-2"
+                className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 dark:border-[rgb(var(--border))] dark:bg-[rgb(var(--bg))]"
                 open={sectionIndex === 0}
               >
                 <summary className="cursor-pointer text-sm font-semibold text-[rgb(var(--fg))] md:text-base">
@@ -361,9 +365,8 @@ export default function CreateVisualFollowup({
                 {section.statementLabel ? (
                   <p className="mt-2 text-sm text-[rgb(var(--muted))]"><span className="font-semibold text-[rgb(var(--fg))]">Erkannt als:</span> {section.statementLabel}</p>
                 ) : null}
-                {section.topicLabel ? <p className="mt-1 text-sm text-[rgb(var(--muted))]"><span className="font-semibold text-[rgb(var(--fg))]">Gehört zu:</span> {section.topicLabel}</p> : null}
-                {section.stanceLabel ? (
-                  <p className="mt-1 text-sm text-[rgb(var(--muted))]"><span className="font-semibold text-[rgb(var(--fg))]">Haltung:</span> {section.stanceLabel}</p>
+                {section.topicLabel ? (
+                  <p className="mt-1 text-sm text-[rgb(var(--muted))]"><span className="font-semibold text-[rgb(var(--fg))]">Gehört zu:</span> {section.topicLabel}</p>
                 ) : null}
                 {section.connectionLabel ? (
                   <p className="mt-1 text-sm text-[rgb(var(--muted))]"><span className="font-semibold text-[rgb(var(--fg))]">Möglicher Anschluss:</span> {section.connectionLabel}</p>
@@ -374,56 +377,22 @@ export default function CreateVisualFollowup({
         </div>
       ) : null}
 
-      <div className="space-y-2 rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] px-3 py-3 md:hidden">
-        <div className="rounded-lg border border-cyan-300/35 bg-cyan-500/10 px-3 py-2 text-sm font-semibold text-cyan-100">
-          5. Bestätigung
-        </div>
-        <p className="text-sm font-semibold text-[rgb(var(--fg))] md:text-base">{CREATE_VISUAL_FOLLOWUP_COPY.impactTitle}</p>
-        <div className="space-y-2">
-          {connectionNodes.slice(0, 3).map((node, index) => (
-            <article key={`${node.id}-mobile-${index}`} className={`rounded-xl border px-3 py-3 ${resolveNodeTone(node.kind)}`}>
-              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">{resolveSuggestionBadge(node.kind)}</p>
-              <p className="mt-1 text-sm font-semibold text-[rgb(var(--fg))]">{node.label}</p>
-              {node.detail ? <p className="mt-1 text-sm text-[rgb(var(--muted))]">Warum passt das? {node.detail}</p> : null}
-              <div className="mt-2 flex flex-wrap gap-2">
-                {node.kind === "new_anlassraum" ? (
-                  <button type="button" className="btn-secondary text-xs" onClick={onOpenNewAnlassraum}>
-                    {resolveSuggestionCta(node.kind)}
-                  </button>
-                ) : (
-                  <Link href={ctaHref} className="btn-secondary text-xs">
-                    {resolveSuggestionCta(node.kind)}
-                  </Link>
-                )}
-                <button type="button" className="btn-secondary text-xs" onClick={() => openCorrection("Anschluss") }>
-                  Nicht passend
-                </button>
-              </div>
-            </article>
-          ))}
-        </div>
-      </div>
-
-      <div className="space-y-3 rounded-xl border border-cyan-300/45 bg-[rgb(var(--card))] px-3 py-3">
+      <div className="space-y-3 rounded-xl border border-cyan-500/30 bg-white px-3 py-3 shadow-sm dark:border-cyan-300/45 dark:bg-[rgb(var(--card))] dark:shadow-none">
         <p className="text-sm font-semibold text-[rgb(var(--fg))] md:text-base">{CREATE_VISUAL_FOLLOWUP_COPY.confirmTitle}</p>
         <p className="text-sm text-[rgb(var(--muted))] md:text-base">
           Du kannst bestätigen, einzelne Punkte ändern oder erst passende Dossiers und Abstimmungen ansehen.
         </p>
         <div className="flex flex-wrap gap-2">
-          <button type="button" className="btn-primary text-xs" onClick={onConfirm}>
+          <button type="button" className="btn-primary min-h-[40px] px-3 py-2 text-sm" onClick={onConfirm}>
             Ja, so einordnen
           </button>
-          <button
-            type="button"
-            className="btn-secondary text-xs"
-            onClick={() => openCorrection("Thema")}
-          >
+          <button type="button" className="btn-secondary min-h-[40px] px-3 py-2 text-sm" onClick={() => openCorrection("Thema")}>
             Ein Thema stimmt nicht
           </button>
-          <Link href={ctaHref} className="btn-secondary text-xs">
+          <Link href={primaryActionHref} className="btn-secondary min-h-[40px] px-3 py-2 text-sm">
             Passende Dossiers ansehen
           </Link>
-          <button type="button" className="btn-secondary text-xs" onClick={onOpenNewAnlassraum}>
+          <button type="button" className="btn-secondary min-h-[40px] px-3 py-2 text-sm" onClick={onOpenNewAnlassraum}>
             Als neues Thema vorschlagen
           </button>
         </div>
@@ -438,7 +407,7 @@ export default function CreateVisualFollowup({
                   key={chip}
                   type="button"
                   className="rounded-full border border-[rgb(var(--border))] px-2 py-1 text-xs text-[rgb(var(--fg))] hover:border-cyan-300/60"
-                  onClick={() => onEdit()}
+                  onClick={onEdit}
                 >
                   {chip}
                 </button>
@@ -448,32 +417,33 @@ export default function CreateVisualFollowup({
         ) : null}
         <p className="text-xs text-[rgb(var(--muted))]">{CREATE_VISUAL_FOLLOWUP_COPY.guardrail}</p>
         {isConfirmed ? (
-          <p className="text-sm text-emerald-300">
+          <p className="text-sm text-emerald-700 dark:text-emerald-300">
             Einordnung bestätigt. Dein Beitrag ist noch nicht veröffentlicht. Wähle jetzt den nächsten Schritt.
           </p>
         ) : null}
         {actionNotice ? (
-          <p className="rounded-lg border border-cyan-300/35 bg-cyan-500/10 px-3 py-2 text-xs text-cyan-100">{actionNotice}</p>
+          <p className="rounded-lg border border-cyan-500/35 bg-cyan-50 px-3 py-2 text-xs text-cyan-900 dark:border-cyan-300/35 dark:bg-cyan-500/10 dark:text-cyan-100">
+            {actionNotice}
+          </p>
         ) : null}
       </div>
 
-      <div className="sticky bottom-3 z-10 rounded-xl border border-cyan-300/45 bg-[rgb(var(--card))]/95 px-3 py-3 shadow-lg shadow-black/20 backdrop-blur">
-        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-          <div>
-            <p className="text-sm font-semibold text-[rgb(var(--fg))]">{CREATE_VISUAL_FOLLOWUP_COPY.confirmTitle}</p>
-            <p className="text-xs text-[rgb(var(--muted))]">{CREATE_VISUAL_FOLLOWUP_COPY.guardrail}</p>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <button type="button" className="btn-primary text-xs" onClick={onConfirm}>
-              Ja, so einordnen
-            </button>
-            <button type="button" className="btn-secondary text-xs" onClick={() => openCorrection("Thema") }>
-              Ändern
-            </button>
-            <Link href={ctaHref} className="btn-secondary text-xs">
-              Dossiers ansehen
-            </Link>
-          </div>
+      <div className="sticky bottom-2 z-10 rounded-xl border border-cyan-500/30 bg-white/95 px-3 py-2 shadow-xl shadow-cyan-950/10 backdrop-blur md:hidden dark:border-cyan-300/45 dark:bg-[rgb(var(--card))]/95 dark:shadow-black/20">
+        <p className="text-sm font-semibold text-[rgb(var(--fg))]">{CREATE_VISUAL_FOLLOWUP_COPY.confirmTitle}</p>
+        <p className="text-xs text-[rgb(var(--muted))]">Keine automatische Stimme oder Veröffentlichung.</p>
+        <div className="mt-2 grid grid-cols-2 gap-2">
+          <button type="button" className="btn-primary min-h-[40px] px-2 py-2 text-sm" onClick={onConfirm}>
+            Ja, so einordnen
+          </button>
+          <button type="button" className="btn-secondary min-h-[40px] px-2 py-2 text-sm" onClick={() => openCorrection("Thema")}>
+            Ändern
+          </button>
+          <Link href={primaryActionHref} className="btn-secondary min-h-[40px] px-2 py-2 text-sm">
+            Dossiers & Abstimmungen
+          </Link>
+          <button type="button" className="btn-secondary min-h-[40px] px-2 py-2 text-sm" onClick={onOpenNewAnlassraum}>
+            Neues Thema
+          </button>
         </div>
       </div>
     </section>

--- a/apps/web/src/features/create/SharedCreateComposer.tsx
+++ b/apps/web/src/features/create/SharedCreateComposer.tsx
@@ -99,6 +99,7 @@ export type SharedCreateComposerProps = {
   heroHeadlineOverride?: CreateComposerHeadlineText;
   heroSublineOverride?: string;
   heroBadgeOverride?: string;
+  collapseModeSelector?: boolean;
 };
 
 export default function SharedCreateComposer({
@@ -136,6 +137,7 @@ export default function SharedCreateComposer({
   heroHeadlineOverride,
   heroSublineOverride,
   heroBadgeOverride,
+  collapseModeSelector = false,
 }: SharedCreateComposerProps) {
   const [attachments, setAttachments] = React.useState<File[]>([]);
   const [attachmentsError, setAttachmentsError] = React.useState<string | null>(null);
@@ -301,35 +303,75 @@ export default function SharedCreateComposer({
         />
 
         <div className="space-y-3">
-          <div aria-label={texts.modeSwitchAriaLabel} className="grid gap-2 md:grid-cols-3">
-            {modeOrder.map((modeOption) => {
-              const modeConfig = modeDefinitions[modeOption];
-              const isActive = modeOption === activeMode;
-              return (
-                <button
-                  key={modeOption}
-                  type="button"
-                  onClick={() => onModeChange(modeOption)}
-                  className={`rounded-2xl border px-3 py-2 text-left transition ${
-                    isActive
-                      ? "border-[rgb(var(--grad-from))]/45 bg-[rgb(var(--card))] text-[rgb(var(--fg))] shadow-sm"
-                      : "border-[rgb(var(--border))] bg-[rgb(var(--bg))] text-[rgb(var(--fg))] hover:border-[rgb(var(--grad-from))]/35"
-                  }`}
-                  aria-pressed={isActive}
-                  aria-selected={isActive}
-                >
-                  <span className="block text-sm font-semibold">{modeConfig.label}</span>
-                  <span
-                    className={`mt-1 block text-xs leading-relaxed ${
-                      isActive ? "text-[rgb(var(--fg))]" : "text-[rgb(var(--muted))]"
+          {collapseModeSelector ? (
+            <details className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] px-4 py-3">
+              <summary className="cursor-pointer text-[11px] font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">
+                Arbeitsweg wählen (optional)
+              </summary>
+              <p className="mt-2 text-sm leading-relaxed text-[rgb(var(--muted))]">
+                Ohne Auswahl startet eDebatte mit dem Standardfluss für Beiträge. Du kannst jederzeit zu Prüfen oder Entwerfen wechseln.
+              </p>
+              <div aria-label={texts.modeSwitchAriaLabel} className="mt-3 grid gap-2 md:grid-cols-3">
+                {modeOrder.map((modeOption) => {
+                  const modeConfig = modeDefinitions[modeOption];
+                  const isActive = modeOption === activeMode;
+                  return (
+                    <button
+                      key={modeOption}
+                      type="button"
+                      onClick={() => onModeChange(modeOption)}
+                      className={`rounded-2xl border px-3 py-2 text-left transition ${
+                        isActive
+                          ? "border-[rgb(var(--grad-from))]/45 bg-[rgb(var(--card))] text-[rgb(var(--fg))] shadow-sm"
+                          : "border-[rgb(var(--border))] bg-[rgb(var(--bg))] text-[rgb(var(--fg))] hover:border-[rgb(var(--grad-from))]/35"
+                      }`}
+                      aria-pressed={isActive}
+                      aria-selected={isActive}
+                    >
+                      <span className="block text-sm font-semibold">{modeConfig.label}</span>
+                      <span
+                        className={`mt-1 block text-xs leading-relaxed ${
+                          isActive ? "text-[rgb(var(--fg))]" : "text-[rgb(var(--muted))]"
+                        }`}
+                      >
+                        {modeConfig.description}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </details>
+          ) : (
+            <div aria-label={texts.modeSwitchAriaLabel} className="grid gap-2 md:grid-cols-3">
+              {modeOrder.map((modeOption) => {
+                const modeConfig = modeDefinitions[modeOption];
+                const isActive = modeOption === activeMode;
+                return (
+                  <button
+                    key={modeOption}
+                    type="button"
+                    onClick={() => onModeChange(modeOption)}
+                    className={`rounded-2xl border px-3 py-2 text-left transition ${
+                      isActive
+                        ? "border-[rgb(var(--grad-from))]/45 bg-[rgb(var(--card))] text-[rgb(var(--fg))] shadow-sm"
+                        : "border-[rgb(var(--border))] bg-[rgb(var(--bg))] text-[rgb(var(--fg))] hover:border-[rgb(var(--grad-from))]/35"
                     }`}
+                    aria-pressed={isActive}
+                    aria-selected={isActive}
                   >
-                    {modeConfig.description}
-                  </span>
-                </button>
-              );
-            })}
-          </div>
+                    <span className="block text-sm font-semibold">{modeConfig.label}</span>
+                    <span
+                      className={`mt-1 block text-xs leading-relaxed ${
+                        isActive ? "text-[rgb(var(--fg))]" : "text-[rgb(var(--muted))]"
+                      }`}
+                    >
+                      {modeConfig.description}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
           <p className="max-w-2xl text-sm leading-relaxed text-[rgb(var(--muted))]">{helperText}</p>
         </div>
 

--- a/apps/web/src/features/create/createConnectionSuggestions.ts
+++ b/apps/web/src/features/create/createConnectionSuggestions.ts
@@ -13,6 +13,26 @@ type BuildCreateConnectionSuggestionsInput = {
   maxSuggestions?: number;
 };
 
+function buildSeededSwipesHref(params: {
+  topic?: string | null;
+  claim?: string | null;
+  stance?: CreateConnectionSuggestion["suggestedStance"];
+}): string {
+  const search = new URLSearchParams();
+  if (params.topic) search.set("topic", params.topic);
+  if (params.claim) search.set("claim", params.claim);
+  if (params.stance) search.set("stance", params.stance);
+  search.set("from", "create");
+  return `/swipes?${search.toString()}`;
+}
+
+function buildSeededDossierHref(topic?: string | null): string {
+  const search = new URLSearchParams();
+  if (topic) search.set("topic", topic);
+  search.set("from", "create");
+  return `/dossier?${search.toString()}`;
+}
+
 function mapConfidence(score: number): "low" | "medium" | "high" {
   if (score >= 0.72) return "high";
   if (score >= 0.42) return "medium";
@@ -28,7 +48,7 @@ function mapVoteStance(value: CreateUnderstandingResult["statements"][number]["s
 
 function shouldSuggestVote(text: string): boolean {
   const normalized = text.toLowerCase();
-  return /abstimm|stimme|vot|entscheid|beschluss|ja\/nein/.test(normalized);
+  return /abstimm|stimme|vot|entscheid|beschluss|ja\/nein|option b|option c|option [a-z]/.test(normalized);
 }
 
 function resolveHumanConnectionTitle(topics: Array<{ label: string }>): string {
@@ -45,13 +65,51 @@ function resolveHumanConnectionTitle(topics: Array<{ label: string }>): string {
   return "Politische Verantwortung und Mindestanforderungen für Amtsträger";
 }
 
+function resolveDossierSuggestionTitle(topics: Array<{ label: string }>): string {
+  const lowered = topics.map((topic) => topic.label.toLowerCase()).join(" ");
+  if (/verantwort|amtstr[aä]ger|mandat/.test(lowered)) {
+    return "Politische Verantwortung öffentlicher Mandate";
+  }
+  if (/sanktion|qualifikation/.test(lowered)) {
+    return "Sanktionen und Qualifikation politischer Ämter";
+  }
+  return resolveHumanConnectionTitle(topics);
+}
+
+function resolveNewAnlassraumTitle(topics: Array<{ label: string }>): string {
+  const lowered = topics.map((topic) => topic.label.toLowerCase()).join(" ");
+  if (/sanktion|qualifikation|amtstr[aä]ger/.test(lowered)) {
+    return "Sanktionen und Qualifikation politischer Ämter";
+  }
+  if (/gesetz|gesetzgebung/.test(lowered)) {
+    return "Gesetzgebung und Verantwortung im Amt";
+  }
+  return resolveHumanConnectionTitle(topics);
+}
+
+function resolveVoteSuggestionTitle(params: {
+  topics: Array<{ label: string }>;
+  statementText?: string | null;
+}): string {
+  const lowered = params.topics.map((topic) => topic.label.toLowerCase()).join(" ");
+  if (/amtstr[aä]ger|qualifikation|sanktion/.test(lowered)) {
+    return "Mindestanforderungen und Konsequenzen für Amtsträger";
+  }
+  const statement = String(params.statementText ?? "").trim();
+  if (!statement) return "Mögliche Abstimmung aus deinem Beitrag";
+  return statement.length > 84 ? `${statement.slice(0, 81)}...` : statement;
+}
+
 export function buildCreateConnectionSuggestions(
   input: BuildCreateConnectionSuggestionsInput,
 ): CreateConnectionSuggestion[] {
   const suggestions: CreateConnectionSuggestion[] = [];
   const maxSuggestions = Math.max(2, Math.min(8, input.maxSuggestions ?? 5));
-  const topics = input.understanding.topics.slice(0, 2);
+  const topics = input.understanding.topics.slice(0, 3);
   const topStatement = input.understanding.statements[0];
+  const primaryTopic = topics[0]?.label ?? null;
+  const primaryClaim = topStatement?.text?.trim() || null;
+  const mappedStance = topStatement ? mapVoteStance(topStatement.stance) : null;
 
   if (input.dossierId) {
     suggestions.push({
@@ -62,7 +120,19 @@ export function buildCreateConnectionSuggestions(
       confidence: "high",
       href: `/dossier/${encodeURIComponent(input.dossierId)}`,
       suggestedContributionKind: input.understanding.categories[0]?.id ?? "hint",
-      suggestedStance: topStatement ? mapVoteStance(topStatement.stance) : null,
+      suggestedStance: mappedStance,
+      requiresConfirmation: true,
+    });
+  } else {
+    suggestions.push({
+      id: "dossier:auto",
+      kind: "dossier",
+      title: resolveDossierSuggestionTitle(topics),
+      reason: "Themen und Zuständigkeiten aus deinem Beitrag passen zu einem Dossier-Weiterlauf.",
+      confidence: input.understanding.confidence,
+      href: buildSeededDossierHref(primaryTopic),
+      suggestedContributionKind: input.understanding.categories[0]?.id ?? "hint",
+      suggestedStance: mappedStance,
       requiresConfirmation: true,
     });
   }
@@ -76,7 +146,7 @@ export function buildCreateConnectionSuggestions(
       confidence: "high",
       href: `/runden?view=active&anlassraumId=${encodeURIComponent(input.anlassraumId)}`,
       suggestedContributionKind: input.understanding.categories[0]?.id ?? "hint",
-      suggestedStance: topStatement ? mapVoteStance(topStatement.stance) : null,
+      suggestedStance: mappedStance,
       requiresConfirmation: true,
     });
   }
@@ -89,29 +159,43 @@ export function buildCreateConnectionSuggestions(
       title: topicalTitle,
       reason: "Thematische Nähe aus deinem Text erkannt.",
       confidence: topics[0].confidence,
-      href: `/swipes?topic=${encodeURIComponent(topics[0].label)}`,
+      href: buildSeededSwipesHref({
+        topic: topics[0].label,
+        claim: primaryClaim,
+        stance: mappedStance,
+      }),
       suggestedContributionKind: input.understanding.categories[0]?.id ?? "hint",
-      suggestedStance: topStatement ? mapVoteStance(topStatement.stance) : null,
+      suggestedStance: mappedStance,
       requiresConfirmation: true,
     });
   }
 
-  if (topStatement && shouldSuggestVote(input.text)) {
+  if (
+    topStatement &&
+    (shouldSuggestVote(input.text) ||
+      topStatement.kind === "demand" ||
+      topStatement.kind === "option" ||
+      topStatement.kind === "question")
+  ) {
     suggestions.push({
       id: `vote:${topStatement.id}`,
       kind: "vote",
-      title: `Mögliche Abstimmung: ${topStatement.text.slice(0, 72)}`,
-      reason: "Im Text ist ein abstimmungsnaher Bezug erkennbar.",
+      title: resolveVoteSuggestionTitle({ topics, statementText: topStatement.text }),
+      reason: "Die Aussage eignet sich als abstimmbarer Claim zur Einordnung im Themenkontext.",
       confidence: mapConfidence(topStatement.confidence === "high" ? 0.8 : topStatement.confidence === "medium" ? 0.55 : 0.3),
-      href: "/swipes",
+      href: buildSeededSwipesHref({
+        topic: primaryTopic,
+        claim: primaryClaim,
+        stance: mappedStance,
+      }),
       suggestedContributionKind: topStatement.kind,
-      suggestedStance: mapVoteStance(topStatement.stance),
+      suggestedStance: mappedStance,
       requiresConfirmation: true,
     });
   }
 
   if (suggestions.length < maxSuggestions) {
-    const fallbackTitle = resolveHumanConnectionTitle(topics);
+    const fallbackTitle = resolveNewAnlassraumTitle(topics);
     suggestions.push({
       id: "new_anlassraum:auto",
       kind: "new_anlassraum",
@@ -120,7 +204,7 @@ export function buildCreateConnectionSuggestions(
       confidence: input.understanding.confidence === "high" ? "medium" : "low",
       href: input.intent === "check" ? "/create?intent=check" : "/create?intent=contribute",
       suggestedContributionKind: input.understanding.categories[0]?.id ?? "hint",
-      suggestedStance: topStatement ? mapVoteStance(topStatement.stance) : null,
+      suggestedStance: mappedStance,
       requiresConfirmation: true,
     });
   }

--- a/apps/web/src/features/create/followupTargetHref.ts
+++ b/apps/web/src/features/create/followupTargetHref.ts
@@ -1,0 +1,111 @@
+import type {
+  CreateConnectionSuggestion,
+  CreateUnderstandingResult,
+} from "@/features/create/intelligentFollowupContract";
+
+type BuildCreateFollowupTargetHrefInput = {
+  kind: CreateConnectionSuggestion["kind"];
+  ctaHref: string;
+  topics: CreateUnderstandingResult["topics"];
+  statements: CreateUnderstandingResult["statements"];
+  stance?: CreateConnectionSuggestion["suggestedStance"] | null;
+  suggestionTitle?: string | null;
+  suggestionHref?: string | null;
+};
+
+function mapStatementStance(
+  stance: CreateUnderstandingResult["statements"][number]["stance"] | undefined,
+): "pro" | "contra" | "open" {
+  if (stance === "pro") return "pro";
+  if (stance === "contra") return "contra";
+  return "open";
+}
+
+function buildSwipesHref(params: {
+  topic?: string | null;
+  claim?: string | null;
+  stance?: string | null;
+}): string {
+  const search = new URLSearchParams();
+  if (params.topic) search.set("topic", params.topic);
+  if (params.claim) search.set("claim", params.claim);
+  if (params.stance) search.set("stance", params.stance);
+  search.set("from", "create");
+  return `/swipes?${search.toString()}`;
+}
+
+function buildDossierHref(topic?: string | null): string {
+  const search = new URLSearchParams();
+  if (topic) search.set("topic", topic);
+  search.set("from", "create");
+  return `/dossier?${search.toString()}`;
+}
+
+export function buildCreateFollowupTargetHref(input: BuildCreateFollowupTargetHrefInput): string {
+  if (input.suggestionHref && input.suggestionHref.trim()) {
+    return input.suggestionHref.trim();
+  }
+
+  const primaryTopic = input.topics[0]?.label?.trim() || null;
+  const primaryClaim =
+    input.statements[0]?.text?.trim() || (input.suggestionTitle ? input.suggestionTitle.trim() : null);
+  const statementStance = mapStatementStance(input.statements[0]?.stance);
+  const seedStance =
+    input.stance === "yes"
+      ? "pro"
+      : input.stance === "no"
+        ? "contra"
+        : input.stance === "abstain"
+          ? "open"
+          : statementStance;
+
+  if (input.kind === "dossier") {
+    return buildDossierHref(primaryTopic);
+  }
+  if (input.kind === "vote" || input.kind === "topic") {
+    return buildSwipesHref({
+      topic: primaryTopic,
+      claim: primaryClaim,
+      stance: seedStance,
+    });
+  }
+  if (input.kind === "new_anlassraum") {
+    const search = new URLSearchParams();
+    search.set("mode", "source");
+    if (primaryTopic) search.set("seedTopic", primaryTopic);
+    if (primaryClaim) search.set("seedClaim", primaryClaim);
+    return `/create?${search.toString()}`;
+  }
+  if (input.kind === "anlassraum") {
+    if (input.ctaHref && input.ctaHref.trim()) return input.ctaHref;
+    return buildSwipesHref({
+      topic: primaryTopic,
+      claim: primaryClaim,
+      stance: seedStance,
+    });
+  }
+
+  return input.ctaHref;
+}
+
+export function buildCreateFollowupPrimaryCtaHref(params: {
+  ctaHref: string;
+  topics: CreateUnderstandingResult["topics"];
+  statements: CreateUnderstandingResult["statements"];
+  suggestions: CreateConnectionSuggestion[];
+}): string {
+  const voteSuggestion = params.suggestions.find((item) => item.kind === "vote");
+  const topicSuggestion = params.suggestions.find((item) => item.kind === "topic");
+  const dossierSuggestion = params.suggestions.find((item) => item.kind === "dossier");
+  const preferred = voteSuggestion ?? topicSuggestion ?? dossierSuggestion ?? null;
+  if (!preferred) return params.ctaHref;
+  return buildCreateFollowupTargetHref({
+    kind: preferred.kind,
+    ctaHref: params.ctaHref,
+    topics: params.topics,
+    statements: params.statements,
+    stance: preferred.suggestedStance ?? null,
+    suggestionTitle: preferred.title,
+    suggestionHref: preferred.href ?? null,
+  });
+}

--- a/apps/web/src/features/surfaces/swipes/SwipesSurface.tsx
+++ b/apps/web/src/features/surfaces/swipes/SwipesSurface.tsx
@@ -4,6 +4,9 @@ import type { SurfaceContext } from "@/features/surface";
 type SwipesSurfaceProps = {
   context: SurfaceContext;
   initialTopic?: string;
+  initialClaim?: string;
+  initialStance?: string;
+  fromCreate?: boolean;
   fromDraftId?: string | null;
   requireAuthAfterFreeVotes?: boolean;
   showWelcomeHint?: boolean;
@@ -12,6 +15,9 @@ type SwipesSurfaceProps = {
 export function SwipesSurface({
   context,
   initialTopic = "",
+  initialClaim = "",
+  initialStance = "",
+  fromCreate = false,
   fromDraftId = null,
   requireAuthAfterFreeVotes = false,
   showWelcomeHint = false,
@@ -28,6 +34,9 @@ export function SwipesSurface({
       <div className="relative z-10">
         <SwipesClient
           initialTopic={initialTopic}
+          initialClaim={initialClaim}
+          initialStance={initialStance}
+          fromCreate={fromCreate}
           fromDraftId={fromDraftId}
           mode={context.mode}
           audience={context.audience}

--- a/apps/web/src/features/surfaces/swipes/discoveryContract.ts
+++ b/apps/web/src/features/surfaces/swipes/discoveryContract.ts
@@ -63,3 +63,56 @@ export function derivePreferredSwipeTopics(params: {
     .forEach((entry) => unique.add(entry));
   return [...unique].slice(0, 8);
 }
+
+type SeededSwipeMatch = {
+  items: SwipeItem[];
+  claimMatchCount: number;
+  topicMatchCount: number;
+};
+
+function hasClaimTextMatch(item: SwipeItem, claim: string): boolean {
+  const haystack = `${item.title} ${item.text ?? ""} ${item.category} ${item.domainLabel}`.toLowerCase();
+  return haystack.includes(claim.trim().toLowerCase());
+}
+
+function hasTopicTextMatch(item: SwipeItem, topic: string): boolean {
+  const haystack = buildTopicHaystack(item);
+  return haystack.includes(topic.trim().toLowerCase());
+}
+
+export function prioritizeSwipeItemsForCreateSeed(params: {
+  items: readonly SwipeItem[];
+  topic?: string;
+  claim?: string;
+}): SeededSwipeMatch {
+  const claim = (params.claim ?? "").trim();
+  const topic = (params.topic ?? "").trim();
+  if (!claim && !topic) {
+    return {
+      items: [...params.items],
+      claimMatchCount: 0,
+      topicMatchCount: 0,
+    };
+  }
+
+  const claimMatched: SwipeItem[] = [];
+  const topicMatched: SwipeItem[] = [];
+  const remainder: SwipeItem[] = [];
+  for (const item of params.items) {
+    if (claim && hasClaimTextMatch(item, claim)) {
+      claimMatched.push(item);
+      continue;
+    }
+    if (topic && hasTopicTextMatch(item, topic)) {
+      topicMatched.push(item);
+      continue;
+    }
+    remainder.push(item);
+  }
+
+  return {
+    items: [...claimMatched, ...topicMatched, ...remainder],
+    claimMatchCount: claimMatched.length,
+    topicMatchCount: topicMatched.length,
+  };
+}

--- a/apps/web/tests/analyze-workbench-hidden-until-start.test.ts
+++ b/apps/web/tests/analyze-workbench-hidden-until-start.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import {
   CREATE_INTELLIGENT_FOLLOWUP_SECTION_LABELS,
   buildCreateLightweightFollowupSnapshot,
@@ -228,5 +230,19 @@ describe("analyze workbench progressive disclosure", () => {
     });
     expect(order[0]).toBe("intelligent-followup");
     expect(order).not.toContain("followup-question");
+  });
+
+  it("keeps visual follow-up light/dark readable and sticky action wording", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "src/features/create/CreateVisualFollowup.tsx"),
+      "utf8",
+    );
+    expect(source).toContain("Dossiers & Abstimmungen");
+    expect(source).toContain("Keine automatische Stimme oder Veröffentlichung.");
+    expect(source).toContain("bg-cyan-50/80");
+    expect(source).toContain("dark:bg-cyan-500/10");
+    expect(source).toContain("border-cyan-500/35 bg-cyan-50 text-cyan-950");
+    expect(source).toContain("dark:border-cyan-300/60 dark:bg-cyan-500/15 dark:text-cyan-50");
+    expect(source).not.toContain('className="text-cyan-50"');
   });
 });

--- a/apps/web/tests/analyze-workbench-hidden-until-start.test.ts
+++ b/apps/web/tests/analyze-workbench-hidden-until-start.test.ts
@@ -239,10 +239,19 @@ describe("analyze workbench progressive disclosure", () => {
     );
     expect(source).toContain("Dossiers & Abstimmungen");
     expect(source).toContain("Keine automatische Stimme oder Veröffentlichung.");
+    expect(source).toContain("Keine automatische Kostenbuchung.");
     expect(source).toContain("bg-cyan-50/80");
     expect(source).toContain("dark:bg-cyan-500/10");
     expect(source).toContain("border-cyan-500/35 bg-cyan-50 text-cyan-950");
     expect(source).toContain("dark:border-cyan-300/60 dark:bg-cyan-500/15 dark:text-cyan-50");
     expect(source).not.toContain('className="text-cyan-50"');
+  });
+
+  it("keeps create entry mode selection optional instead of dominant first view", () => {
+    const clientSource = readFileSync(resolve(process.cwd(), "src/app/create/CreateClient.tsx"), "utf8");
+    const composerSource = readFileSync(resolve(process.cwd(), "src/features/create/SharedCreateComposer.tsx"), "utf8");
+    expect(clientSource).toContain("collapseModeSelector");
+    expect(composerSource).toContain("Arbeitsweg wählen (optional)");
+    expect(composerSource).toContain("Ohne Auswahl startet eDebatte mit dem Standardfluss");
   });
 });

--- a/apps/web/tests/create-intelligent-followup.contract.test.ts
+++ b/apps/web/tests/create-intelligent-followup.contract.test.ts
@@ -127,6 +127,15 @@ describe("create intelligent follow-up contract", () => {
     );
     expect(result.understanding.statements[0]?.stance).toBe("pro");
     expect(result.suggestions.some((item) => item.title.includes("Politische Verantwortung"))).toBe(true);
+    const dossierSuggestion = result.suggestions.find((item) => item.kind === "dossier");
+    const voteSuggestion = result.suggestions.find((item) => item.kind === "vote");
+    expect(dossierSuggestion?.href).toContain("/dossier?");
+    expect(dossierSuggestion?.href).toContain("topic=");
+    expect(voteSuggestion?.href).toContain("/swipes?");
+    expect(voteSuggestion?.href).toContain("topic=");
+    expect(voteSuggestion?.href).toContain("claim=");
+    expect(voteSuggestion?.href).toContain("from=create");
+    expect(voteSuggestion?.title).toContain("Mindestanforderungen");
     expect(result.suggestions.every((item) => item.requiresConfirmation)).toBe(true);
     const visualMap = buildCreateVisualMap(result);
     expect(visualMap.nodes.map((node) => node.label)).toEqual(
@@ -190,5 +199,8 @@ describe("create intelligent follow-up contract", () => {
     expect(voteSuggestion).toBeTruthy();
     expect(voteSuggestion?.requiresConfirmation).toBe(true);
     expect(voteSuggestion?.suggestedStance).toBeDefined();
+    expect(voteSuggestion?.href).toContain("/swipes?");
+    expect(voteSuggestion?.href).toContain("claim=");
+    expect(voteSuggestion?.href).toContain("from=create");
   });
 });

--- a/apps/web/tests/swipes-action-hierarchy.contract.test.ts
+++ b/apps/web/tests/swipes-action-hierarchy.contract.test.ts
@@ -21,6 +21,11 @@ describe("swipes action hierarchy contract", () => {
 
     expect(source).toContain("Quellenlage");
     expect(source).toContain("Mögliche Folgen");
+    expect(source).toContain("Aus deinem Beitrag");
+    expect(source).toContain("Dazu abstimmen");
+    expect(source).toContain("Erst ähnliche Positionen ansehen");
+    expect(source).toContain("Wir haben noch keine passende Abstimmung gefunden.");
+    expect(source).toContain("Keine automatische Stimme.");
     expect(detailSource).toContain("Varianten / mögliche Folgen");
     expect(detailSource).toContain("Quellenlage ansehen");
     expect(detailSource).not.toContain("Evidenz ansehen");

--- a/apps/web/tests/swipes-discovery.contract.test.ts
+++ b/apps/web/tests/swipes-discovery.contract.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   derivePreferredSwipeTopics,
   filterSwipeItemsByDiscoverySegment,
+  prioritizeSwipeItemsForCreateSeed,
   SWIPE_DISCOVERY_SEGMENTS,
 } from "@/features/surfaces/swipes/discoveryContract";
 import type { SwipeItem } from "@/features/swipes/types";
@@ -92,5 +93,16 @@ describe("swipes discovery contract", () => {
       segment: "all",
     });
     expect(all.map((item) => item.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("prioritizes claim/topic seeded items before general discovery", () => {
+    const seeded = prioritizeSwipeItemsForCreateSeed({
+      items: ITEMS,
+      topic: "Wohnen",
+      claim: "Mieten-Deckel",
+    });
+    expect(seeded.claimMatchCount).toBeGreaterThan(0);
+    expect(seeded.topicMatchCount).toBeGreaterThanOrEqual(0);
+    expect(seeded.items[0]?.id).toBe("b");
   });
 });


### PR DESCRIPTION
Implements #80: light-mode polish for the visual /create follow-up, mobile-first confirmation, freemium service framing, and claim/topic-seeded swipe handoff.

Validation:
- pnpm -C apps/web run typecheck ✅
- pnpm -C apps/web run lint ✅
- pnpm -C apps/web exec vitest run tests/create-intelligent-followup.contract.test.ts tests/create-intelligent-followup.route.test.ts tests/analyze-workbench-hidden-until-start.test.ts tests/swipes-discovery.contract.test.ts tests/swipes-action-hierarchy.contract.test.ts ✅