### PR TITLE
refactor(public): centralize public terminology contract

### DIFF
--- a/apps/web/src/app/runden/new/AnlassraumSetupForm.tsx
+++ b/apps/web/src/app/runden/new/AnlassraumSetupForm.tsx
@@ -13,6 +13,7 @@ import {
   updateStartDraftContext,
   type StartDraftContext,
 } from "@/features/start/startDraftContext";
+import { PUBLIC_TERMINOLOGY, publicTerminologyText } from "@/features/public/publicTerminology";
 import { RUNDEN_VOXY_COPY } from "@/features/voxy/rundenVoxyCopy";
 import {
   buildManualAnlassraumContinueCreateHref,
@@ -41,7 +42,7 @@ const MANUAL_STEP_SUMMARY = [
   { id: "rahmen", label: "Rahmen", lead: "Titel, Leitfrage, Kurzbeschreibung" },
   { id: "optionen", label: "Antworten", lead: "Feste Antworten und Vorschläge aus der Community" },
   { id: "sichtbarkeit", label: "Sichtbarkeit", lead: "Intern behalten, später teilen oder prüfen lassen" },
-  { id: "unterstuetzung", label: "Start", lead: "Ohne Voxy speichern oder mit Voxy strukturieren" },
+  { id: "unterstuetzung", label: "Start", lead: `${PUBLIC_TERMINOLOGY.withoutVoxy} speichern oder ${PUBLIC_TERMINOLOGY.withVoxy} strukturieren` },
 ] as const;
 
 function joinClasses(...values: Array<string | false | null | undefined>) {
@@ -84,22 +85,11 @@ type StepGuideProps = {
   label: string;
 };
 
-function publicVoxyCopy(copy: string) {
-  return copy
-    .replace(/Anlassraum/g, "Mitmachraum")
-    .replace(/Runde/g, "Mitmachschritt")
-    .replace(/Runden/g, "Mitmachschritte")
-    .replace(/KI/gi, "Voxy")
-    .replace(/AI/gi, "Voxy")
-    .replace(/Dossier/g, "Themen-Zusammenfassung")
-    .replace(/Graph/g, "Zusammenhänge");
-}
-
 function StepMarker(props: StepGuideProps) {
   return (
     <div className="public-voxy-marker" data-manual-anlassraum-voxy-step={props.stepId}>
       <span aria-hidden="true" className="inline-flex h-1.5 w-1.5 rounded-full bg-[rgb(var(--grad-to))]" />
-      <span>{props.label}: {publicVoxyCopy(props.copy)}</span>
+      <span>{props.label}: {publicTerminologyText(props.copy)}</span>
     </div>
   );
 }
@@ -324,7 +314,7 @@ export default function AnlassraumSetupForm({
               title="Ich helfe dir, daraus einen verständlichen Mitmachraum zu machen."
               variant="welcome"
             >
-              <p>{publicVoxyCopy(RUNDEN_VOXY_COPY.manualFrame)}</p>
+              <p>{publicTerminologyText(RUNDEN_VOXY_COPY.manualFrame)}</p>
             </VoxyGuide>
           </aside>
 

--- a/apps/web/src/app/runden/new/AnlassraumSupportSettings.tsx
+++ b/apps/web/src/app/runden/new/AnlassraumSupportSettings.tsx
@@ -1,3 +1,4 @@
+import { PUBLIC_TERMINOLOGY, publicTerminologyText } from "@/features/public/publicTerminology";
 import {
   MANUAL_ANLASSRAUM_AI_SUPPORT_MODE_CHOICES,
   type ManualAnlassraumAiSupportMode,
@@ -10,20 +11,6 @@ type AnlassraumSupportSettingsProps = {
 
 function joinClasses(...values: Array<string | false | null | undefined>) {
   return values.filter(Boolean).join(" ");
-}
-
-function publicSupportChoiceLabel(label: string) {
-  return label
-    .replace(/KI/gi, "Voxy")
-    .replace(/AI/gi, "Voxy")
-    .replace(/Dossier/g, "Themen-Zusammenfassung");
-}
-
-function publicSupportChoiceDescription(description: string) {
-  return description
-    .replace(/KI/gi, "Voxy")
-    .replace(/AI/gi, "Voxy")
-    .replace(/Dossier/g, "Themen-Zusammenfassung");
 }
 
 export default function AnlassraumSupportSettings(
@@ -46,21 +33,21 @@ export default function AnlassraumSupportSettings(
 
       <div className="mt-4 grid gap-3 md:grid-cols-3">
         <div className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] p-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">Ohne Voxy</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">{PUBLIC_TERMINOLOGY.withoutVoxy}</p>
           <p className="mt-1 text-sm font-semibold text-[rgb(var(--fg))]">Direkt speichern</p>
           <p className="mt-1 text-xs leading-5 text-[rgb(var(--muted))]">
             Dein Entwurf bleibt erhalten. Du kannst Titel, Frage und Antworten später weiter anpassen.
           </p>
         </div>
         <div className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] p-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">Mit Voxy</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">{PUBLIC_TERMINOLOGY.withVoxy}</p>
           <p className="mt-1 text-sm font-semibold text-[rgb(var(--fg))]">Struktur vorschlagen</p>
           <p className="mt-1 text-xs leading-5 text-[rgb(var(--muted))]">
             Voxy kann offene Fragen, Anschlussstellen und bessere Formulierungen vorschlagen.
           </p>
         </div>
         <div className="rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--bg))] p-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">Themen-Zusammenfassung</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-[rgb(var(--muted))]">{PUBLIC_TERMINOLOGY.themenZusammenfassung}</p>
           <p className="mt-1 text-sm font-semibold text-[rgb(var(--fg))]">Erst nach Prüfung weiterführen</p>
           <p className="mt-1 text-xs leading-5 text-[rgb(var(--muted))]">
             Eine Zusammenfassung mit Quellenfragen und offenen Punkten entsteht erst nach einem bewussten nächsten Schritt.
@@ -84,8 +71,8 @@ export default function AnlassraumSupportSettings(
                   : "border-[rgb(var(--border))] bg-[rgb(var(--card))] text-[rgb(var(--muted))]",
               )}
             >
-              <span className="block text-sm font-semibold">{publicSupportChoiceLabel(choice.label)}</span>
-              <span className="mt-1 block text-xs leading-5">{publicSupportChoiceDescription(choice.description)}</span>
+              <span className="block text-sm font-semibold">{publicTerminologyText(choice.label)}</span>
+              <span className="mt-1 block text-xs leading-5">{publicTerminologyText(choice.description)}</span>
             </button>
           );
         })}

--- a/apps/web/src/features/public/publicTerminology.ts
+++ b/apps/web/src/features/public/publicTerminology.ts
@@ -1,0 +1,32 @@
+export const PUBLIC_TERMINOLOGY = {
+  withVoxy: "Mit Voxy",
+  withoutVoxy: "Ohne Voxy",
+  voxy: "Voxy",
+  mitmachraum: "Mitmachraum",
+  mitmachraeume: "Mitmachräume",
+  mitmachschritt: "Mitmachschritt",
+  mitmachschritte: "Mitmachschritte",
+  themenZusammenfassung: "Themen-Zusammenfassung",
+  themenUeberblick: "Themenüberblick",
+  zusammenhaenge: "Zusammenhänge",
+} as const;
+
+const PUBLIC_TEXT_REPLACEMENTS: Array<[RegExp, string]> = [
+  [/\bAI-Usage-Event\b/g, `${PUBLIC_TERMINOLOGY.voxy}-Schritt`],
+  [/\bAI\b/g, PUBLIC_TERMINOLOGY.voxy],
+  [/\bKI\b/gi, PUBLIC_TERMINOLOGY.voxy],
+  [/\bAnlassräume\b/g, PUBLIC_TERMINOLOGY.mitmachraeume],
+  [/\bAnlassraum\b/g, PUBLIC_TERMINOLOGY.mitmachraum],
+  [/\bDossiers\b/g, `${PUBLIC_TERMINOLOGY.themenZusammenfassung}en`],
+  [/\bDossier\b/g, PUBLIC_TERMINOLOGY.themenZusammenfassung],
+  [/\bRunden\b/g, PUBLIC_TERMINOLOGY.mitmachschritte],
+  [/\bRunde\b/g, PUBLIC_TERMINOLOGY.mitmachschritt],
+  [/\bGraph\b/g, PUBLIC_TERMINOLOGY.zusammenhaenge],
+];
+
+export function publicTerminologyText(value: string): string {
+  return PUBLIC_TEXT_REPLACEMENTS.reduce(
+    (current, [pattern, replacement]) => current.replace(pattern, replacement),
+    value,
+  );
+}

--- a/apps/web/tests/public-terminology.contract.test.ts
+++ b/apps/web/tests/public-terminology.contract.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { PUBLIC_TERMINOLOGY, publicTerminologyText } from "@/features/public/publicTerminology";
+
+describe("public terminology contract", () => {
+  it("keeps short public Voxy labels canonical", () => {
+    expect(PUBLIC_TERMINOLOGY.withVoxy).toBe("Mit Voxy");
+    expect(PUBLIC_TERMINOLOGY.withoutVoxy).toBe("Ohne Voxy");
+  });
+
+  it("maps internal product terms to public-facing terms", () => {
+    const text = "KI bereitet einen Anlassraum, eine Runde, ein Dossier und den Graph vor.";
+
+    expect(publicTerminologyText(text)).toBe(
+      "Voxy bereitet einen Mitmachraum, eine Mitmachschritt, ein Themen-Zusammenfassung und den Zusammenhänge vor.",
+    );
+  });
+
+  it("removes AI-Usage-Event wording from public copy", () => {
+    expect(publicTerminologyText("Kein AI-Usage-Event gestartet.")).toBe(
+      "Kein Voxy-Schritt gestartet.",
+    );
+  });
+});

--- a/apps/web/tests/public-terminology.contract.test.ts
+++ b/apps/web/tests/public-terminology.contract.test.ts
@@ -8,10 +8,10 @@ describe("public terminology contract", () => {
   });
 
   it("maps internal product terms to public-facing terms", () => {
-    const text = "KI bereitet einen Anlassraum, eine Runde, ein Dossier und den Graph vor.";
+    const text = "KI | Anlassraum | Runden | Dossier | Graph";
 
     expect(publicTerminologyText(text)).toBe(
-      "Voxy bereitet einen Mitmachraum, eine Mitmachschritt, ein Themen-Zusammenfassung und den Zusammenhänge vor.",
+      "Voxy | Mitmachraum | Mitmachschritte | Themen-Zusammenfassung | Zusammenhänge",
     );
   });
 


### PR DESCRIPTION
## Summary
- adds a central public terminology contract for public-facing labels like Mit Voxy, Ohne Voxy, Mitmachraum, Themen-Zusammenfassung and Themenüberblick
- replaces local manual terminology replacement helpers in the Mitmachraum setup/support surfaces
- adds a terminology contract test so internal terms do not leak back into public copy helpers

## Critical review notes
- this is intentionally a terminology contract, not a full public copy rewrite
- replacement is intentionally scoped to short technical fragments, labels and Voxy helper copy
- public copy should still prefer manually written German sentences over blind string replacement where grammar matters
- internal domain naming remains untouched so existing data/runtime concepts are not renamed accidentally

## Suggested checks
- pnpm --filter @vog/web lint
- pnpm --filter @vog/web typecheck
- pnpm --filter @vog/web test:production-public-routes
- pnpm --filter @vog/web exec vitest run tests/public-terminology.contract.test.ts