### PR TITLE
fix(public): harden V3 public entry surfaces

### DIFF
--- a/apps/web/src/app/dossier/ui.tsx
+++ b/apps/web/src/app/dossier/ui.tsx
@@ -5,7 +5,9 @@ import Link from "next/link";
 import { CreateHandoffPanel } from "@/features/create/CreateHandoffPanel";
 import { useCreateHandoffDraft } from "@/features/create/useCreateHandoffDraft";
 import VoxyGuide from "@/components/voxy/VoxyGuide";
-import { getVoxyCopy } from "@/features/voxy/voxyCopy";
+
+const DOSSIER_VOXY_COPY =
+  "Ich zeige dir, was aus deinem Beitrag schon verständlich wird, welche Fragen offen bleiben und was vor einer Veröffentlichung geprüft werden muss.";
 
 function readableNextStepLabel(action?: string | null): string {
   switch (action) {
@@ -32,7 +34,7 @@ export default function DossierIndexClient(props: {
       <div className="public-reader-grid">
         <aside className="public-voxy-rail">
           <VoxyGuide appearance="compact" title="Voxy als Prüfhinweis" variant="hint">
-            {getVoxyCopy("dossier")}
+            {DOSSIER_VOXY_COPY}
           </VoxyGuide>
         </aside>
 

--- a/apps/web/src/app/dossier/ui.tsx
+++ b/apps/web/src/app/dossier/ui.tsx
@@ -2,12 +2,24 @@
 
 import * as React from "react";
 import Link from "next/link";
-import { CreateHandoffPanel } from "@/features/create/CreateHandoffPanel";
-import { useCreateHandoffDraft } from "@/features/create/useCreateHandoffDraft";
 import VoxyGuide from "@/components/voxy/VoxyGuide";
 
 const DOSSIER_VOXY_COPY =
   "Ich zeige dir, was aus deinem Beitrag schon verständlich wird, welche Fragen offen bleiben und was vor einer Veröffentlichung geprüft werden muss.";
+
+const HANDOFF_STORAGE_KEY = "edb_create_handoff_drafts_v1";
+
+type DossierHandoffPreview = {
+  id: string;
+  sourceText?: string;
+  resumeHref?: string;
+  plannerResult?: {
+    plannerTopic?: string;
+    plannerCore?: string;
+  };
+  openQuestions?: Array<{ id?: string; question?: string }>;
+  claims?: Array<{ id?: string; text?: string }>;
+};
 
 function readableNextStepLabel(action?: string | null): string {
   switch (action) {
@@ -22,12 +34,83 @@ function readableNextStepLabel(action?: string | null): string {
   }
 }
 
+function readPreviewFromStorage(handoffId: string | null | undefined): DossierHandoffPreview | null {
+  if (typeof window === "undefined") return null;
+  const normalized = String(handoffId ?? "").trim();
+  if (!normalized) return null;
+  try {
+    const raw = window.sessionStorage.getItem(HANDOFF_STORAGE_KEY);
+    if (!raw) return null;
+    const store = JSON.parse(raw) as Record<string, DossierHandoffPreview>;
+    const preview = store?.[normalized];
+    return preview && typeof preview === "object" ? preview : null;
+  } catch {
+    return null;
+  }
+}
+
+function DossierHandoffPreviewCard({ preview }: { preview: DossierHandoffPreview }) {
+  const title = preview.plannerResult?.plannerCore?.trim() || preview.plannerResult?.plannerTopic?.trim() || "Aus deinem Beitrag vorbereitet";
+  const topic = preview.plannerResult?.plannerTopic?.trim();
+  const questions = (preview.openQuestions ?? []).filter((item) => item.question?.trim()).slice(0, 3);
+  const claims = (preview.claims ?? []).filter((item) => item.text?.trim()).slice(0, 3);
+
+  return (
+    <section className="rounded-3xl border border-cyan-200/70 bg-[rgb(var(--card))] px-4 py-4 shadow-[0_18px_42px_rgba(2,6,23,0.06)] dark:border-cyan-300/20">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[rgb(var(--muted))]">Aus deinem Beitrag vorbereitet</p>
+      <h2 className="mt-1 text-lg font-semibold text-[rgb(var(--fg))]">{title}</h2>
+      {topic ? <p className="mt-1 text-sm text-[rgb(var(--muted))]">Thema: {topic}</p> : null}
+      {preview.sourceText ? (
+        <p className="mt-3 text-sm leading-6 text-[rgb(var(--muted))]">{preview.sourceText}</p>
+      ) : null}
+
+      <div className="mt-4 grid gap-3 md:grid-cols-2">
+        <div className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] p-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">Kernaussagen</p>
+          {claims.length > 0 ? (
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-[rgb(var(--fg))]">
+              {claims.map((claim, index) => <li key={claim.id ?? index}>{claim.text}</li>)}
+            </ul>
+          ) : (
+            <p className="mt-2 text-sm text-[rgb(var(--muted))]">Noch keine Kernaussagen übernommen.</p>
+          )}
+        </div>
+        <div className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] p-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">Offene Fragen</p>
+          {questions.length > 0 ? (
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-[rgb(var(--fg))]">
+              {questions.map((question, index) => <li key={question.id ?? index}>{question.question}</li>)}
+            </ul>
+          ) : (
+            <p className="mt-2 text-sm text-[rgb(var(--muted))]">Noch keine offenen Fragen übernommen.</p>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {preview.resumeHref ? (
+          <Link href={preview.resumeHref} className="btn-secondary min-h-[42px] px-3 py-2 text-sm">
+            Beitrag weiter bearbeiten
+          </Link>
+        ) : null}
+        <Link href="/community/contributions" className="btn-secondary min-h-[42px] px-3 py-2 text-sm">
+          Zur Prüfung
+        </Link>
+      </div>
+    </section>
+  );
+}
+
 export default function DossierIndexClient(props: {
   handoffId?: string | null;
   createAction?: string | null;
   seedTopic?: string | null;
 }) {
-  const draft = useCreateHandoffDraft(props.handoffId ?? null);
+  const [preview, setPreview] = React.useState<DossierHandoffPreview | null>(null);
+
+  React.useEffect(() => {
+    setPreview(readPreviewFromStorage(props.handoffId));
+  }, [props.handoffId]);
 
   return (
     <div className="public-shell mx-auto w-full px-4 py-8 sm:px-6 sm:py-10">
@@ -47,17 +130,9 @@ export default function DossierIndexClient(props: {
             </p>
           </div>
 
-          {draft ? (
+          {preview ? (
             <div className="public-proof-zone mt-5 space-y-3">
-              <CreateHandoffPanel draft={draft} title="Aus deinem Beitrag vorbereitet" />
-              <div className="flex flex-wrap gap-2">
-                <Link href="/community/contributions" className="btn-secondary min-h-[42px] px-3 py-2 text-sm">
-                  Redaktionell prüfen lassen
-                </Link>
-                <Link href="/create" className="btn-secondary min-h-[42px] px-3 py-2 text-sm">
-                  Beitrag weiter bearbeiten
-                </Link>
-              </div>
+              <DossierHandoffPreviewCard preview={preview} />
             </div>
           ) : (
             <div className="public-dialog-surface mt-5 space-y-4 px-4 py-5">

--- a/apps/web/src/app/dossier/ui.tsx
+++ b/apps/web/src/app/dossier/ui.tsx
@@ -38,10 +38,10 @@ export default function DossierIndexClient(props: {
 
         <div className="public-dialog-area">
           <div className="public-section space-y-2">
-            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[rgb(var(--muted))]">Vorbereiteter Beitrag</p>
-            <h1 className="text-2xl font-semibold text-[rgb(var(--fg))]">Dossier vorbereiten</h1>
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[rgb(var(--muted))]">Dossier-Vorbereitung</p>
+            <h1 className="text-2xl font-semibold text-[rgb(var(--fg))]">Aus einem Beitrag wird ein prüfbarer Arbeitsstand.</h1>
             <p className="text-sm text-[rgb(var(--muted))]">
-              Hier wird nichts automatisch an ein bestehendes Dossier angehängt. Der Arbeitsstand bleibt reviewbar und bestaetigungspflichtig.
+              Ein Dossier bündelt Anliegen, prüfbare Aussagen, Quellenfragen, Gegenpositionen, Zuständigkeit und offene Punkte. Nichts wird automatisch veröffentlicht oder an bestehende Dossiers angehängt.
             </p>
           </div>
 
@@ -53,21 +53,44 @@ export default function DossierIndexClient(props: {
                   Redaktionell prüfen lassen
                 </Link>
                 <Link href="/create" className="btn-secondary min-h-[42px] px-3 py-2 text-sm">
-                  Zurück zu /create
+                  Beitrag weiter bearbeiten
                 </Link>
               </div>
             </div>
           ) : (
-            <div className="public-dialog-surface mt-5 px-4 py-5">
-              <p className="text-sm text-[rgb(var(--muted))]">
-                Noch kein vorbereiteter Beitrag gefunden.
-                {props.seedTopic ? ` Themenhinweis: ${props.seedTopic}.` : ""}
-              </p>
+            <div className="public-dialog-surface mt-5 space-y-4 px-4 py-5">
+              <div className="space-y-2">
+                <p className="text-sm font-semibold text-[rgb(var(--fg))]">
+                  Noch kein Dossier-Entwurf geöffnet.
+                </p>
+                <p className="text-sm leading-6 text-[rgb(var(--muted))]">
+                  Starte mit einem kurzen Beitrag. eDebatte kann daraus eine erste Struktur vorbereiten: Was ist die Kernfrage, welche Aussagen sind prüfbar, welche Belege fehlen und welche Gegenpositionen sollten sichtbar werden?
+                  {props.seedTopic ? ` Themenhinweis: ${props.seedTopic}.` : ""}
+                </p>
+              </div>
+              <div className="grid gap-2 text-sm text-[rgb(var(--muted))] sm:grid-cols-2">
+                <div className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-3">
+                  <strong className="block text-[rgb(var(--fg))]">Was entsteht?</strong>
+                  Beitrag, Claims, Quellenfragen, offene Punkte und nächster Review-Schritt.
+                </div>
+                <div className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-3">
+                  <strong className="block text-[rgb(var(--fg))]">Was passiert nicht?</strong>
+                  Keine automatische Veröffentlichung, keine automatische Anheftung, keine Entscheidung ohne Prüfung.
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Link href="/create?intent=create_dossier" className="btn-primary min-h-[42px] px-3 py-2 text-sm">
+                  Beitrag für Dossier starten
+                </Link>
+                <Link href="/themen" className="btn-secondary min-h-[42px] px-3 py-2 text-sm">
+                  Beispielthemen ansehen
+                </Link>
+              </div>
             </div>
           )}
 
           <div className="public-flow-line mt-5 px-0 pt-4 text-sm text-[rgb(var(--muted))]">
-            Nächster Schritt: {readableNextStepLabel(props.createAction)} · Keine automatische Anheftung an bestehende Dossiers ohne Bestätigung.
+            Nächster Schritt: {readableNextStepLabel(props.createAction)} · Veröffentlichung oder Verknüpfung erfolgt erst nach bewusster Bestätigung.
           </div>
         </div>
       </div>

--- a/apps/web/src/app/dossier/ui.tsx
+++ b/apps/web/src/app/dossier/ui.tsx
@@ -10,9 +10,9 @@ import { getVoxyCopy } from "@/features/voxy/voxyCopy";
 function readableNextStepLabel(action?: string | null): string {
   switch (action) {
     case "append_to_dossier":
-      return "Dossier ergänzen";
+      return "Zusammenfassung ergänzen";
     case "create_dossier":
-      return "Neues Dossier vorbereiten";
+      return "Neue Themen-Zusammenfassung vorbereiten";
     case "request_factcheck":
       return "Prüfung vorbereiten";
     default:
@@ -38,10 +38,10 @@ export default function DossierIndexClient(props: {
 
         <div className="public-dialog-area">
           <div className="public-section space-y-2">
-            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[rgb(var(--muted))]">Dossier-Vorbereitung</p>
-            <h1 className="text-2xl font-semibold text-[rgb(var(--fg))]">Aus einem Beitrag wird ein prüfbarer Arbeitsstand.</h1>
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[rgb(var(--muted))]">Themen-Zusammenfassung</p>
+            <h1 className="text-2xl font-semibold text-[rgb(var(--fg))]">Aus deinem Beitrag wird ein verständlicher Überblick.</h1>
             <p className="text-sm text-[rgb(var(--muted))]">
-              Ein Dossier bündelt Anliegen, prüfbare Aussagen, Quellenfragen, Gegenpositionen, Zuständigkeit und offene Punkte. Nichts wird automatisch veröffentlicht oder an bestehende Dossiers angehängt.
+              Eine Themen-Zusammenfassung bündelt Anliegen, prüfbare Aussagen, Quellenfragen, Gegenpositionen, Zuständigkeit und offene Punkte. Nichts wird automatisch veröffentlicht oder irgendwo angehängt.
             </p>
           </div>
 
@@ -61,7 +61,7 @@ export default function DossierIndexClient(props: {
             <div className="public-dialog-surface mt-5 space-y-4 px-4 py-5">
               <div className="space-y-2">
                 <p className="text-sm font-semibold text-[rgb(var(--fg))]">
-                  Noch kein Dossier-Entwurf geöffnet.
+                  Noch keine Themen-Zusammenfassung geöffnet.
                 </p>
                 <p className="text-sm leading-6 text-[rgb(var(--muted))]">
                   Starte mit einem kurzen Beitrag. eDebatte kann daraus eine erste Struktur vorbereiten: Was ist die Kernfrage, welche Aussagen sind prüfbar, welche Belege fehlen und welche Gegenpositionen sollten sichtbar werden?
@@ -71,16 +71,16 @@ export default function DossierIndexClient(props: {
               <div className="grid gap-2 text-sm text-[rgb(var(--muted))] sm:grid-cols-2">
                 <div className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-3">
                   <strong className="block text-[rgb(var(--fg))]">Was entsteht?</strong>
-                  Beitrag, Claims, Quellenfragen, offene Punkte und nächster Review-Schritt.
+                  Beitrag, Kernaussagen, Quellenfragen, offene Punkte und nächster Prüfschritt.
                 </div>
                 <div className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-3">
                   <strong className="block text-[rgb(var(--fg))]">Was passiert nicht?</strong>
-                  Keine automatische Veröffentlichung, keine automatische Anheftung, keine Entscheidung ohne Prüfung.
+                  Keine automatische Veröffentlichung, keine automatische Verknüpfung, keine Entscheidung ohne Prüfung.
                 </div>
               </div>
               <div className="flex flex-wrap gap-2">
                 <Link href="/create?intent=create_dossier" className="btn-primary min-h-[42px] px-3 py-2 text-sm">
-                  Beitrag für Dossier starten
+                  Beitrag zusammenfassen lassen
                 </Link>
                 <Link href="/themen" className="btn-secondary min-h-[42px] px-3 py-2 text-sm">
                   Beispielthemen ansehen

--- a/apps/web/src/app/runden/new/AnlassraumPrePublishCheck.tsx
+++ b/apps/web/src/app/runden/new/AnlassraumPrePublishCheck.tsx
@@ -26,7 +26,7 @@ export default function AnlassraumPrePublishCheck(
       <div className="space-y-2">
         <h2 className="text-xl font-semibold text-[rgb(var(--fg))]">Nächste Schritte</h2>
         <p className="max-w-3xl text-sm leading-6 text-[rgb(var(--muted))]">
-          Prüfe den Entwurf zum Schluss noch einmal. Danach kannst du direkt speichern, Voxy drüberschauen lassen oder ihn bewusst zur Prüfung einreichen.
+          Prüfe den Entwurf zum Schluss noch einmal. Danach kannst du ohne Voxy speichern, mit Voxy strukturieren oder ihn bewusst zur Prüfung einreichen.
         </p>
       </div>
 
@@ -56,7 +56,7 @@ export default function AnlassraumPrePublishCheck(
               Voxy
             </p>
             <p className="mt-1 text-sm font-semibold text-[rgb(var(--fg))]">
-              {props.setup.aiSupportMode === "disabled" ? "Nicht ausgewählt" : "Optional ausgewählt"}
+              {props.setup.aiSupportMode === "disabled" ? "Ohne Voxy" : "Mit Voxy"}
             </p>
           </div>
         </div>
@@ -80,7 +80,7 @@ export default function AnlassraumPrePublishCheck(
           disabled={!props.actionState.canSaveDraft || actionDisabled}
           className="vog-btn-brand disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {props.isSaving ? "Speichert..." : "Direkt speichern"}
+          {props.isSaving ? "Speichert..." : "Ohne Voxy"}
         </button>
         <Link
           href={props.continueCreateHref}
@@ -93,7 +93,7 @@ export default function AnlassraumPrePublishCheck(
           aria-disabled={!props.actionState.canContinueCreate || actionDisabled}
           data-continue-create-href={props.continueCreateHref}
         >
-          Voxy drüberschauen lassen
+          Mit Voxy
         </Link>
         <button
           type="button"
@@ -101,7 +101,7 @@ export default function AnlassraumPrePublishCheck(
           disabled={!props.actionState.canSubmitPublicReview || actionDisabled}
           className="vog-btn-secondary disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {props.isSaving ? "Speichert..." : "Zur Prüfung einreichen"}
+          {props.isSaving ? "Speichert..." : "Zur Prüfung"}
         </button>
         <button
           type="button"

--- a/apps/web/src/app/runden/new/AnlassraumPrePublishCheck.tsx
+++ b/apps/web/src/app/runden/new/AnlassraumPrePublishCheck.tsx
@@ -26,8 +26,7 @@ export default function AnlassraumPrePublishCheck(
       <div className="space-y-2">
         <h2 className="text-xl font-semibold text-[rgb(var(--fg))]">Nächste Schritte</h2>
         <p className="max-w-3xl text-sm leading-6 text-[rgb(var(--muted))]">
-          Prüfe den Entwurf zum Schluss noch einmal. Danach kannst du ihn ohne KI speichern, in `/create`
-          weiter ausarbeiten oder bewusst nach Review einreichen.
+          Prüfe den Entwurf zum Schluss noch einmal. Danach kannst du direkt speichern, Voxy drüberschauen lassen oder ihn bewusst zur Prüfung einreichen.
         </p>
       </div>
 
@@ -46,7 +45,7 @@ export default function AnlassraumPrePublishCheck(
           </div>
           <div className="rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-3">
             <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">
-              Feste Optionen
+              Antwortmöglichkeiten
             </p>
             <p className="mt-1 text-sm font-semibold text-[rgb(var(--fg))]">
               {props.actionState.optionCount}
@@ -54,10 +53,10 @@ export default function AnlassraumPrePublishCheck(
           </div>
           <div className="rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-3">
             <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">
-              KI
+              Voxy
             </p>
             <p className="mt-1 text-sm font-semibold text-[rgb(var(--fg))]">
-              {props.setup.aiSupportMode === "disabled" ? "Aus" : "Optional später"}
+              {props.setup.aiSupportMode === "disabled" ? "Nicht ausgewählt" : "Optional ausgewählt"}
             </p>
           </div>
         </div>
@@ -81,7 +80,7 @@ export default function AnlassraumPrePublishCheck(
           disabled={!props.actionState.canSaveDraft || actionDisabled}
           className="vog-btn-brand disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {props.isSaving ? "Speichert..." : "Ohne KI speichern"}
+          {props.isSaving ? "Speichert..." : "Direkt speichern"}
         </button>
         <Link
           href={props.continueCreateHref}
@@ -94,7 +93,7 @@ export default function AnlassraumPrePublishCheck(
           aria-disabled={!props.actionState.canContinueCreate || actionDisabled}
           data-continue-create-href={props.continueCreateHref}
         >
-          Mit KI in /create weiter
+          Voxy drüberschauen lassen
         </Link>
         <button
           type="button"
@@ -102,7 +101,7 @@ export default function AnlassraumPrePublishCheck(
           disabled={!props.actionState.canSubmitPublicReview || actionDisabled}
           className="vog-btn-secondary disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {props.isSaving ? "Speichert..." : "Öffentlich nach Review einreichen"}
+          {props.isSaving ? "Speichert..." : "Zur Prüfung einreichen"}
         </button>
         <button
           type="button"
@@ -110,7 +109,7 @@ export default function AnlassraumPrePublishCheck(
           disabled={!props.actionState.canStartInternal || actionDisabled}
           className="vog-btn-secondary disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {props.isSaving ? "Speichert..." : "Intern starten"}
+          {props.isSaving ? "Speichert..." : "Intern behalten"}
         </button>
       </div>
     </section>

--- a/apps/web/src/app/runden/new/AnlassraumSetupForm.tsx
+++ b/apps/web/src/app/runden/new/AnlassraumSetupForm.tsx
@@ -41,7 +41,7 @@ const MANUAL_STEP_SUMMARY = [
   { id: "rahmen", label: "Rahmen", lead: "Titel, Leitfrage, Kurzbeschreibung" },
   { id: "optionen", label: "Antworten", lead: "Feste Antworten und Vorschläge aus der Community" },
   { id: "sichtbarkeit", label: "Sichtbarkeit", lead: "Intern behalten, später teilen oder prüfen lassen" },
-  { id: "unterstuetzung", label: "Start", lead: "Direkt speichern oder Voxy drüberschauen lassen" },
+  { id: "unterstuetzung", label: "Start", lead: "Ohne Voxy speichern oder mit Voxy strukturieren" },
 ] as const;
 
 function joinClasses(...values: Array<string | false | null | undefined>) {
@@ -286,12 +286,12 @@ export default function AnlassraumSetupForm({
       if (!result.ok) {
         if (result.error === "not_authenticated") {
           setActionNotice(
-            "Zum Weiterarbeiten mit Voxy bitte zuerst anmelden. Dein Entwurf bleibt lokal gespeichert; es wurde nichts veröffentlicht.",
+            "Zum Arbeiten mit Voxy bitte zuerst anmelden. Dein Entwurf bleibt lokal gespeichert; es wurde nichts veröffentlicht.",
           );
           return;
         }
         setActionNotice(
-          "Der Entwurf konnte nicht gespeichert werden. Bitte speichere oder öffne ihn erneut, bevor Voxy drüberschaut. Es wurde nichts veröffentlicht.",
+          "Der Entwurf konnte nicht gespeichert werden. Bitte speichere oder öffne ihn erneut, bevor du mit Voxy weiterarbeitest. Es wurde nichts veröffentlicht.",
         );
         return;
       }
@@ -307,7 +307,7 @@ export default function AnlassraumSetupForm({
       );
     } catch {
       setActionNotice(
-        "Der Entwurf konnte nicht gespeichert werden. Bitte speichere oder öffne ihn erneut, bevor Voxy drüberschaut. Es wurde nichts veröffentlicht.",
+        "Der Entwurf konnte nicht gespeichert werden. Bitte speichere oder öffne ihn erneut, bevor du mit Voxy weiterarbeitest. Es wurde nichts veröffentlicht.",
       );
     } finally {
       setIsPersisting(false);
@@ -337,11 +337,11 @@ export default function AnlassraumSetupForm({
               <span className="public-gradient-text">Schritt für Schritt</span> vor.
             </h1>
             <p className="public-hero-lead mt-3 max-w-3xl">
-              Lege Thema, Frage, mögliche Antworten und Sichtbarkeit zuerst selbst fest. Danach kannst du direkt speichern oder Voxy drüberschauen lassen.
+              Lege Thema, Frage, mögliche Antworten und Sichtbarkeit zuerst selbst fest. Danach kannst du ohne Voxy speichern oder mit Voxy strukturieren.
             </p>
             <div className="mt-4 flex flex-wrap gap-2 text-sm text-[rgb(var(--muted))]">
               <span className="anlassraum-soft-signal">4 klare Schritte</span>
-              <span className="anlassraum-soft-signal">Voxy optional</span>
+              <span className="anlassraum-soft-signal">Mit oder ohne Voxy</span>
               <span className="anlassraum-soft-signal">Nichts geht automatisch online</span>
             </div>
           </div>
@@ -631,7 +631,7 @@ export default function AnlassraumSetupForm({
                     "save_draft",
                     {
                       saved:
-                        "Mitmachraum-Entwurf gespeichert. Es wurde nichts veröffentlicht und Voxy hat noch keine weitere Ausarbeitung gestartet.",
+                        "Mitmachraum-Entwurf gespeichert. Es wurde nichts veröffentlicht. Du kannst später ohne Voxy weiterarbeiten oder mit Voxy strukturieren.",
                       authRequired:
                         "Mitmachraum-Entwurf lokal gespeichert. Zum Speichern im Konto bitte anmelden. Es wurde nichts veröffentlicht.",
                       failed:
@@ -682,7 +682,7 @@ export default function AnlassraumSetupForm({
           Antwortmöglichkeiten: {actionState.optionCount}
         </span>
         <span className="rounded-full border border-[rgb(var(--border))] bg-[rgb(var(--card))] px-3 py-1">
-          Voxy: {setup.aiSupportMode === "disabled" ? "nicht ausgewählt" : "optional"}
+          Voxy: {setup.aiSupportMode === "disabled" ? "ohne" : "mit"}
         </span>
       </div>
     </div>

--- a/apps/web/src/app/runden/new/AnlassraumSetupForm.tsx
+++ b/apps/web/src/app/runden/new/AnlassraumSetupForm.tsx
@@ -7,17 +7,17 @@ import VoxyGuide from "@/components/voxy/VoxyGuide";
 import StartDraftWorkspaceChooser from "@/features/start/StartDraftWorkspaceChooser";
 import {
   clearStartDraftContext,
-  saveStartDraftContext,
-  getStartDraftForTarget,
   createStartDraftContext,
+  getStartDraftForTarget,
+  saveStartDraftContext,
   updateStartDraftContext,
   type StartDraftContext,
 } from "@/features/start/startDraftContext";
 import { RUNDEN_VOXY_COPY } from "@/features/voxy/rundenVoxyCopy";
 import {
-  buildManualAnlassraumStartDraft,
-  buildManualAnlassraumServerDraftSavePayload,
   buildManualAnlassraumContinueCreateHref,
+  buildManualAnlassraumServerDraftSavePayload,
+  buildManualAnlassraumStartDraft,
   createEmptyManualAnlassraumSetup,
   resolveManualAnlassraumActionState,
   sanitizeManualAnlassraumSetup,
@@ -29,18 +29,19 @@ import {
   type ManualAnlassraumSetup,
   type ManualAnlassraumVisibility,
 } from "@/features/surfaces/runden/manualAnlassraumSetup";
-import AnlassraumStartDraftPanel from "./AnlassraumStartDraftPanel";
 import AnlassraumOptionEditor from "./AnlassraumOptionEditor";
 import AnlassraumPrePublishCheck from "./AnlassraumPrePublishCheck";
+import AnlassraumStartDraftPanel from "./AnlassraumStartDraftPanel";
 import AnlassraumSupportSettings from "./AnlassraumSupportSettings";
 import AnlassraumVisibilitySettings from "./AnlassraumVisibilitySettings";
 
 const MANUAL_ANLASSRAUM_STORAGE_KEY = "manual-anlassraum-setup.v1";
+
 const MANUAL_STEP_SUMMARY = [
   { id: "rahmen", label: "Rahmen", lead: "Titel, Leitfrage, Kurzbeschreibung" },
-  { id: "optionen", label: "Optionen", lead: "Feste Antworten und Community-Vorschläge" },
-  { id: "sichtbarkeit", label: "Sichtbarkeit", lead: "Intern, später öffentlich oder nach Review" },
-  { id: "unterstuetzung", label: "Unterstützung & Start", lead: "KI, Graph und Dossier bleiben optional" },
+  { id: "optionen", label: "Antworten", lead: "Feste Antworten und Vorschläge aus der Community" },
+  { id: "sichtbarkeit", label: "Sichtbarkeit", lead: "Intern behalten, später teilen oder prüfen lassen" },
+  { id: "unterstuetzung", label: "Start", lead: "Direkt speichern oder Voxy drüberschauen lassen" },
 ] as const;
 
 function joinClasses(...values: Array<string | false | null | undefined>) {
@@ -83,11 +84,22 @@ type StepGuideProps = {
   label: string;
 };
 
+function publicVoxyCopy(copy: string) {
+  return copy
+    .replace(/Anlassraum/g, "Mitmachraum")
+    .replace(/Runde/g, "Mitmachschritt")
+    .replace(/Runden/g, "Mitmachschritte")
+    .replace(/KI/gi, "Voxy")
+    .replace(/AI/gi, "Voxy")
+    .replace(/Dossier/g, "Themen-Zusammenfassung")
+    .replace(/Graph/g, "Zusammenhänge");
+}
+
 function StepMarker(props: StepGuideProps) {
   return (
     <div className="public-voxy-marker" data-manual-anlassraum-voxy-step={props.stepId}>
       <span aria-hidden="true" className="inline-flex h-1.5 w-1.5 rounded-full bg-[rgb(var(--grad-to))]" />
-      <span>{props.label}: {props.copy}</span>
+      <span>{props.label}: {publicVoxyCopy(props.copy)}</span>
     </div>
   );
 }
@@ -122,11 +134,9 @@ export default function AnlassraumSetupForm({
       setStartDraft(existingDraft);
     }
     const restoredSetup = initialServerDraft?.setup ?? readStoredSetup();
-    const restoreText = initialServerDraft
-      ? "Dein serverseitig gespeicherter Entwurf wurde wieder geöffnet."
-      : restoredSetup
-        ? "Dein lokal gesicherter Entwurf wurde wieder geöffnet."
-        : null;
+    const restoreText = restoredSetup
+      ? "Dein gespeicherter Entwurf wurde wieder geöffnet."
+      : null;
     if (initialServerDraft?.draftId) {
       setServerDraftId(initialServerDraft.draftId);
       syncDraftUrl(initialServerDraft.draftId);
@@ -181,7 +191,7 @@ export default function AnlassraumSetupForm({
     const nextDraft =
       buildManualAnlassraumStartDraft(nextSetup, startDraft) ??
       createStartDraftContext({
-        text: nextSetup.title || nextSetup.votingQuestion || "Manueller Anlassraum-Entwurf",
+        text: nextSetup.title || nextSetup.votingQuestion || "Mitmachraum-Entwurf",
         origin: "round_handoff",
         intent: "round_suggestion",
         targetHint,
@@ -234,9 +244,9 @@ export default function AnlassraumSetupForm({
   async function persistManualDraftWithNotice(
     nextStep: ManualAnlassraumNextStep,
     notices: {
-      serverSaved: string;
+      saved: string;
       authRequired: string;
-      serverFailed: string;
+      failed: string;
     },
   ) {
     const nextSetup = persistWithNextStep(nextStep);
@@ -248,16 +258,16 @@ export default function AnlassraumSetupForm({
       if (result.ok) {
         setServerDraftId(result.draftId);
         syncDraftUrl(result.draftId);
-        setActionNotice(notices.serverSaved);
+        setActionNotice(notices.saved);
         return;
       }
       if (result.error === "not_authenticated") {
         setActionNotice(notices.authRequired);
         return;
       }
-      setActionNotice(notices.serverFailed);
+      setActionNotice(notices.failed);
     } catch {
-      setActionNotice(notices.serverFailed);
+      setActionNotice(notices.failed);
     } finally {
       setIsPersisting(false);
     }
@@ -276,12 +286,12 @@ export default function AnlassraumSetupForm({
       if (!result.ok) {
         if (result.error === "not_authenticated") {
           setActionNotice(
-            "Zum KI-gestützten Weiterarbeiten in /create bitte zuerst anmelden. Dein Entwurf bleibt lokal gespeichert; es wurde kein KI-Lauf gestartet.",
+            "Zum Weiterarbeiten mit Voxy bitte zuerst anmelden. Dein Entwurf bleibt lokal gespeichert; es wurde nichts veröffentlicht.",
           );
           return;
         }
         setActionNotice(
-          "Der serverseitige Entwurf konnte nicht gespeichert werden. Bitte speichere oder öffne den Entwurf erneut, bevor du in /create weitergehst. Es wurde kein KI-Lauf gestartet.",
+          "Der Entwurf konnte nicht gespeichert werden. Bitte speichere oder öffne ihn erneut, bevor Voxy drüberschaut. Es wurde nichts veröffentlicht.",
         );
         return;
       }
@@ -297,7 +307,7 @@ export default function AnlassraumSetupForm({
       );
     } catch {
       setActionNotice(
-        "Der serverseitige Entwurf konnte nicht gespeichert werden. Bitte speichere oder öffne den Entwurf erneut, bevor du in /create weitergehst. Es wurde kein KI-Lauf gestartet.",
+        "Der Entwurf konnte nicht gespeichert werden. Bitte speichere oder öffne ihn erneut, bevor Voxy drüberschaut. Es wurde nichts veröffentlicht.",
       );
     } finally {
       setIsPersisting(false);
@@ -311,35 +321,28 @@ export default function AnlassraumSetupForm({
           <aside className="public-voxy-rail order-2 lg:order-1">
             <VoxyGuide
               appearance="panel"
-              title="Ich führe dich Schritt für Schritt durch den Entwurf."
+              title="Ich helfe dir, daraus einen verständlichen Mitmachraum zu machen."
               variant="welcome"
             >
-              <p>{RUNDEN_VOXY_COPY.manualFrame}</p>
+              <p>{publicVoxyCopy(RUNDEN_VOXY_COPY.manualFrame)}</p>
             </VoxyGuide>
           </aside>
 
           <div className="public-dialog-area order-1 lg:order-2">
             <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[rgb(var(--muted))]">
-              eDebatte Anlassraum
+              eDebatte Mitmachraum
             </p>
             <h1 className="mt-2 public-hero-title anlassraum-hero-title font-semibold tracking-tight text-[rgb(var(--fg))]">
-              Bereite deinen <span className="public-gradient-text">Anlassraum</span>{" "}
+              Bereite deinen <span className="public-gradient-text">Mitmachraum</span>{" "}
               <span className="public-gradient-text">Schritt für Schritt</span> vor.
             </h1>
             <p className="public-hero-lead mt-3 max-w-3xl">
-              Lege Rahmen, Optionen und Sichtbarkeit zuerst selbst fest. Alles Weitere bleibt ein bewusster
-              Folgeschritt.
+              Lege Thema, Frage, mögliche Antworten und Sichtbarkeit zuerst selbst fest. Danach kannst du direkt speichern oder Voxy drüberschauen lassen.
             </p>
             <div className="mt-4 flex flex-wrap gap-2 text-sm text-[rgb(var(--muted))]">
-              <span className="anlassraum-soft-signal">
-                4 klare Schritte
-              </span>
-              <span className="anlassraum-soft-signal">
-                KI optional
-              </span>
-              <span className="anlassraum-soft-signal">
-                Nichts geht automatisch online
-              </span>
+              <span className="anlassraum-soft-signal">4 klare Schritte</span>
+              <span className="anlassraum-soft-signal">Voxy optional</span>
+              <span className="anlassraum-soft-signal">Nichts geht automatisch online</span>
             </div>
           </div>
         </div>
@@ -371,9 +374,9 @@ export default function AnlassraumSetupForm({
         ) : null}
         <AnlassraumStartDraftPanel
           visible={Boolean(startDraft)}
-          title="Runde aus deinem Entwurf vorbereiten"
+          title="Mitmachraum aus deinem Entwurf vorbereiten"
           statusLine="Noch nicht veröffentlicht"
-          helperText="Optionen ergänzen. Du kannst Titel, Frage und Optionen weiterbearbeiten."
+          helperText="Du kannst Titel, Frage und Antworten weiterbearbeiten oder den Stand später fortsetzen."
         />
         {startDraft ? (
           <div className="mt-4">
@@ -390,14 +393,14 @@ export default function AnlassraumSetupForm({
                 {
                   key: "themes",
                   title: "Passende Themen finden",
-                  description: "Mit demselben Anliegen im Themenmodus weiterarbeiten.",
+                  description: "Mit demselben Anliegen im Themenüberblick weiterarbeiten.",
                   href: "/themen?startDraft=1",
                   onClick: () => updateStartDraftContext({ targetHint: "themes" }),
                 },
                 {
                   key: "rounds",
-                  title: "Runde vorbereiten",
-                  description: "Optionen weiterbearbeiten und als Runden-Entwurf offen halten.",
+                  title: "Mitmachraum vorbereiten",
+                  description: "Antworten weiterbearbeiten und als Entwurf offen halten.",
                   href: serverDraftId
                     ? `/runden/new?draftId=${encodeURIComponent(serverDraftId)}&startDraft=1&from=rounds`
                     : "/runden/new?startDraft=1&from=rounds",
@@ -405,8 +408,8 @@ export default function AnlassraumSetupForm({
                 },
                 {
                   key: "editorial",
-                  title: "Redaktionelle Prüfung anfragen",
-                  description: "Denselben Entwurf manuell prüfen lassen, ohne etwas zu veröffentlichen.",
+                  title: "Prüfung anfragen",
+                  description: "Denselben Entwurf prüfen lassen, ohne etwas zu veröffentlichen.",
                   href: "/start?review=editorial",
                   onClick: () => updateStartDraftContext({ origin: "start_relevance_review" }),
                 },
@@ -429,7 +432,7 @@ export default function AnlassraumSetupForm({
                   setSetup(createEmptyManualAnlassraumSetup());
                   setStartDraft(null);
                   setRestoreNotice(null);
-                  setActionNotice("Entwurf verworfen. Es wurde kein KI-Lauf gestartet.");
+                  setActionNotice("Entwurf verworfen. Es wurde nichts veröffentlicht.");
                 }}
               >
                 Entwurf verwerfen
@@ -448,7 +451,7 @@ export default function AnlassraumSetupForm({
         <section className="space-y-4">
           <div className="space-y-4">
             <StepMarker
-               copy={RUNDEN_VOXY_COPY.manualFrame}
+              copy={RUNDEN_VOXY_COPY.manualFrame}
               stepId="rahmen"
               label="Schritt 1"
             />
@@ -461,7 +464,7 @@ export default function AnlassraumSetupForm({
               </p>
               <h2 className="mt-1 text-xl font-semibold text-[rgb(var(--fg))]">Rahmen</h2>
               <p className="mt-2 max-w-3xl text-sm leading-6 text-[rgb(var(--muted))]">
-                Noch keine perfekte Formulierung nötig. Lege erst den Rahmen fest.
+                Noch keine perfekte Formulierung nötig. Halte erst fest, worum es geht.
               </p>
 
               <div className="mt-4 grid gap-4 lg:grid-cols-2">
@@ -483,7 +486,7 @@ export default function AnlassraumSetupForm({
                 </label>
                 <label className="block">
                   <span className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">
-                    Abstimmungsfrage
+                    Leitfrage
                   </span>
                   <input
                     value={setup.votingQuestion}
@@ -512,7 +515,7 @@ export default function AnlassraumSetupForm({
                     }))
                   }
                   className="mt-2 min-h-[120px] w-full rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] px-3 py-2.5 text-sm text-[rgb(var(--fg))] outline-none focus:border-sky-300 focus:ring-2 focus:ring-sky-200/60"
-                  placeholder="Beschreibe kurz, worum es geht, wer betroffen ist und warum der Anlass jetzt wichtig ist."
+                  placeholder="Beschreibe kurz, worum es geht, wer betroffen ist und warum das Thema jetzt wichtig ist."
                 />
               </label>
             </section>
@@ -524,7 +527,7 @@ export default function AnlassraumSetupForm({
         <section className="space-y-4">
           <div className="space-y-4">
             <StepMarker
-               copy={RUNDEN_VOXY_COPY.manualOptions}
+              copy={RUNDEN_VOXY_COPY.manualOptions}
               stepId="optionen"
               label="Schritt 2"
             />
@@ -570,7 +573,7 @@ export default function AnlassraumSetupForm({
         <section className="space-y-4">
           <div className="space-y-4">
             <StepMarker
-               copy={RUNDEN_VOXY_COPY.manualVisibility}
+              copy={RUNDEN_VOXY_COPY.manualVisibility}
               stepId="sichtbarkeit"
               label="Schritt 3"
             />
@@ -598,7 +601,7 @@ export default function AnlassraumSetupForm({
         <section className="space-y-4">
           <div className="space-y-4">
             <StepMarker
-               copy={RUNDEN_VOXY_COPY.manualSupport}
+              copy={RUNDEN_VOXY_COPY.manualSupport}
               stepId="unterstuetzung"
               label="Schritt 4"
             />
@@ -627,12 +630,12 @@ export default function AnlassraumSetupForm({
                   void persistManualDraftWithNotice(
                     "save_draft",
                     {
-                      serverSaved:
-                        "Anlassraum-Entwurf lokal und serverseitig gespeichert. Kein KI-Lauf, kein AI-Usage-Event und keine weitere Recherche-Automation wurden gestartet. Du kannst denselben Stand später wieder auf /runden/new öffnen oder bewusst in /create vertiefen.",
+                      saved:
+                        "Mitmachraum-Entwurf gespeichert. Es wurde nichts veröffentlicht und Voxy hat noch keine weitere Ausarbeitung gestartet.",
                       authRequired:
-                        "Anlassraum-Entwurf lokal gespeichert. Zum serverseitigen Speichern bitte anmelden. Kein KI-Lauf, kein AI-Usage-Event und keine weitere Recherche-Automation wurden gestartet.",
-                      serverFailed:
-                        "Anlassraum-Entwurf lokal gespeichert. Serverseitiges Speichern ist fehlgeschlagen. Kein KI-Lauf, kein AI-Usage-Event und keine weitere Recherche-Automation wurden gestartet.",
+                        "Mitmachraum-Entwurf lokal gespeichert. Zum Speichern im Konto bitte anmelden. Es wurde nichts veröffentlicht.",
+                      failed:
+                        "Mitmachraum-Entwurf lokal gespeichert. Das Speichern im Konto ist fehlgeschlagen. Es wurde nichts veröffentlicht.",
                     },
                   );
                 }}
@@ -641,12 +644,12 @@ export default function AnlassraumSetupForm({
                   void persistManualDraftWithNotice(
                     "start_internal",
                     {
-                      serverSaved:
-                        "Interner Anlassraum-Entwurf lokal und serverseitig gespeichert. Sichtbarkeit, Prüfung und KI bleiben bewusste nächste Schritte.",
+                      saved:
+                        "Mitmachraum intern vorgemerkt. Sichtbarkeit, Prüfung und Voxy bleiben bewusste nächste Schritte.",
                       authRequired:
-                        "Interner Anlassraum-Entwurf lokal gespeichert. Zum serverseitigen Speichern bitte anmelden. Sichtbarkeit, Prüfung und KI bleiben bewusste nächste Schritte.",
-                      serverFailed:
-                        "Interner Anlassraum-Entwurf lokal gespeichert. Serverseitiges Speichern ist fehlgeschlagen. Sichtbarkeit, Prüfung und KI bleiben bewusste nächste Schritte.",
+                        "Mitmachraum lokal vorgemerkt. Zum Speichern im Konto bitte anmelden. Sichtbarkeit, Prüfung und Voxy bleiben bewusste nächste Schritte.",
+                      failed:
+                        "Mitmachraum lokal vorgemerkt. Das Speichern im Konto ist fehlgeschlagen. Sichtbarkeit, Prüfung und Voxy bleiben bewusste nächste Schritte.",
                     },
                   );
                 }}
@@ -655,12 +658,12 @@ export default function AnlassraumSetupForm({
                   void persistManualDraftWithNotice(
                     "submit_public_review",
                     {
-                      serverSaved:
-                        "Entwurf lokal und serverseitig für spätere öffentliche Prüfung vorgemerkt. Es wurde nichts automatisch veröffentlicht und kein KI-Lauf gestartet.",
+                      saved:
+                        "Entwurf für spätere öffentliche Prüfung vorgemerkt. Es wurde nichts automatisch veröffentlicht.",
                       authRequired:
-                        "Entwurf lokal für spätere öffentliche Prüfung vorgemerkt. Zum serverseitigen Speichern bitte anmelden. Es wurde nichts automatisch veröffentlicht und kein KI-Lauf gestartet.",
-                      serverFailed:
-                        "Entwurf lokal für spätere öffentliche Prüfung vorgemerkt. Serverseitiges Speichern ist fehlgeschlagen. Es wurde nichts automatisch veröffentlicht und kein KI-Lauf gestartet.",
+                        "Entwurf lokal für spätere öffentliche Prüfung vorgemerkt. Zum Speichern im Konto bitte anmelden. Es wurde nichts automatisch veröffentlicht.",
+                      failed:
+                        "Entwurf lokal für spätere öffentliche Prüfung vorgemerkt. Das Speichern im Konto ist fehlgeschlagen. Es wurde nichts automatisch veröffentlicht.",
                     },
                   );
                 }}
@@ -671,15 +674,15 @@ export default function AnlassraumSetupForm({
         </section>
       </MotionStep>
 
-      <div className={joinClasses("flex flex-wrap gap-2 text-sm text-[rgb(var(--muted))]")}>
+      <div className="flex flex-wrap gap-2 text-sm text-[rgb(var(--muted))]">
         <span className="rounded-full border border-[rgb(var(--border))] bg-[rgb(var(--card))] px-3 py-1">
           Titel oder Frage: {actionState.hasFrameInput ? "gesetzt" : "noch offen"}
         </span>
         <span className="rounded-full border border-[rgb(var(--border))] bg-[rgb(var(--card))] px-3 py-1">
-          Feste Optionen: {actionState.optionCount}
+          Antwortmöglichkeiten: {actionState.optionCount}
         </span>
         <span className="rounded-full border border-[rgb(var(--border))] bg-[rgb(var(--card))] px-3 py-1">
-          KI: {setup.aiSupportMode === "disabled" ? "nicht aktiv" : "optional"}
+          Voxy: {setup.aiSupportMode === "disabled" ? "nicht ausgewählt" : "optional"}
         </span>
       </div>
     </div>

--- a/apps/web/src/app/runden/new/AnlassraumSupportSettings.tsx
+++ b/apps/web/src/app/runden/new/AnlassraumSupportSettings.tsx
@@ -41,20 +41,20 @@ export default function AnlassraumSupportSettings(
         Unterstützung &amp; Start
       </h2>
       <p className="mt-2 max-w-3xl text-sm leading-6 text-[rgb(var(--muted))]">
-        Du kannst direkt weiterarbeiten oder Voxy noch einmal drüberschauen lassen. Nichts davon startet automatisch.
+        Du kannst ohne Voxy direkt speichern oder mit Voxy weiter strukturieren. Nichts davon geht automatisch online.
       </p>
 
       <div className="mt-4 grid gap-3 md:grid-cols-3">
         <div className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] p-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">Direkt bearbeiten</p>
-          <p className="mt-1 text-sm font-semibold text-[rgb(var(--fg))]">Ohne Zusatzprüfung speichern</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">Ohne Voxy</p>
+          <p className="mt-1 text-sm font-semibold text-[rgb(var(--fg))]">Direkt speichern</p>
           <p className="mt-1 text-xs leading-5 text-[rgb(var(--muted))]">
             Dein Entwurf bleibt erhalten. Du kannst Titel, Frage und Antworten später weiter anpassen.
           </p>
         </div>
         <div className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] p-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">Voxy</p>
-          <p className="mt-1 text-sm font-semibold text-[rgb(var(--fg))]">Noch einmal drüberschauen</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">Mit Voxy</p>
+          <p className="mt-1 text-sm font-semibold text-[rgb(var(--fg))]">Struktur vorschlagen</p>
           <p className="mt-1 text-xs leading-5 text-[rgb(var(--muted))]">
             Voxy kann offene Fragen, Anschlussstellen und bessere Formulierungen vorschlagen.
           </p>

--- a/apps/web/src/app/runden/new/AnlassraumSupportSettings.tsx
+++ b/apps/web/src/app/runden/new/AnlassraumSupportSettings.tsx
@@ -12,6 +12,20 @@ function joinClasses(...values: Array<string | false | null | undefined>) {
   return values.filter(Boolean).join(" ");
 }
 
+function publicSupportChoiceLabel(label: string) {
+  return label
+    .replace(/KI/gi, "Voxy")
+    .replace(/AI/gi, "Voxy")
+    .replace(/Dossier/g, "Themen-Zusammenfassung");
+}
+
+function publicSupportChoiceDescription(description: string) {
+  return description
+    .replace(/KI/gi, "Voxy")
+    .replace(/AI/gi, "Voxy")
+    .replace(/Dossier/g, "Themen-Zusammenfassung");
+}
+
 export default function AnlassraumSupportSettings(
   props: AnlassraumSupportSettingsProps,
 ) {
@@ -27,29 +41,29 @@ export default function AnlassraumSupportSettings(
         Unterstützung &amp; Start
       </h2>
       <p className="mt-2 max-w-3xl text-sm leading-6 text-[rgb(var(--muted))]">
-        KI, Graph und Dossier bleiben optionale Hilfe. Nichts davon startet automatisch.
+        Du kannst direkt weiterarbeiten oder Voxy noch einmal drüberschauen lassen. Nichts davon startet automatisch.
       </p>
 
       <div className="mt-4 grid gap-3 md:grid-cols-3">
         <div className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] p-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">KI</p>
-          <p className="mt-1 text-sm font-semibold text-[rgb(var(--fg))]">Optional für Formulierungen</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">Direkt bearbeiten</p>
+          <p className="mt-1 text-sm font-semibold text-[rgb(var(--fg))]">Ohne Zusatzprüfung speichern</p>
           <p className="mt-1 text-xs leading-5 text-[rgb(var(--muted))]">
-            Nur wenn du es auswählst, kommen Hinweise oder weitere Vorschläge dazu.
+            Dein Entwurf bleibt erhalten. Du kannst Titel, Frage und Antworten später weiter anpassen.
           </p>
         </div>
         <div className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] p-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">Graph</p>
-          <p className="mt-1 text-sm font-semibold text-[rgb(var(--fg))]">Später einordnen</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">Voxy</p>
+          <p className="mt-1 text-sm font-semibold text-[rgb(var(--fg))]">Noch einmal drüberschauen</p>
           <p className="mt-1 text-xs leading-5 text-[rgb(var(--muted))]">
-            Zusammenhänge und Anschlussfragen bleiben ein bewusster Folgeschritt.
+            Voxy kann offene Fragen, Anschlussstellen und bessere Formulierungen vorschlagen.
           </p>
         </div>
         <div className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] p-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">Dossier</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">Themen-Zusammenfassung</p>
           <p className="mt-1 text-sm font-semibold text-[rgb(var(--fg))]">Erst nach Prüfung weiterführen</p>
           <p className="mt-1 text-xs leading-5 text-[rgb(var(--muted))]">
-            Ein Dossier entsteht nicht automatisch, sondern erst nach einem bewussten nächsten Schritt.
+            Eine Zusammenfassung mit Quellenfragen und offenen Punkten entsteht erst nach einem bewussten nächsten Schritt.
           </p>
         </div>
       </div>
@@ -70,8 +84,8 @@ export default function AnlassraumSupportSettings(
                   : "border-[rgb(var(--border))] bg-[rgb(var(--card))] text-[rgb(var(--muted))]",
               )}
             >
-              <span className="block text-sm font-semibold">{choice.label}</span>
-              <span className="mt-1 block text-xs leading-5">{choice.description}</span>
+              <span className="block text-sm font-semibold">{publicSupportChoiceLabel(choice.label)}</span>
+              <span className="mt-1 block text-xs leading-5">{publicSupportChoiceDescription(choice.description)}</span>
             </button>
           );
         })}

--- a/apps/web/src/app/runden/new/page.tsx
+++ b/apps/web/src/app/runden/new/page.tsx
@@ -7,9 +7,9 @@ import { readRundenEntryCanonReadModel } from "@/features/surfaces/runden/runden
 import AnlassraumSetupForm from "./AnlassraumSetupForm";
 
 export const metadata: Metadata = {
-  title: "Anlassraum manuell starten - eDebatte",
+  title: "Anlassraum vorbereiten - eDebatte",
   description:
-    "Lege einen Anlassraum zuerst manuell an und entscheide später bewusst über KI, Prüfung und Sichtbarkeit.",
+    "Lege einen Anlassraum zuerst als Entwurf an und entscheide später bewusst über KI, Prüfung und Sichtbarkeit.",
 };
 
 type SearchParamsShape =
@@ -43,17 +43,17 @@ export default async function RundenManualCreatePage(props: {
               eDebatte Anlassraum
             </p>
             <h1 className="mt-1 text-3xl font-semibold tracking-tight text-[rgb(var(--fg))] md:text-4xl">
-              Manuell starten
+              Anlassraum vorbereiten
             </h1>
             <p className="mt-2 max-w-2xl text-sm leading-6 text-[rgb(var(--muted))]">
-              Rahmen zuerst selbst setzen. KI, Prüfung und weitere Ausarbeitung bleiben optionale nächste Schritte.
+              Setze zuerst Thema, Rahmen und Ziel. KI, Prüfung und weitere Ausarbeitung bleiben optionale nächste Schritte.
             </p>
           </div>
           <Link
             href="/runden"
             className="vog-btn-secondary"
           >
-            Zurück zu /runden
+            Zurück zu den Anlassräumen
           </Link>
         </div>
 
@@ -62,30 +62,27 @@ export default async function RundenManualCreatePage(props: {
           data-runden-entry-canon="true"
         >
           <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[rgb(var(--muted))]">
-            Kanonischer Einstieg heute
+            So funktioniert der Start
           </p>
           <h2 className="mt-1 text-lg font-semibold text-[rgb(var(--fg))]">
-            /runden/new startet mit einem wiederaufnehmbaren Entwurf.
+            Erst Entwurf, dann Prüfung, dann bewusster nächster Schritt.
           </h2>
           <p className="mt-2 leading-6 text-[rgb(var(--muted))]">
-            {entryCanon.firstPersistentRecord.runtimeTruth}
+            Ein Anlassraum beginnt als vorbereiteter Arbeitsstand. Du kannst ihn speichern, später fortsetzen oder mit KI-Unterstützung weiter strukturieren lassen.
           </p>
           <ul className="mt-3 list-disc space-y-1.5 pl-5 text-[rgb(var(--muted))]">
             <li>
-              <strong className="text-[rgb(var(--fg))]">Ohne KI speichern</strong> erzeugt zuerst den
-              bestehenden serverseitigen Draft plus lokalen Resume-Kontext.
+              <strong className="text-[rgb(var(--fg))]">Ohne KI speichern</strong> hält deinen Rahmen als Entwurf fest.
             </li>
             <li>
-              <strong className="text-[rgb(var(--fg))]">Mit KI in /create weiter</strong> bereitet nur
-              den Wechsel in die vorhandene Analyze-/Planner-Surface vor.
+              <strong className="text-[rgb(var(--fg))]">Mit KI weiterarbeiten</strong> hilft beim Ordnen von Thema, Fragen, Zielgruppe und nächsten Schritten.
             </li>
             <li>
-              Echter Anlassraum, Dossier oder Beteiligungsraum entstehen erst aus bewussten
-              Review- und Runtime-Pfaden.
+              Dossier, Beteiligung oder Veröffentlichung entstehen erst nach bewusster Prüfung und Bestätigung.
             </li>
           </ul>
           <p className="mt-3 leading-6 text-[rgb(var(--muted))]">
-            {entryCanon.reusableSummary.interplay}
+            So bleibt transparent, was vorbereitet wurde, was noch offen ist und welcher Schritt als Nächstes sinnvoll ist.
           </p>
         </section>
 

--- a/apps/web/src/app/runden/new/page.tsx
+++ b/apps/web/src/app/runden/new/page.tsx
@@ -46,7 +46,7 @@ export default async function RundenManualCreatePage(props: {
               Mitmachraum vorbereiten
             </h1>
             <p className="mt-2 max-w-2xl text-sm leading-6 text-[rgb(var(--muted))]">
-              Setze zuerst Thema, Frage und mögliche Antworten. Voxy kann danach drüberschauen – aber du entscheidest jeden nächsten Schritt.
+              Setze zuerst Thema, Frage und mögliche Antworten. Danach entscheidest du: ohne Voxy weiter oder mit Voxy strukturieren.
             </p>
           </div>
           <Link
@@ -68,14 +68,14 @@ export default async function RundenManualCreatePage(props: {
             Erst festhalten, dann sortieren, dann gemeinsam klären.
           </h2>
           <p className="mt-2 leading-6 text-[rgb(var(--muted))]">
-            Ein Mitmachraum beginnt als Entwurf für eine Frage, kleine Umfrage oder gemeinsame Klärung. Du kannst direkt weiterarbeiten oder Voxy bitten, Struktur, offene Punkte und nächste Schritte zu prüfen.
+            Ein Mitmachraum beginnt als Entwurf für eine Frage, kleine Umfrage oder gemeinsame Klärung. Du kannst direkt weiterarbeiten oder Voxy für Struktur, offene Punkte und nächste Schritte nutzen.
           </p>
           <ul className="mt-3 list-disc space-y-1.5 pl-5 text-[rgb(var(--muted))]">
             <li>
-              <strong className="text-[rgb(var(--fg))]">Direkt bearbeiten</strong> speichert deinen Stand ohne zusätzliche Ausarbeitung.
+              <strong className="text-[rgb(var(--fg))]">Ohne Voxy</strong> speicherst du deinen Stand ohne zusätzliche Ausarbeitung.
             </li>
             <li>
-              <strong className="text-[rgb(var(--fg))]">Voxy drüberschauen lassen</strong> hilft beim Ordnen von Thema, Fragen, Zielgruppe und nächsten Schritten.
+              <strong className="text-[rgb(var(--fg))]">Mit Voxy</strong> werden Thema, Fragen, Zielgruppe und nächste Schritte geordnet.
             </li>
             <li>
               Themen-Zusammenfassung, Beteiligung oder Veröffentlichung entstehen erst nach bewusster Prüfung und Bestätigung.

--- a/apps/web/src/app/runden/new/page.tsx
+++ b/apps/web/src/app/runden/new/page.tsx
@@ -7,9 +7,9 @@ import { readRundenEntryCanonReadModel } from "@/features/surfaces/runden/runden
 import AnlassraumSetupForm from "./AnlassraumSetupForm";
 
 export const metadata: Metadata = {
-  title: "Anlassraum vorbereiten - eDebatte",
+  title: "Mitmachraum vorbereiten - eDebatte",
   description:
-    "Lege einen Anlassraum zuerst als Entwurf an und entscheide später bewusst über KI, Prüfung und Sichtbarkeit.",
+    "Lege einen Mitmachraum zuerst als Entwurf an und entscheide später bewusst über Voxy, Prüfung und Sichtbarkeit.",
 };
 
 type SearchParamsShape =
@@ -40,20 +40,20 @@ export default async function RundenManualCreatePage(props: {
         <div className="mx-auto flex w-full max-w-[78rem] flex-wrap items-center justify-between gap-3">
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[rgb(var(--muted))]">
-              eDebatte Anlassraum
+              eDebatte Mitmachraum
             </p>
             <h1 className="mt-1 text-3xl font-semibold tracking-tight text-[rgb(var(--fg))] md:text-4xl">
-              Anlassraum vorbereiten
+              Mitmachraum vorbereiten
             </h1>
             <p className="mt-2 max-w-2xl text-sm leading-6 text-[rgb(var(--muted))]">
-              Setze zuerst Thema, Rahmen und Ziel. KI, Prüfung und weitere Ausarbeitung bleiben optionale nächste Schritte.
+              Setze zuerst Thema, Frage und mögliche Antworten. Voxy kann danach drüberschauen – aber du entscheidest jeden nächsten Schritt.
             </p>
           </div>
           <Link
             href="/runden"
             className="vog-btn-secondary"
           >
-            Zurück zu den Anlassräumen
+            Zurück zum Themenüberblick
           </Link>
         </div>
 
@@ -65,24 +65,24 @@ export default async function RundenManualCreatePage(props: {
             So funktioniert der Start
           </p>
           <h2 className="mt-1 text-lg font-semibold text-[rgb(var(--fg))]">
-            Erst Entwurf, dann Prüfung, dann bewusster nächster Schritt.
+            Erst festhalten, dann sortieren, dann gemeinsam klären.
           </h2>
           <p className="mt-2 leading-6 text-[rgb(var(--muted))]">
-            Ein Anlassraum beginnt als vorbereiteter Arbeitsstand. Du kannst ihn speichern, später fortsetzen oder mit KI-Unterstützung weiter strukturieren lassen.
+            Ein Mitmachraum beginnt als Entwurf für eine Frage, kleine Umfrage oder gemeinsame Klärung. Du kannst direkt weiterarbeiten oder Voxy bitten, Struktur, offene Punkte und nächste Schritte zu prüfen.
           </p>
           <ul className="mt-3 list-disc space-y-1.5 pl-5 text-[rgb(var(--muted))]">
             <li>
-              <strong className="text-[rgb(var(--fg))]">Ohne KI speichern</strong> hält deinen Rahmen als Entwurf fest.
+              <strong className="text-[rgb(var(--fg))]">Direkt bearbeiten</strong> speichert deinen Stand ohne zusätzliche Ausarbeitung.
             </li>
             <li>
-              <strong className="text-[rgb(var(--fg))]">Mit KI weiterarbeiten</strong> hilft beim Ordnen von Thema, Fragen, Zielgruppe und nächsten Schritten.
+              <strong className="text-[rgb(var(--fg))]">Voxy drüberschauen lassen</strong> hilft beim Ordnen von Thema, Fragen, Zielgruppe und nächsten Schritten.
             </li>
             <li>
-              Dossier, Beteiligung oder Veröffentlichung entstehen erst nach bewusster Prüfung und Bestätigung.
+              Themen-Zusammenfassung, Beteiligung oder Veröffentlichung entstehen erst nach bewusster Prüfung und Bestätigung.
             </li>
           </ul>
           <p className="mt-3 leading-6 text-[rgb(var(--muted))]">
-            So bleibt transparent, was vorbereitet wurde, was noch offen ist und welcher Schritt als Nächstes sinnvoll ist.
+            So bleibt verständlich, was vorbereitet wurde, was noch offen ist und wobei Menschen konkret mitmachen können.
           </p>
         </section>
 

--- a/apps/web/src/app/themen/page.tsx
+++ b/apps/web/src/app/themen/page.tsx
@@ -32,7 +32,7 @@ function topicReadinessLabel(topic: Topic) {
     case "ready_for_vote_check":
       return "Prüfung für Abstimmung";
     case "next_round_needed":
-      return "Nächste Runde vorgesehen";
+      return "Nächster Mitmachschritt vorgesehen";
     case "in_implementation":
       return "In Umsetzung";
     case "monitoring_impact":
@@ -98,19 +98,19 @@ function StageSection({
 
                 <div className="mt-3 flex flex-wrap gap-2 text-xs text-[rgb(var(--muted))]">
                   <span className="rounded-full border border-[rgb(var(--border))] bg-[rgb(var(--card))] px-2.5 py-1">
-                    Offene Runden: {openRounds}
+                    Offene Mitmachräume: {openRounds}
                   </span>
                   <span className="rounded-full border border-[rgb(var(--border))] bg-[rgb(var(--card))] px-2.5 py-1">
-                    Abgeschlossene Runden: {closedRounds}
+                    Abgeschlossene Schritte: {closedRounds}
                   </span>
                 </div>
 
                 <div className="mt-3 flex flex-wrap gap-2">
                   <Link href={`/topic/${topic.slug}`} className="btn-secondary inline-flex">
-                    Themenraum öffnen
+                    Thema öffnen
                   </Link>
                   <Link href={`/runden?topic=${encodeURIComponent(topic.slug)}`} className="btn-secondary inline-flex">
-                    Anlassraum nutzen
+                    Mitmachräume ansehen
                   </Link>
                 </div>
               </li>
@@ -131,17 +131,17 @@ export default function ThemenPage() {
   return (
     <ProductSurfaceShell>
       <header className="rounded-[1.75rem] border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-6 shadow-sm sm:p-8">
-        <p className="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">Themen</p>
-        <h1 className="mt-2 text-3xl font-bold tracking-tight text-[rgb(var(--fg))] sm:text-4xl">Themen, an die dein Beitrag anknüpfen kann.</h1>
+        <p className="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">Themenüberblick</p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-[rgb(var(--fg))] sm:text-4xl">Das große Ganze hinter einzelnen Beiträgen.</h1>
         <p className="mt-3 max-w-4xl text-sm leading-relaxed text-[rgb(var(--muted))] sm:text-base">
-          eDebatte sammelt Anliegen nicht als lose Kommentare. Themen zeigen, welche Fragen bereits sichtbar sind, welche Beteiligungsräume vorbereitet werden und wo ein Beitrag weiterhelfen kann.
+          eDebatte sammelt Anliegen nicht als lose Kommentare. Der Themenüberblick zeigt, welche Fragen bereits sichtbar sind, wo kleine Mitmachräume vorbereitet werden und wo dein Beitrag weiterhelfen kann.
         </p>
         <div className="mt-5 flex flex-wrap gap-3">
           <Link href="/create?intent=issue_signal" className="btn-primary inline-flex">
             Beitrag einordnen
           </Link>
           <Link href="/runden" className="btn-secondary inline-flex">
-            Anlassräume ansehen
+            Mitmachräume ansehen
           </Link>
           <Link href="/create?intent=round_setup" className="btn-secondary inline-flex">
             Abstimmungsfähigkeit prüfen
@@ -162,11 +162,11 @@ export default function ThemenPage() {
           title="Aktuell"
           subtitle="Themen mit sichtbarem Arbeitsstand und möglicher Beteiligung."
           topics={aktuell}
-          emptyText="Hier erscheinen Themen, sobald ein Anliegen ausreichend eingeordnet wurde. Bis dahin kannst du einen eigenen Beitrag starten oder vorhandene Anlassräume ansehen."
+          emptyText="Hier erscheinen Themen, sobald ein Anliegen ausreichend eingeordnet wurde. Bis dahin kannst du einen eigenen Beitrag starten oder vorhandene Mitmachräume ansehen."
         />
         <StageSection
           title="Geplant"
-          subtitle="Nächste Runden, Prüfungen oder strukturierte Umsetzungsschritte."
+          subtitle="Nächste Mitmachschritte, Prüfungen oder strukturierte Umsetzungsschritte."
           topics={geplant}
           emptyText="Noch ist kein nächster öffentlicher Schritt geplant. Ein Thema wandert hierher, wenn offene Fragen, Zuständigkeit und möglicher Beteiligungsrahmen geklärt sind."
         />
@@ -174,7 +174,7 @@ export default function ThemenPage() {
           title="Archiv"
           subtitle="Abgeschlossene oder beobachtete Themen mit nachvollziehbarem Verlauf."
           topics={archiv}
-          emptyText="Archivierte Themen erscheinen hier erst, wenn eine Runde abgeschlossen oder eine Wirkung nachvollziehbar beobachtet wurde."
+          emptyText="Archivierte Themen erscheinen hier erst, wenn ein Mitmachschritt abgeschlossen oder eine Wirkung nachvollziehbar beobachtet wurde."
         />
       </div>
     </ProductSurfaceShell>

--- a/apps/web/src/app/themen/page.tsx
+++ b/apps/web/src/app/themen/page.tsx
@@ -30,13 +30,13 @@ function mapTopicStage(topic: Topic): ThemenStage {
 function topicReadinessLabel(topic: Topic) {
   switch (topic.readiness) {
     case "ready_for_vote_check":
-      return "Vorbereitung auf Vote-Check";
+      return "Prüfung für Abstimmung";
     case "next_round_needed":
       return "Nächste Runde vorgesehen";
     case "in_implementation":
       return "In Umsetzung";
     case "monitoring_impact":
-      return "Wirkungsbeobachtung";
+      return "Wirkung wird beobachtet";
     default:
       return "In Bearbeitung";
   }
@@ -55,10 +55,12 @@ function StageSection({
   title,
   subtitle,
   topics,
+  emptyText,
 }: {
   title: string;
   subtitle: string;
   topics: Topic[];
+  emptyText: string;
 }) {
   return (
     <section className="space-y-3 rounded-3xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-5 shadow-sm sm:p-6">
@@ -73,8 +75,8 @@ function StageSection({
       </div>
 
       {topics.length === 0 ? (
-        <div className="rounded-2xl border border-dashed border-[rgb(var(--border))] px-4 py-3 text-sm text-[rgb(var(--muted))]">
-          Aktuell keine Einträge. Neue Themen können jederzeit über den Anlassraum gestartet werden.
+        <div className="rounded-2xl border border-dashed border-[rgb(var(--border))] bg-[rgb(var(--bg))] px-4 py-3 text-sm leading-6 text-[rgb(var(--muted))]">
+          {emptyText}
         </div>
       ) : (
         <ul className="grid gap-3">
@@ -130,17 +132,16 @@ export default function ThemenPage() {
     <ProductSurfaceShell>
       <header className="rounded-[1.75rem] border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-6 shadow-sm sm:p-8">
         <p className="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">Themen</p>
-        <h1 className="mt-2 text-3xl font-bold tracking-tight text-[rgb(var(--fg))] sm:text-4xl">Themen als Dachfläche</h1>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-[rgb(var(--fg))] sm:text-4xl">Themen, an die dein Beitrag anknüpfen kann.</h1>
         <p className="mt-3 max-w-4xl text-sm leading-relaxed text-[rgb(var(--muted))] sm:text-base">
-          Aktuelle Arbeitsstände, geplante nächste Schritte und archivierte Themen bleiben in einer Oberfläche sichtbar.
-          Für die operative Arbeit kannst du direkt in Anlassraum, Beitragsvorbereitung oder Prüfung wechseln.
+          eDebatte sammelt Anliegen nicht als lose Kommentare. Themen zeigen, welche Fragen bereits sichtbar sind, welche Beteiligungsräume vorbereitet werden und wo ein Beitrag weiterhelfen kann.
         </p>
         <div className="mt-5 flex flex-wrap gap-3">
-          <Link href="/runden" className="btn-primary inline-flex">
-            Anlass starten
+          <Link href="/create?intent=issue_signal" className="btn-primary inline-flex">
+            Beitrag einordnen
           </Link>
-          <Link href="/create?intent=issue_signal" className="btn-secondary inline-flex">
-            Beitrag vorbereiten
+          <Link href="/runden" className="btn-secondary inline-flex">
+            Anlassräume ansehen
           </Link>
           <Link href="/create?intent=round_setup" className="btn-secondary inline-flex">
             Abstimmungsfähigkeit prüfen
@@ -159,18 +160,21 @@ export default function ThemenPage() {
       <div className="mt-8 space-y-4">
         <StageSection
           title="Aktuell"
-          subtitle="Themen mit aktivem Arbeitsstand und offener Beteiligung."
+          subtitle="Themen mit sichtbarem Arbeitsstand und möglicher Beteiligung."
           topics={aktuell}
+          emptyText="Hier erscheinen Themen, sobald ein Anliegen ausreichend eingeordnet wurde. Bis dahin kannst du einen eigenen Beitrag starten oder vorhandene Anlassräume ansehen."
         />
         <StageSection
           title="Geplant"
-          subtitle="Nächste Runden, Vote-Check-Vorbereitung oder strukturierte Umsetzung."
+          subtitle="Nächste Runden, Prüfungen oder strukturierte Umsetzungsschritte."
           topics={geplant}
+          emptyText="Noch ist kein nächster öffentlicher Schritt geplant. Ein Thema wandert hierher, wenn offene Fragen, Zuständigkeit und möglicher Beteiligungsrahmen geklärt sind."
         />
         <StageSection
           title="Archiv"
           subtitle="Abgeschlossene oder beobachtete Themen mit nachvollziehbarem Verlauf."
           topics={archiv}
+          emptyText="Archivierte Themen erscheinen hier erst, wenn eine Runde abgeschlossen oder eine Wirkung nachvollziehbar beobachtet wurde."
         />
       </div>
     </ProductSurfaceShell>

--- a/apps/web/src/features/dossier/publicRuntime.ts
+++ b/apps/web/src/features/dossier/publicRuntime.ts
@@ -6,19 +6,7 @@ import type {
   DossierSourceDoc,
   OpenQuestionDoc,
 } from "@features/dossier";
-import {
-  dossierClaimsCol,
-  dossierFindingsCol,
-  dossierSourcesCol,
-  dossiersCol,
-  openQuestionsCol,
-} from "@features/dossier/db";
-import { buildDossierUpdateReadModel, type DossierPublicUpdateContext } from "@features/dossier/updateReadModel";
-import {
-  getAnyDossierPublicationRecordByDossierId,
-  getPublishedDossierPublicationRecordByDossierId,
-  listPublishedDossierPublicationRecords,
-} from "@/features/create/dossierPublishWorkflowServer";
+import type { DossierPublicUpdateContext } from "@features/dossier/updateReadModel";
 import {
   stripDossierInternalFieldsForPublic,
   type DossierPublicationRecord,
@@ -222,6 +210,9 @@ export function mapDossierToPublicDossier(input: {
 }
 
 export async function listPublishedDossiers(limit = 40) {
+  const { listPublishedDossierPublicationRecords } = await import(
+    "@/features/create/dossierPublishWorkflowServer"
+  );
   const records = await listPublishedDossierPublicationRecords(limit);
   return records.map((record): PublicDossierRuntimeItem => ({
     id: String(record.dossierId),
@@ -234,29 +225,34 @@ export async function listPublishedDossiers(limit = 40) {
 }
 
 export async function getPublishedDossierBySlugOrId(slugOrId: string) {
-  const publication = await getPublishedDossierPublicationRecordByDossierId(slugOrId);
+  const [workflowServer, dossierDb, updateReadModel] = await Promise.all([
+    import("@/features/create/dossierPublishWorkflowServer"),
+    import("@features/dossier/db"),
+    import("@features/dossier/updateReadModel"),
+  ]);
+  const publication = await workflowServer.getPublishedDossierPublicationRecordByDossierId(slugOrId);
   if (!publication) return null;
 
-  const [dossierDoc, claims, sources, findings, openQuestions, updateReadModel] =
+  const [dossierDoc, claims, sources, findings, openQuestions, updateReadModelResult] =
     await Promise.all([
-      (await dossiersCol()).findOne({ dossierId: String(publication.dossierId) } as any),
-      (await dossierClaimsCol())
+      (await dossierDb.dossiersCol()).findOne({ dossierId: String(publication.dossierId) } as any),
+      (await dossierDb.dossierClaimsCol())
         .find({ dossierId: String(publication.dossierId) })
         .sort({ createdAt: 1 })
         .toArray(),
-      (await dossierSourcesCol())
+      (await dossierDb.dossierSourcesCol())
         .find({ dossierId: String(publication.dossierId) })
         .sort({ publishedAt: -1, createdAt: -1 })
         .toArray(),
-      (await dossierFindingsCol())
+      (await dossierDb.dossierFindingsCol())
         .find({ dossierId: String(publication.dossierId) })
         .sort({ updatedAt: -1 })
         .toArray(),
-      (await openQuestionsCol())
+      (await dossierDb.openQuestionsCol())
         .find({ dossierId: String(publication.dossierId) })
         .sort({ status: 1, createdAt: 1 })
         .toArray(),
-      buildDossierUpdateReadModel({
+      updateReadModel.buildDossierUpdateReadModel({
         dossierId: String(publication.dossierId),
         materialize: true,
         publicVisible: true,
@@ -277,7 +273,7 @@ export async function getPublishedDossierBySlugOrId(slugOrId: string) {
       id: String(publication.dossierId),
       slug: String(publication.dossierId),
       dossier,
-      updateContext: updateReadModel?.publicContext ?? null,
+      updateContext: updateReadModelResult?.publicContext ?? null,
       materialLinks: [],
       source: "runtime" as const,
     },
@@ -286,5 +282,8 @@ export async function getPublishedDossierBySlugOrId(slugOrId: string) {
 }
 
 export async function getDossierPublicationRuntimeHint(slugOrId: string) {
+  const { getAnyDossierPublicationRecordByDossierId } = await import(
+    "@/features/create/dossierPublishWorkflowServer"
+  );
   return getAnyDossierPublicationRecordByDossierId(slugOrId);
 }


### PR DESCRIPTION
## Summary
- removes public runtime/debug-style wording from `/runden/new`
- improves `/dossier` empty state so it explains the dossier value instead of looking like a dead route
- clarifies `/themen` copy and empty states for external users

## Notes
- scoped intentionally to public UX/copy hardening only
- no new orchestration, payment, AI, or publishing logic
- keeps review-first/no-auto-publish framing visible

## Tests
- not run in connector; please run local/web CI checks before merge