### PR TITLE
fix(public): align entry copy with refined terminology

### DIFF
--- a/apps/web/src/app/dossier/ui.tsx
+++ b/apps/web/src/app/dossier/ui.tsx
@@ -24,9 +24,9 @@ type DossierHandoffPreview = {
 function readableNextStepLabel(action?: string | null): string {
   switch (action) {
     case "append_to_dossier":
-      return "Zusammenfassung ergänzen";
+      return "Debatte & Argumente ergänzen";
     case "create_dossier":
-      return "Neue Themen-Zusammenfassung vorbereiten";
+      return "Neue Debatte & Argumente vorbereiten";
     case "request_factcheck":
       return "Prüfung vorbereiten";
     default:
@@ -123,10 +123,10 @@ export default function DossierIndexClient(props: {
 
         <div className="public-dialog-area">
           <div className="public-section space-y-2">
-            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[rgb(var(--muted))]">Themen-Zusammenfassung</p>
-            <h1 className="text-2xl font-semibold text-[rgb(var(--fg))]">Aus deinem Beitrag wird ein verständlicher Überblick.</h1>
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[rgb(var(--muted))]">Debatte &amp; Argumente</p>
+            <h1 className="text-2xl font-semibold text-[rgb(var(--fg))]">Aus deinem Beitrag entsteht ein verständlicher Debattenstand.</h1>
             <p className="text-sm text-[rgb(var(--muted))]">
-              Eine Themen-Zusammenfassung bündelt Anliegen, prüfbare Aussagen, Quellenfragen, Gegenpositionen, Zuständigkeit und offene Punkte. Nichts wird automatisch veröffentlicht oder irgendwo angehängt.
+              Debatte &amp; Argumente bündelt Anliegen, prüfbare Aussagen, Quellenfragen, Gegenpositionen, Zuständigkeit und offene Punkte. Nichts wird automatisch veröffentlicht oder irgendwo angehängt.
             </p>
           </div>
 
@@ -138,7 +138,7 @@ export default function DossierIndexClient(props: {
             <div className="public-dialog-surface mt-5 space-y-4 px-4 py-5">
               <div className="space-y-2">
                 <p className="text-sm font-semibold text-[rgb(var(--fg))]">
-                  Noch keine Themen-Zusammenfassung geöffnet.
+                  Noch keine Debatte &amp; Argumente geöffnet.
                 </p>
                 <p className="text-sm leading-6 text-[rgb(var(--muted))]">
                   Starte mit einem kurzen Beitrag. eDebatte kann daraus eine erste Struktur vorbereiten: Was ist die Kernfrage, welche Aussagen sind prüfbar, welche Belege fehlen und welche Gegenpositionen sollten sichtbar werden?
@@ -157,10 +157,10 @@ export default function DossierIndexClient(props: {
               </div>
               <div className="flex flex-wrap gap-2">
                 <Link href="/create?intent=create_dossier" className="btn-primary min-h-[42px] px-3 py-2 text-sm">
-                  Beitrag zusammenfassen lassen
+                  Debatte &amp; Argumente vorbereiten
                 </Link>
                 <Link href="/themen" className="btn-secondary min-h-[42px] px-3 py-2 text-sm">
-                  Beispielthemen ansehen
+                  Themensuche öffnen
                 </Link>
               </div>
             </div>

--- a/apps/web/src/app/runden/new/AnlassraumSetupForm.tsx
+++ b/apps/web/src/app/runden/new/AnlassraumSetupForm.tsx
@@ -383,7 +383,7 @@ export default function AnlassraumSetupForm({
                 {
                   key: "themes",
                   title: "Passende Themen finden",
-                  description: "Mit demselben Anliegen im Themenüberblick weiterarbeiten.",
+                  description: "Mit demselben Anliegen in der Themensuche weiterarbeiten.",
                   href: "/themen?startDraft=1",
                   onClick: () => updateStartDraftContext({ targetHint: "themes" }),
                 },

--- a/apps/web/src/app/runden/new/page.tsx
+++ b/apps/web/src/app/runden/new/page.tsx
@@ -50,10 +50,10 @@ export default async function RundenManualCreatePage(props: {
             </p>
           </div>
           <Link
-            href="/runden"
+            href="/themen"
             className="vog-btn-secondary"
           >
-            Zurück zum Themenüberblick
+            Zurück zur Themensuche
           </Link>
         </div>
 
@@ -78,11 +78,11 @@ export default async function RundenManualCreatePage(props: {
               <strong className="text-[rgb(var(--fg))]">Mit Voxy</strong> werden Thema, Fragen, Zielgruppe und nächste Schritte geordnet.
             </li>
             <li>
-              Themen-Zusammenfassung, Beteiligung oder Veröffentlichung entstehen erst nach bewusster Prüfung und Bestätigung.
+              Debatte &amp; Argumente, Beteiligung oder Veröffentlichung entstehen erst nach bewusster Prüfung und Bestätigung.
             </li>
           </ul>
           <p className="mt-3 leading-6 text-[rgb(var(--muted))]">
-            So bleibt verständlich, was vorbereitet wurde, was noch offen ist und wobei Menschen konkret mitmachen können.
+            So bleibt verständlich, was vorbereitet wurde, was noch offen ist und wobei Menschen konkret aktiv dabei sein können.
           </p>
         </section>
 

--- a/apps/web/src/app/themen/page.tsx
+++ b/apps/web/src/app/themen/page.tsx
@@ -5,8 +5,8 @@ import { listRoundsByTopicSlug, listTopics, type Topic } from "@features/topicRo
 import ThemenStartDraftAssistant from "./ThemenStartDraftAssistant";
 
 export const metadata: Metadata = {
-  title: "Themen · eDebatte",
-  description: "Aktuelle, geplante und archivierte Themen mit klaren Anschlusswegen.",
+  title: "Themensuche · eDebatte",
+  description: "Finde Themen, Debatten und Beteiligungsmöglichkeiten mit klaren Anschlusswegen.",
 };
 
 type ThemenStage = "aktuell" | "geplant" | "archiv";
@@ -98,7 +98,7 @@ function StageSection({
 
                 <div className="mt-3 flex flex-wrap gap-2 text-xs text-[rgb(var(--muted))]">
                   <span className="rounded-full border border-[rgb(var(--border))] bg-[rgb(var(--card))] px-2.5 py-1">
-                    Offene Mitmachräume: {openRounds}
+                    Aktiv dabei möglich: {openRounds}
                   </span>
                   <span className="rounded-full border border-[rgb(var(--border))] bg-[rgb(var(--card))] px-2.5 py-1">
                     Abgeschlossene Schritte: {closedRounds}
@@ -107,10 +107,10 @@ function StageSection({
 
                 <div className="mt-3 flex flex-wrap gap-2">
                   <Link href={`/topic/${topic.slug}`} className="btn-secondary inline-flex">
-                    Thema öffnen
+                    Debatte &amp; Argumente ansehen
                   </Link>
                   <Link href={`/runden?topic=${encodeURIComponent(topic.slug)}`} className="btn-secondary inline-flex">
-                    Mitmachräume ansehen
+                    Aktiv dabei
                   </Link>
                 </div>
               </li>
@@ -131,17 +131,17 @@ export default function ThemenPage() {
   return (
     <ProductSurfaceShell>
       <header className="rounded-[1.75rem] border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-6 shadow-sm sm:p-8">
-        <p className="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">Themenüberblick</p>
-        <h1 className="mt-2 text-3xl font-bold tracking-tight text-[rgb(var(--fg))] sm:text-4xl">Das große Ganze hinter einzelnen Beiträgen.</h1>
+        <p className="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">Themensuche</p>
+        <h1 className="mt-2 text-3xl font-bold tracking-tight text-[rgb(var(--fg))] sm:text-4xl">Finde, wo dein Beitrag anknüpft.</h1>
         <p className="mt-3 max-w-4xl text-sm leading-relaxed text-[rgb(var(--muted))] sm:text-base">
-          eDebatte sammelt Anliegen nicht als lose Kommentare. Der Themenüberblick zeigt, welche Fragen bereits sichtbar sind, wo kleine Mitmachräume vorbereitet werden und wo dein Beitrag weiterhelfen kann.
+          eDebatte sammelt Anliegen nicht als lose Kommentare. Die Themensuche zeigt, welche Debatten bereits sichtbar sind, wo Argumente und offene Fragen gesammelt werden und wo du aktiv dabei sein kannst.
         </p>
         <div className="mt-5 flex flex-wrap gap-3">
           <Link href="/create?intent=issue_signal" className="btn-primary inline-flex">
             Beitrag einordnen
           </Link>
           <Link href="/runden" className="btn-secondary inline-flex">
-            Mitmachräume ansehen
+            Aktiv dabei
           </Link>
           <Link href="/create?intent=round_setup" className="btn-secondary inline-flex">
             Abstimmungsfähigkeit prüfen
@@ -160,9 +160,9 @@ export default function ThemenPage() {
       <div className="mt-8 space-y-4">
         <StageSection
           title="Aktuell"
-          subtitle="Themen mit sichtbarem Arbeitsstand und möglicher Beteiligung."
+          subtitle="Themen mit sichtbarer Debatte, Argumenten und möglicher Beteiligung."
           topics={aktuell}
-          emptyText="Hier erscheinen Themen, sobald ein Anliegen ausreichend eingeordnet wurde. Bis dahin kannst du einen eigenen Beitrag starten oder vorhandene Mitmachräume ansehen."
+          emptyText="Hier erscheinen Themen, sobald ein Anliegen ausreichend eingeordnet wurde. Bis dahin kannst du einen eigenen Beitrag starten oder schauen, wo du bereits aktiv dabei sein kannst."
         />
         <StageSection
           title="Geplant"

--- a/apps/web/tests/public-debug-leak.guard.test.ts
+++ b/apps/web/tests/public-debug-leak.guard.test.ts
@@ -24,6 +24,11 @@ const FORBIDDEN_PUBLIC_DEBUG_TERMS = [
   "kein KI-Lauf",
 ] as const;
 
+const FORBIDDEN_REPLACED_PUBLIC_TERMS = [
+  "Themen-Zusammenfassung",
+  "Themenüberblick",
+] as const;
+
 function readPublicSurfaceFile(path: string) {
   return readFileSync(resolve(process.cwd(), path), "utf8");
 }
@@ -36,6 +41,22 @@ describe("public debug leak guard", () => {
       const source = readPublicSurfaceFile(file);
 
       for (const term of FORBIDDEN_PUBLIC_DEBUG_TERMS) {
+        if (source.includes(term)) {
+          leaks.push(`${file}: ${term}`);
+        }
+      }
+    }
+
+    expect(leaks).toEqual([]);
+  });
+
+  it("keeps replaced public terminology off the aligned entry surfaces", () => {
+    const leaks: string[] = [];
+
+    for (const file of PUBLIC_SURFACE_FILES) {
+      const source = readPublicSurfaceFile(file);
+
+      for (const term of FORBIDDEN_REPLACED_PUBLIC_TERMS) {
         if (source.includes(term)) {
           leaks.push(`${file}: ${term}`);
         }


### PR DESCRIPTION
## Summary
- aligns the public `/themen` copy with Themensuche, Debatte & Argumente and Aktiv dabei
- aligns the public `/dossier` surface with Debatte & Argumente while keeping the route/internal model untouched
- aligns `/runden/new` helper copy with Themensuche and Debatte & Argumente
- extends the public leak guard so replaced terms do not reappear on the aligned entry surfaces

## Scope
- copy-only public surface alignment
- no auth, runtime, data-model, publishing or routing behavior changes

## Suggested checks
- pnpm --filter @vog/web lint
- pnpm --filter @vog/web typecheck
- pnpm --filter @vog/web test:production-public-routes
- pnpm --filter @vog/web exec vitest run tests/public-debug-leak.guard.test.ts tests/public-terminology.contract.test.ts