### PR TITLE
copy(dialog): refine dialog results perspective wording

### DIFF
--- a/apps/web/src/features/dialog/DialogResultsHandoffPanel.tsx
+++ b/apps/web/src/features/dialog/DialogResultsHandoffPanel.tsx
@@ -22,7 +22,7 @@ export type DialogResultsHandoffPanelProps = {
 };
 
 const HANDOFF_LABELS: Record<DialogHandoffTarget, string> = {
-  count_opinion: "Meinung zählen",
+  count_opinion: "Meine Meinung so erfassen",
   dossier_candidate: "Dossier vorbereiten",
   anlassraum_candidate: "Anlassraum vorbereiten",
   participation_space_candidate: "Beteiligungsraum vorbereiten",
@@ -57,28 +57,53 @@ function getIntentActions(outcome: DialogOutcome): Array<{
   const actions = [
     {
       id: "count_opinion_intent",
-      label: "Meinung zählen",
+      label: "Meine Meinung so erfassen",
       disabled: !canCountOpinion(outcome),
     },
     {
       id: "clarify_standpoint_intent",
-      label: "Standpunkt klären",
+      label: "Standpunkt präzisieren",
       disabled:
         outcome.resultStatus !== "needs_user_confirmation" &&
         outcome.resultStatus !== "draft",
     },
     {
       id: "perspective_review_intent",
-      label: "Perspektiven prüfen",
+      label: "Weitere Blickwinkel prüfen",
       disabled: getPerspectivePrompts(outcome).length === 0,
     },
     {
       id: "argumentation_intent",
-      label: "Argumentation ausarbeiten",
+      label: "Argumentation gemeinsam ausbauen",
       disabled:
         outcome.engagementMode === "count_only" &&
         outcome.arguments.length === 0 &&
         outcome.branches.length === 0,
+    },
+    {
+      id: "enrich_sources_intent",
+      label: "Quellen, Beispiele oder neue Aspekte ergänzen",
+      disabled: outcome.resultStatus === "rejected",
+    },
+    {
+      id: "branch_intent",
+      label: "Neuen Themenzweig vormerken",
+      disabled:
+        outcome.resultStatus === "rejected" ||
+        (getNewBranchSuggestions(outcome).length === 0 &&
+          outcome.engagementMode === "count_only"),
+    },
+    {
+      id: "handoff_intent",
+      label: "Dossier oder Anlassraum vorbereiten",
+      disabled:
+        outcome.resultStatus === "rejected" ||
+        !getDialogHandoffCandidates(outcome).some(
+          (candidate) =>
+            candidate.eligible &&
+            (candidate.target === "dossier_candidate" ||
+              candidate.target === "anlassraum_candidate"),
+        ),
     },
   ];
 
@@ -93,19 +118,19 @@ function renderBlockedReasons(reasons: string[]): string {
     return "Zuerst muss der Standpunkt bestätigt werden.";
   }
   if (reasons.includes("fact_claim_needs_source")) {
-    return "Vorher ist Quellenprüfung nötig.";
+    return "Bevor daraus mehr wird, sollten erst Quellen oder Beispiele ergänzt werden.";
   }
   if (reasons.includes("count_only_mode_limits_handoff")) {
-    return "Dieser Dialog bleibt vorerst beim Meinungsstand.";
+    return "Dieser Stand bleibt vorerst beim Meinungsbild und lässt sich später weiter ausbauen.";
   }
   if (reasons.includes("low_openness_limits_anlassraum")) {
-    return "Für Anlassraum-Vorbereitung braucht es mehr Klärung oder Offenheit.";
+    return "Für einen Anlassraum braucht es vorher noch mehr Klärung oder zusätzliche Bausteine.";
   }
   if (reasons.includes("count_only_mode_limits_participation_space")) {
-    return "Für einen Beteiligungsraum fehlt noch ein vertiefter Arbeitsstand.";
+    return "Für einen Beteiligungsraum fehlt noch ein weiter ausgearbeiteter Arbeitsstand.";
   }
   if (reasons.includes("reviewable_substance_required")) {
-    return "Es fehlt noch genug reviewbare Substanz.";
+    return "Hier fehlen noch nachvollziehbare Bausteine für einen belastbaren Review-Stand.";
   }
   if (reasons.includes("recognized_standpoint_missing")) {
     return "Es fehlt noch ein erkennbarer Standpunkt.";
@@ -158,6 +183,28 @@ export default function DialogResultsHandoffPanel({
 
       <div className="mt-4 space-y-3">
         <div className="rounded-2xl border border-slate-200/80 bg-[rgb(var(--bg))] px-4 py-3 dark:border-[rgb(var(--border))]">
+          <p className="text-sm leading-relaxed text-[rgb(var(--fg))]">
+            Wir versuchen deinen Standpunkt so zu verstehen, wie du ihn meinst.
+            Du kannst ihn einfach zählen lassen - oder gemeinsam mit eDebatte
+            weiter ausbauen.
+          </p>
+          <p className="mt-3 text-sm leading-relaxed text-[rgb(var(--muted))]">
+            Dabei geht es nicht darum, dich von einer anderen Meinung zu
+            überzeugen. Es geht darum, deinen Beitrag stärker zu machen: durch
+            klare Argumente, nachvollziehbare Beispiele, mögliche Gegenfragen,
+            weitere Blickwinkel und Hinweise auf Quellen oder Erfahrungen, die
+            du selbst einbringen möchtest.
+          </p>
+          <p className="mt-3 text-sm leading-relaxed text-[rgb(var(--muted))]">
+            Die Community entscheidet - und das stärkste Argument setzt sich
+            durch.
+          </p>
+          <p className="mt-2 text-xs font-medium text-[rgb(var(--muted))]">
+            eDebatte - lass das stärkste Argument gewinnen.
+          </p>
+        </div>
+
+        <div className="rounded-2xl border border-slate-200/80 bg-[rgb(var(--bg))] px-4 py-3 dark:border-[rgb(var(--border))]">
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[rgb(var(--muted))]">
             Erkannter Standpunkt
           </p>
@@ -191,7 +238,8 @@ export default function DialogResultsHandoffPanel({
               </ul>
             ) : (
               <p className="mt-2 text-sm text-[rgb(var(--muted))]">
-                Keine zusätzliche Rückfrage erzwungen.
+                Aktuell braucht es keine zusätzliche Rückfrage. Du kannst deine
+                Meinung auch einfach so erfassen lassen.
               </p>
             )}
           </div>
@@ -221,7 +269,7 @@ export default function DialogResultsHandoffPanel({
         <div className="grid gap-3 lg:grid-cols-2">
           <div className="rounded-2xl border border-slate-200/80 px-4 py-3 dark:border-[rgb(var(--border))]">
             <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[rgb(var(--muted))]">
-              Perspektiven
+              Weitere Blickwinkel
             </p>
             {perspectivePrompts.length > 0 ? (
               <div className="mt-2 space-y-2">
@@ -241,7 +289,9 @@ export default function DialogResultsHandoffPanel({
               </div>
             ) : (
               <p className="mt-2 text-sm text-[rgb(var(--muted))]">
-                Kein Perspektivenzwang. Dieser Stand kann auch ohne Gegenperspektiven nur als Meinung weitergeführt werden.
+                Weitere Blickwinkel sind ein Angebot, keine Pflicht. Du kannst
+                deine Meinung auch einfach so erfassen lassen oder später eigene
+                Beispiele, Quellen und Erfahrungen ergänzen.
               </p>
             )}
           </div>
@@ -268,7 +318,8 @@ export default function DialogResultsHandoffPanel({
               </div>
             ) : (
               <p className="mt-2 text-sm text-[rgb(var(--muted))]">
-                Keine neuen Zweige werden automatisch erstellt. Zusätzliche Themenäste bleiben nur Vorschlag oder Parkzustand.
+                Neue Themenzweige werden nicht automatisch erstellt. Zusätzliche
+                Aspekte bleiben nur als Vorschlag oder Vormerkung sichtbar.
               </p>
             )}
           </div>
@@ -294,7 +345,7 @@ export default function DialogResultsHandoffPanel({
                   </span>
                   <span className="mt-1 block text-[13px] leading-relaxed text-[rgb(var(--muted))]">
                     {candidate.eligible
-                      ? "Nur vorbereitend. Kein Auto-Create, kein Auto-Publish."
+                      ? "Nur vorbereitend. Kein Auto-Create, kein Auto-Publish, kein stiller Handoff."
                       : renderBlockedReasons(candidate.blockedReasons)}
                   </span>
                 </button>
@@ -303,7 +354,8 @@ export default function DialogResultsHandoffPanel({
           </div>
           {hasNeedsSourceClaim ? (
             <p className="mt-3 text-xs text-[rgb(var(--muted))]">
-              Faktische Claims bleiben bis zur Quellenprüfung reviewpflichtig.
+              Faktische Claims bleiben reviewpflichtig, bis du passende Quellen,
+              Beispiele oder weitere Nachweise ergänzt hast.
             </p>
           ) : null}
         </div>

--- a/apps/web/src/features/dialog/dialogIntelligenceFixtures.ts
+++ b/apps/web/src/features/dialog/dialogIntelligenceFixtures.ts
@@ -7,9 +7,11 @@ import type {
   DialogPerspective,
 } from "@/features/dialog/dialogIntelligenceContract";
 
-export const DIALOG_INTELLIGENCE_FIXTURES = {
+// Preview- und Test-Fixtures. Sie duerfen nicht als produktive
+// Dialoganalyse oder persistierter Nutzerstand gelesen werden.
+export const DIALOG_INTELLIGENCE_PREVIEW_FIXTURES = {
   countOnlyOpinion: {
-    id: "dialog-fixture-count-only",
+    id: "dialog-preview-fixture-count-only",
     topicTitle: "Verkehr vor Schulen",
     engagementMode: "count_only",
     userOpenness: "low",
@@ -27,7 +29,7 @@ export const DIALOG_INTELLIGENCE_FIXTURES = {
     handoffTargets: ["count_opinion", "editorial_review"],
   } satisfies DialogOutcome,
   clarifyStandpoint: {
-    id: "dialog-fixture-clarify",
+    id: "dialog-preview-fixture-clarify",
     topicTitle: "Kommunale Beteiligung",
     engagementMode: "clarify_standpoint",
     userOpenness: "medium",
@@ -79,7 +81,7 @@ export const DIALOG_INTELLIGENCE_FIXTURES = {
     ],
   } satisfies DialogOutcome,
   reviewReadySourceBlocked: {
-    id: "dialog-fixture-review-ready-source-blocked",
+    id: "dialog-preview-fixture-review-ready-source-blocked",
     topicTitle: "Beteiligungsraum mit Quellenprüfung",
     engagementMode: "prepare_dossier_or_space",
     userOpenness: "high",
@@ -333,7 +335,7 @@ export function buildDialogOutcomePreviewFromCreateFollowup(input: {
 }
 
 export function getDialogOutcomePreviewFixture(
-  key: keyof typeof DIALOG_INTELLIGENCE_FIXTURES,
+  key: keyof typeof DIALOG_INTELLIGENCE_PREVIEW_FIXTURES,
 ): DialogOutcome {
-  return DIALOG_INTELLIGENCE_FIXTURES[key];
+  return DIALOG_INTELLIGENCE_PREVIEW_FIXTURES[key];
 }

--- a/apps/web/tests/dialog-results-handoff-panel.test.tsx
+++ b/apps/web/tests/dialog-results-handoff-panel.test.tsx
@@ -4,7 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import DialogResultsHandoffPanel from "@/features/dialog/DialogResultsHandoffPanel";
 import {
-  DIALOG_INTELLIGENCE_FIXTURES,
+  DIALOG_INTELLIGENCE_PREVIEW_FIXTURES,
   buildDialogOutcomePreviewFromCreateFollowup,
 } from "@/features/dialog/dialogIntelligenceFixtures";
 import type { DialogOutcome } from "@/features/dialog/dialogIntelligenceContract";
@@ -56,9 +56,15 @@ function renderPanel(outcome: DialogOutcome): string {
 
 describe("dialog results handoff panel", () => {
   it("renders the result heading and recognized standpoint", () => {
-    const html = renderPanel(DIALOG_INTELLIGENCE_FIXTURES.clarifyStandpoint);
+    const html = renderPanel(DIALOG_INTELLIGENCE_PREVIEW_FIXTURES.clarifyStandpoint);
 
     expect(html).toContain("Was eDebatte bisher aus deinem Beitrag erkennt");
+    expect(html).toContain(
+      "Wir versuchen deinen Standpunkt so zu verstehen, wie du ihn meinst.",
+    );
+    expect(html).toContain(
+      "Du kannst ihn einfach zählen lassen - oder gemeinsam mit eDebatte weiter ausbauen.",
+    );
     expect(html).toContain("Erkannter Standpunkt");
     expect(html).toContain(
       "Der Beitrag fordert mehr Mitsprache, aber mit klaren Schutzregeln und nachvollziehbaren Zuständigkeiten.",
@@ -66,7 +72,7 @@ describe("dialog results handoff panel", () => {
   });
 
   it("shows the confirmation hint for needs_user_confirmation", () => {
-    const html = renderPanel(DIALOG_INTELLIGENCE_FIXTURES.clarifyStandpoint);
+    const html = renderPanel(DIALOG_INTELLIGENCE_PREVIEW_FIXTURES.clarifyStandpoint);
 
     expect(html).toContain(
       "Bitte bestätige, ob wir deinen Standpunkt richtig verstanden haben.",
@@ -75,21 +81,27 @@ describe("dialog results handoff panel", () => {
   });
 
   it("shows count-only / low openness without forcing perspectives", () => {
-    const html = renderPanel(DIALOG_INTELLIGENCE_FIXTURES.countOnlyOpinion);
+    const html = renderPanel(DIALOG_INTELLIGENCE_PREVIEW_FIXTURES.countOnlyOpinion);
 
-    expect(html).toContain("Meinung zählen");
+    expect(html).toContain("Meine Meinung so erfassen");
     expect(html).toContain(
-      "Kein Perspektivenzwang. Dieser Stand kann auch ohne Gegenperspektiven nur als Meinung weitergeführt werden.",
+      "Bitte bestätige, ob wir deinen Standpunkt richtig verstanden haben.",
+    );
+    expect(html).toContain(
+      "Weitere Blickwinkel sind ein Angebot, keine Pflicht. Du kannst deine Meinung auch einfach so erfassen lassen oder später eigene Beispiele, Quellen und Erfahrungen ergänzen.",
     );
     expect(html).not.toContain("Dossier vorbereiten");
   });
 
   it("shows perspective offers for medium and high openness", () => {
-    const html = renderPanel(DIALOG_INTELLIGENCE_FIXTURES.clarifyStandpoint);
+    const html = renderPanel(DIALOG_INTELLIGENCE_PREVIEW_FIXTURES.clarifyStandpoint);
 
-    expect(html).toContain("Perspektiven");
+    expect(html).toContain("Weitere Blickwinkel prüfen");
     expect(html).toContain("Institutionelle Sicht");
     expect(html).toContain("Soll die institutionelle Sicht Institutionelle Sicht als Kontext ergänzt werden?");
+    expect(html).toContain(
+      "Dabei geht es nicht darum, dich von einer anderen Meinung zu überzeugen.",
+    );
   });
 
   it("renders handoff candidates as preparatory and not as created or published", () => {
@@ -137,25 +149,31 @@ describe("dialog results handoff panel", () => {
     expect(html).toContain("Dossier vorbereiten");
     expect(html).toContain("Anlassraum vorbereiten");
     expect(html).toContain("Beteiligungsraum vorbereiten");
-    expect(html).toContain("Nur vorbereitend. Kein Auto-Create, kein Auto-Publish.");
+    expect(html).toContain(
+      "Nur vorbereitend. Kein Auto-Create, kein Auto-Publish, kein stiller Handoff.",
+    );
     expect(html).not.toContain("wurde erstellt");
     expect(html).not.toContain("wurde veröffentlicht");
   });
 
   it("shows factcheck / source review hints for needs_source claims", () => {
-    const html = renderPanel(DIALOG_INTELLIGENCE_FIXTURES.reviewReadySourceBlocked);
+    const html = renderPanel(DIALOG_INTELLIGENCE_PREVIEW_FIXTURES.reviewReadySourceBlocked);
 
     expect(html).toContain("Quellenprüfung vorbereiten");
-    expect(html).toContain("Faktische Claims bleiben bis zur Quellenprüfung reviewpflichtig.");
-    expect(html).toContain("Vorher ist Quellenprüfung nötig.");
+    expect(html).toContain(
+      "Faktische Claims bleiben reviewpflichtig, bis du passende Quellen, Beispiele oder weitere Nachweise ergänzt hast.",
+    );
+    expect(html).toContain(
+      "Bevor daraus mehr wird, sollten erst Quellen oder Beispiele ergänzt werden.",
+    );
   });
 
   it("blocks preparatory handoffs for rejected outcomes", () => {
     const rejectedOutcome: DialogOutcome = {
-      ...DIALOG_INTELLIGENCE_FIXTURES.clarifyStandpoint,
+      ...DIALOG_INTELLIGENCE_PREVIEW_FIXTURES.clarifyStandpoint,
       resultStatus: "rejected",
       recognizedStandpoint: {
-        ...DIALOG_INTELLIGENCE_FIXTURES.clarifyStandpoint.recognizedStandpoint,
+        ...DIALOG_INTELLIGENCE_PREVIEW_FIXTURES.clarifyStandpoint.recognizedStandpoint,
         confirmedByUser: false,
       },
     };
@@ -173,7 +191,7 @@ describe("dialog results handoff panel", () => {
     const onSelectHandoff = vi.fn();
 
     const element = DialogResultsHandoffPanel({
-      outcome: DIALOG_INTELLIGENCE_FIXTURES.clarifyStandpoint,
+      outcome: DIALOG_INTELLIGENCE_PREVIEW_FIXTURES.clarifyStandpoint,
       onConfirmStandpoint,
       onSelectPerspective,
       onSelectBranch,
@@ -183,7 +201,7 @@ describe("dialog results handoff panel", () => {
     findButtonByLabel(element, "Standpunkt bestätigen")?.props.onClick?.();
     findButtonByLabel(element, "Institutionelle Sicht")?.props.onClick?.();
     findButtonByLabel(element, "Pilotphase zuerst testen")?.props.onClick?.();
-    findButtonByLabel(element, "Meinung zählen")?.props.onClick?.();
+    findButtonByLabel(element, "Meine Meinung so erfassen")?.props.onClick?.();
 
     expect(onConfirmStandpoint).toHaveBeenCalledTimes(1);
     expect(onSelectPerspective).toHaveBeenCalledWith(
@@ -193,5 +211,15 @@ describe("dialog results handoff panel", () => {
       "dialog-fixture-clarify-branch",
     );
     expect(onSelectHandoff).toHaveBeenCalledWith("count_opinion");
+  });
+
+  it("includes the dialog slogan without claiming the community already decided", () => {
+    const html = renderPanel(DIALOG_INTELLIGENCE_PREVIEW_FIXTURES.clarifyStandpoint);
+
+    expect(html).toContain("eDebatte - lass das stärkste Argument gewinnen.");
+    expect(html).toContain(
+      "Die Community entscheidet - und das stärkste Argument setzt sich durch.",
+    );
+    expect(html).not.toContain("Die Community hat bereits entschieden");
   });
 });

--- a/docs/E150/DIALOG-RESULTS-HANDOFF-UI-02_2026-06-28.md
+++ b/docs/E150/DIALOG-RESULTS-HANDOFF-UI-02_2026-06-28.md
@@ -32,19 +32,19 @@ Die Komponente zeigt:
 - neue Zweige aus `getNewBranchSuggestions(...)`
 - review-first Handoff-Kandidaten aus `getDialogHandoffCandidates(...)`
 
-Zusätzlich gibt es `apps/web/src/features/dialog/dialogIntelligenceFixtures.ts` mit:
+Zusätzlich gibt es `apps/web/src/features/dialog/dialogIntelligenceFixtures.ts` mit klar als Preview-/Test-Fixtures markierten Beispielen:
 
 - `countOnlyOpinion`
 - `clarifyStandpoint`
 - `reviewReadySourceBlocked`
 
-und einen kleinen Preview-Adapter `buildDialogOutcomePreviewFromCreateFollowup(...)`, damit das Panel ohne neue Backend-/AI-Laufzeit im bestehenden Create-Follow-up gerendert werden kann.
+und einen kleinen Preview-Adapter `buildDialogOutcomePreviewFromCreateFollowup(...)`, damit das Panel ohne neue Backend-/AI-Laufzeit im bestehenden Create-Follow-up gerendert werden kann. Weder die Preview-Fixtures noch der Adapter dürfen als persistierte oder produktive Dialoganalyse gelesen werden; sie rahmen nur einen sichtbaren Vorschaustand im bestehenden Follow-up.
 
 ## Wie Meinung-zählen-ohne-Ausarbeitung sichtbar wird
 
 `count_only` bzw. `low openness` bleibt explizit als kleinerer Pfad sichtbar:
 
-- `Meinung zählen` ist als vorbereitender Schritt da
+- `Meine Meinung so erfassen` ist als vorbereitender Schritt da
 - Perspektiven werden nicht erzwungen
 - Dossier-/Anlassraum-/Participation-Space-Handoffs erscheinen nicht als schon erstellt
 
@@ -53,6 +53,7 @@ und einen kleinen Preview-Adapter `buildDialogOutcomePreviewFromCreateFollowup(.
 Das Panel bietet Perspektiven und Zweige nur optional an:
 
 - Perspektiven erscheinen als Angebot, nicht als Pflicht
+- sie sind als weitere Blickwinkel oder Gegenfragen gerahmt, nicht als Korrektur- oder Überzeugungsversuch
 - Zweige bleiben Vorschläge oder Parkzustände
 - offene Rückfragen bleiben sichtbar, ohne schon eine neue Runtime zu behaupten
 
@@ -66,6 +67,13 @@ Alle Handoff-Karten bleiben review-first:
 - `needs_source`-Claims verweisen sichtbar auf Quellenprüfung statt auf direkte Übernahme
 
 Die kleine Create-Integration sitzt in `apps/web/src/features/create/CreateVisualFollowup.tsx`. Sie nutzt nur den vorhandenen Follow-up-Stand und blendet das Panel als Preview unterhalb des bestehenden Arbeitsstands ein. `CreateClient.tsx` musste dafür nicht breit umgebaut werden.
+
+Das Wording wurde bewusst auf den Leitgedanken geschärft:
+
+- eDebatte versucht den Standpunkt ernsthaft so zu verstehen, wie er gemeint ist
+- Meinung zählen ohne Ausarbeitung bleibt sichtbar
+- weitere Blickwinkel, Quellen, Beispiele, Erfahrungen und neue Aspekte werden als ergänzbare Bausteine angeboten
+- `eDebatte - lass das stärkste Argument gewinnen` erscheint einmal als Leitgedanke, ohne schon eine fertige Community-Entscheidung zu behaupten
 
 ## Guardrails
 


### PR DESCRIPTION
Refines the Dialog Results handoff panel wording. Perspectives are now framed as optional offers, not corrections or persuasion attempts. Opinion capture without further elaboration remains visible. Authors can add sources, examples, experiences and new aspects. Preview fixtures are clearly marked and the runtime path does not present static demo outcomes as real analysis. Validation: typecheck, lint, focused dialog/create tests and build green.