### PR TITLE
docs(v3): manifest canonical language bridge runtime backlog

### DIFF
--- a/docs/E150/V3_CANONICAL_COMPLETION_READINESS_GUARDRAILS_2026-07-06.md
+++ b/docs/E150/V3_CANONICAL_COMPLETION_READINESS_GUARDRAILS_2026-07-06.md
@@ -1,0 +1,273 @@
+# V3 Canonical Completion Readiness Guardrails
+
+Stand: 2026-07-06
+
+## Zweck
+
+Diese Datei ergaenzt `docs/E150/V3_CANONICAL_LANGUAGE_BRIDGE_RUNTIME_BACKLOG_2026-07-06.md` um die letzte Meta-Ebene: Abschlussfaehigkeit, Betriebsreife, Rollout, Sicherheit, Messbarkeit und saubere Grenzen.
+
+Sie ist bewusst **keine neue Feature-Wunschliste**. Sie definiert, wann eine V3-Capability wirklich als fachlich abschliessbar gelten darf und wann nur ein sichtbarer Zwischenstand vorliegt.
+
+## Grundsatz 1: Definition of Done fuer jede V3-Capability
+
+Eine V3-Capability gilt erst als fachlich fertig, wenn mindestens diese Ebenen vorhanden sind:
+
+- kanonische Doku / OpenTasks-Verankerung
+- typed Contract oder begruendete Bridge zu bestehendem Contract
+- relevante Contract-/Guardrail-Tests
+- Admin- oder Review-Sicht, sofern die Capability operatorisch relevant ist
+- Public-/User-Sicht, sofern die Capability nutzerseitig sichtbar wird
+- Reviewpfad und Rollenbezug
+- Fehlerstatus und Blockerstatus
+- Recovery-/Retry- oder manuelle Korrekturmoeglichkeit
+- Audit-/Provenance-Hinweis
+- klare Non-Goals und Stop-Regeln
+- keine falsche Readiness-Hochstufung
+
+Kanonischer Satz:
+
+> Eine Capability ist nicht fertig, nur weil sie sichtbar ist. Fertig ist sie erst, wenn Doku, Contract, Test, Review, Fehlerstatus, Rollout-Grenze und Audit zusammenpassen.
+
+## Grundsatz 2: Preview ist nicht Runtime, Draft ist nicht Publish
+
+Diese Unterscheidung muss repo-weit erhalten bleiben.
+
+Nicht gleichsetzen:
+
+- Preview ≠ Runtime
+- Suggestion ≠ Entscheidung
+- Draft ≠ Publish
+- Publish-ready ≠ Published
+- Handoff ≠ Vollzug
+- Review-ready ≠ Approved
+- Source hint ≠ verifizierte Quelle
+- Trust hint ≠ Faktencheck-Siegel
+- planned_handoff ≠ persistierte Runtime-Wahrheit
+- operational_basic ≠ endstate_ready
+
+Kanonischer Satz:
+
+> Sichtbarkeit ist kein Endstand. Preview ist kein Runtime-Pfad. Draft ist kein Publish. Handoff ist kein Vollzug. Suggestion ist keine Entscheidung.
+
+## Grundsatz 3: Demo-Journey als Abnahmepfad
+
+Jede V3-Automation muss an einer realistischen Demo-/User-Journey pruefbar sein.
+
+Mindestjourney:
+
+```text
+User schreibt etwas
+-> Voxy/eDebatte ordnet ein
+-> Sprache, Original und Uebersetzung bleiben sauber getrennt
+-> Aussagen, Fragen und Quellenlage werden sichtbar
+-> Unsicherheiten und offene Punkte werden markiert
+-> passendes Beteiligungsformat wird vorgeschlagen
+-> Vorschau entsteht
+-> Review-ready Zustand entsteht
+-> Publish-ready / Activation-ready Zustand entsteht
+-> One-click Aktivierung ist erst nach Review moeglich
+-> User sieht, was aus dem Beitrag wurde
+```
+
+Akzeptanz:
+
+- Kein Beitrag verschwindet ohne Rueckmeldung.
+- Kein oeffentlicher Output entsteht ohne passenden Review.
+- Keine technische Runtime-Wahrheit wird oeffentlich als fertiger Status verkauft.
+- Jeder Schritt zeigt, was vorbereitet wurde und was noch fehlt.
+
+## Grundsatz 4: Rollen-, Rechte- und Organisationsgrenzen
+
+Nicht jeder Nutzer darf jeden Schritt ausloesen oder freigeben.
+
+Mindestens zu unterscheiden:
+
+- Gast / nicht eingeloggter Nutzer
+- eingeloggter Nutzer
+- Beitragsersteller
+- Moderator
+- Redaktion / Operator
+- Organisation / Kommune / Mandant
+- Admin
+- Superadmin
+- Kosten-/Provider-verantwortliche Rolle
+
+Regeln:
+
+- One-click Publish/Activate setzt passende Rolle plus passenden Reviewstatus voraus.
+- Organisations- oder kommunale Sichtbarkeit braucht Organisations-/Mandantenfreigabe.
+- Moderations- und Abuse-Faelle brauchen Moderationsreview.
+- Kostenrelevante Schritte koennen eigene Freigabe brauchen.
+- Public Output darf nicht allein aus technischer Fertigstellung folgen.
+
+## Grundsatz 5: Entitlement, Paywall, Credits und Kontingente
+
+Automatisierung darf nur so weit laufen, wie Rolle, Paket, Credits und Reviewstatus es erlauben.
+
+Zu klaeren / spaeter zu operationalisieren:
+
+- Was ist frei nutzbar?
+- Was braucht Login?
+- Was ist Demo-only?
+- Was ist hinter Paywall?
+- Was verbraucht Credits?
+- Was braucht Organisations-/Admin-Plan?
+- Welche Providerkosten duerfen automatisch vorbereitet werden?
+- Wann wird nur ein Vorschlag gezeigt statt ein Lauf gestartet?
+
+Kanonischer Satz:
+
+> Auto-Prepare darf attraktiv wirken, aber kosten- und paketpflichtige Schritte brauchen klare Entitlement-, Credit- und Review-Grenzen.
+
+## Grundsatz 6: Public Safety, Abuse, PII und sensible Inhalte
+
+Public-ready ist nicht nur technisch publish-ready.
+
+Zusaetzlich zu pruefen:
+
+- personenbezogene Daten / PII
+- Minderjaehrige
+- Beleidigung, Hass, Hetze, Drohung
+- sensible politische Inhalte
+- Gesundheits-, Rechts- oder Finanzbehauptungen
+- private Anschuldigungen
+- manipulierte oder unklare Quellen
+- koordinierte Kampagnen / Spam
+- Standortdaten oder identifizierende Details
+- Bild-, Voice- oder Avatarrechte
+
+Regeln:
+
+- Sensitive Inhalte brauchen erhoehten Review.
+- Voxy darf sensible Zuspitzung nicht ungeprueft als Fakt ausgeben.
+- Public Output darf bei PII-/Abuse-/Safety-Blockern nicht aktivierbar sein.
+- User-facing soll klar sagen, dass vor Aktivierung noch Schutz-/Pruefschritte offen sind.
+
+## Grundsatz 7: Versionierung und Audit von KI-Ableitungen
+
+Jede KI-Ableitung muss nachvollziehbar bleiben.
+
+Mindestens zu dokumentieren / spaeter technisch abzubilden:
+
+- urspruengliche Eingabe
+- Zeitpunkt der Verarbeitung
+- genutzte Sprachebenen
+- Quellenstand / SourcePack
+- Provider/Modell, sofern reale Runtime-Wahrheit vorhanden ist
+- Prompt-/Run-Referenz oder RunReceipt, sofern vorhanden
+- erzeugte Ableitung: Zusammenfassung, Einordnung, Formatvorschlag, Script, Draft
+- Reviewentscheidung
+- Reviewrolle
+- Veraenderungen nach Review
+- final aktivierte/veroeffentlichte Version
+
+Kanonischer Satz:
+
+> Jede KI-Ableitung braucht Version, Herkunft, Quellenstand und Reviewhistorie. Ohne diese Provenance bleibt sie Draft oder Vorschlag.
+
+## Grundsatz 8: Feature-Flags, Admin-Gates und Rollout-Grenzen
+
+Neue V3-Funktionen duerfen vorbereitet, aber nicht unkontrolliert oeffentlich aktiviert werden.
+
+Regeln:
+
+- Neue Public-Flows brauchen Feature-Flag oder Admin-Gate.
+- Beta-/Demo-Flows muessen als solche erkennbar sein.
+- Provider-, Rendering-, DeepSearch- und Publishing-Pfade brauchen separate Aktivierung.
+- Public Routes duerfen keine internen Debug-/Runtime-Begriffe leaken.
+- Rollback oder Deaktivierung muss moeglich bleiben.
+
+Kanonischer Satz:
+
+> V3 darf sichtbar wachsen, aber neue oeffentliche Wirkung braucht Rollout-Gate, Review-Gate und deaktivierbaren Pfad.
+
+## Grundsatz 9: Migration, Altbestand und Terminologie
+
+Public Copy darf modernisiert werden, aber Runtime- und Datenmodell-Migrationen brauchen eigene Pfade.
+
+Regeln:
+
+- Alte Begriffe nicht blind loeschen.
+- Interne Begriffe wie Dossier koennen erhalten bleiben, waehrend Public Copy `Debatte & Argumente` nutzt.
+- Bestehende URLs, Slugs und Daten duerfen nicht unabsichtlich brechen.
+- Neue Terminologie braucht Mapping, nicht Hard-Cut.
+- Migrationen brauchen Tests oder zumindest dokumentierte Nicht-Ziele.
+
+Kanonischer Satz:
+
+> Public-Sprache darf schneller modernisiert werden als Runtime-Modelle. Datenmodell- und URL-Migrationen brauchen explizite Migrationspfade.
+
+## Grundsatz 10: Messbarkeit und KPI-Faehigkeit
+
+V3 ist erst produktiv, wenn Fortschritt, Blocker, Kosten und Beteiligung sichtbar werden.
+
+Zu messen / spaeter operatorisch sichtbar zu machen:
+
+- wie viele Eingaben eingehen
+- wie viele eingeordnet werden
+- wie viele Formatvorschlaege entstehen
+- welche Formate vorgeschlagen werden
+- wie viele Outputs `review_ready` erreichen
+- wie viele `publish_ready` erreichen
+- wie viele nach Review aktiviert/veroeffentlicht werden
+- wo Nutzer abbrechen
+- welche Review-Blocker haeufig sind
+- welche Quellen-/Trust-Luecken haeufig sind
+- welche Providerkosten entstehen
+- welche Automationen fehlschlagen
+- wie viele Beitraege zu echter Beteiligung fuehren
+
+Kanonischer Satz:
+
+> V3-Erfolg misst sich nicht an erzeugten Vorschlaegen, sondern an nachvollziehbar vorbereiteten, geprueften und sinnvoll aktivierten Beteiligungspfaden.
+
+## Grundsatz 11: Abschlussfaehigkeit statt endloser Zwischenstand
+
+Jede neue V3-Aufgabe braucht einen Abschlussmodus:
+
+- Was ist der kleinste ehrliche Endstand?
+- Was ist bewusst nur docs-only?
+- Was ist contract-only?
+- Was ist operational_basic?
+- Was ist endstate_ready?
+- Welche Folgepfade bleiben offen?
+- Welche Tests belegen den Stand?
+- Was darf oeffentlich sichtbar sein?
+- Was bleibt intern/admin?
+
+Kanonischer Satz:
+
+> Keine halbe Zwischenloesung gilt als final. Jeder Slice muss sagen, ob er Doku, Contract, Preview, Runtime, Review oder Public-Endstand liefert.
+
+## Einbindung in den morgigen Codex-Autopilot
+
+Der Codex-Autopilot soll diese Datei als zweite kanonische Referenz nutzen:
+
+- `docs/E150/V3_CANONICAL_LANGUAGE_BRIDGE_RUNTIME_BACKLOG_2026-07-06.md`
+- `docs/E150/V3_CANONICAL_COMPLETION_READINESS_GUARDRAILS_2026-07-06.md`
+
+Ergaenzende Anweisung fuer den Autopilot:
+
+```text
+Nutze zusaetzlich docs/E150/V3_CANONICAL_COMPLETION_READINESS_GUARDRAILS_2026-07-06.md als Meta-Guardrail.
+Jede neu angelegte oder aktualisierte V3-Task muss klar unterscheiden:
+- docs_only
+- contract_only
+- preview_only
+- operational_basic
+- endstate_ready
+
+Stufe nichts hoch, wenn Tests, Reviewpfad, Rollout-Gate, Fehlerstatus oder Provenance fehlen.
+Halte in OpenTasks fest, welche Capabilities zwar sichtbar, aber noch nicht abgeschlossen sind.
+```
+
+## Nicht-Ziel dieser Datei
+
+- keine neue Runtime
+- keine neue UI
+- keine neuen Provider
+- keine neuen Tests
+- keine OpenTasks-Aenderung
+- keine ProductionReadiness-Hochstufung
+
+Diese Datei manifestiert nur die Abschluss- und Betriebsreife-Regeln, damit Codex morgen nicht nur Features sortiert, sondern auch Abschlussfaehigkeit und Grenzen sauber fuehrt.

--- a/docs/E150/V3_CANONICAL_LANGUAGE_BRIDGE_RUNTIME_BACKLOG_2026-07-06.md
+++ b/docs/E150/V3_CANONICAL_LANGUAGE_BRIDGE_RUNTIME_BACKLOG_2026-07-06.md
@@ -1,0 +1,529 @@
+# V3 Canonical Language Bridge Runtime Backlog
+
+Stand: 2026-07-06
+
+## Zweck
+
+Diese Datei manifestiert die in der aktuellen V3-Abstimmung konsolidierten Produktregeln, Guardrails und Codex-Folgepfade fuer eDebatte/Voxy.
+
+Sie ersetzt keine `OpenTasks.md`, sondern dient als kanonische Verdichtung fuer den naechsten OpenTasks-/Codex-Sweep. Sobald `docs/E150/OpenTasks.md` aktualisiert ist, bleibt `OpenTasks.md` der operative SSOT.
+
+## Repo-Manifestationsregel
+
+1. `docs/E150/V3_CANONICAL_LANGUAGE_BRIDGE_RUNTIME_BACKLOG_2026-07-06.md`
+   - Kanonische Verdichtung aller hier besprochenen Produktentscheidungen.
+   - Grundlage fuer Codex-Prompts und OpenTasks-Normalisierung.
+2. `docs/E150/OpenTasks.md`
+   - Operative Queue.
+   - Morgen gezielt per Codex aktualisieren, nicht manuell in einem grossen unsicheren Patch.
+3. `docs/E150/ProductionReadinessMatrix.md`
+   - Nur Statusfortschreibung nach realer Umsetzung oder Reality-Audit.
+   - Nicht als Wunschliste verwenden.
+4. GitHub Issue `#310`
+   - Voxy Video Briefing Flow Mastertask.
+   - Muss auf diese Datei und die Auto-Prepare-/Publish-ready-Regel verweisen.
+5. Code-Contracts und Tests
+   - Erst in Codex-Slices anlegen.
+   - Heute keine Runtime- oder Produktlogik ohne Tests anfassen.
+
+## Grundsatz 1: User gibt frei ein, eDebatte ordnet ein
+
+Der Nutzer soll nicht vorab entscheiden muessen, ob er Poll, Statement, Dossier, Mitmachraum, Live-Frage oder Social-/Voxy-Output braucht.
+
+Kanonischer Flow:
+
+```text
+User gibt ein
+-> Voxy/eDebatte ordnet ein
+-> Sprache, Original und Uebersetzung werden getrennt
+-> Aussagen, Fragen, Quellenlage und Unsicherheiten werden sichtbar
+-> passendes Beteiligungsformat wird vorgeschlagen
+-> Vorschau entsteht
+-> Publish-ready / Activation-ready Zustand wird vorbereitet
+-> Nutzer/Admin prueft
+-> Aktivierung/Veroeffentlichung erfolgt erst nach Review
+```
+
+## Grundsatz 2: Auto-Prepare statt Auto-Publish
+
+Nicht aktivieren:
+
+- Auto-Publish
+- automatische oeffentliche Aktivierung von Mitmachraeumen
+- automatische Poll-/Live-Frage-/Statement-/Social-/Voxy-Video-Veroeffentlichung
+- automatische externe Social-API-Ausloesung
+
+Aktivieren:
+
+- Auto-Draft
+- Auto-Enrichment
+- Auto-Format-Recommendation
+- Auto-Preview
+- Auto-Schedule-Suggestion
+- Publish-ready / Activation-ready Status
+- One-click Publish/Activate nach passendem Review
+
+Kanonischer Satz:
+
+> eDebatte automatisiert Vorbereitung, Einordnung, Anreicherung, Formatvorschlag, Vorschau und Publish-ready-Status, aber niemals oeffentliche Aktivierung ohne Review.
+
+## Grundsatz 3: Gemeinsamer Statusvertrag fuer Outputs
+
+Alle outputfaehigen Objekte sollen mittelfristig eine gemeinsame Statusgrammatik nutzen oder darauf mappen:
+
+```ts
+type CanonicalPreparationStatus =
+  | "draft"
+  | "needs_clarification"
+  | "review_ready"
+  | "publish_ready"
+  | "scheduled_after_review"
+  | "active_or_published"
+  | "archived"
+  | "failed";
+```
+
+Gemeinsame Guardrail-Flags:
+
+```ts
+type CanonicalPublishGuard = {
+  autoPublish: false;
+  reviewRequired: true;
+  publicOutputAllowed: boolean; // false bis passendes Review/Approval
+  publishActionEnabled: boolean; // true erst nach passendem Approval
+  externalSocialApiTriggered: false;
+};
+```
+
+Akzeptanzkriterium:
+
+- `publish_ready` bedeutet nicht `published`.
+- `publishActionEnabled` darf erst nach Review/Approval true werden.
+- `publicOutputAllowed` bleibt false, solange Review fehlt oder Blocker bestehen.
+
+## Grundsatz 4: Restpruefungs-Checkliste sichtbar machen
+
+Jeder vorbereitete Output braucht eine sichtbare Liste dessen, was noch offen ist.
+
+Beispiele:
+
+- Quelle fehlt
+- Quellenlage unklar
+- Zustaendigkeit offen
+- Uebersetzung unsicher
+- Poll-Frage noch zu breit
+- Poll-Optionen nicht neutral genug
+- Live-Kontext fehlt
+- Beteiligungsformat braucht Review
+- sensitive Inhalte brauchen erhoehten Review
+- Provider-/Kosten-Preflight fehlt
+
+Public/UX-Sprache:
+
+```text
+Voxy hat deinen Beitrag eingeordnet.
+Debatte & Argumente sind vorbereitet.
+Quellenlage ist ergaenzt.
+Ein passendes Format wurde vorgeschlagen.
+Noch offen: Quelle pruefen / Zustaendigkeit klaeren.
+Veroeffentlichungsbereit nach Review.
+```
+
+Nicht oeffentlich verwenden:
+
+- KI-Lauf
+- Runtime fehlt
+- Handoff pending
+- missing_runtime_truth
+- planned_not_active
+- Provider-Matrix
+
+Technische Wahrheit bleibt intern/admin sichtbar, aber User-facing wird sie in verstaendlichen Fortschritt uebersetzt.
+
+## Grundsatz 5: Review ist rollen- und objektbezogen
+
+Review darf nicht generisch bleiben.
+
+Kanonische Review-Typen:
+
+- `self_review`: Nutzer prueft eigenen Beitrag/Entwurf.
+- `editorial_review`: Redaktion/Operator prueft Debatte, Aussagen, Quellen und Sprache.
+- `org_review`: Organisation/Verwaltung prueft Aktivierung oder offizielle Sichtbarkeit.
+- `moderation_review`: Missbrauch, PII, sensible Inhalte, Sicherheit.
+- `cost_provider_review`: kostenrelevante Provider-, Research-, Render- oder Export-Schritte.
+- `publish_review`: finale oeffentliche Aktivierung/Veroeffentlichung.
+
+One-click Publish/Activate ist nur erlaubt, wenn der passende Review-Typ durch die passende Rolle abgeschlossen ist.
+
+## Grundsatz 6: Evidence/Source Pack als gemeinsames Kernobjekt
+
+Dossier, Statements, Polls, Social Drafts, Voxy Video, Factcheck, Feed-Enrichment und Public Outputs sollen nicht jeweils eigene Quellenlogik erfinden.
+
+Kanonisches Zielobjekt:
+
+```ts
+type CanonicalSourcePack = {
+  sourcePackId: string;
+  sources: Array<{
+    sourceId: string;
+    title: string;
+    url?: string;
+    sourceLocale?: string;
+    regionCode?: string;
+    sourceType: "official" | "media" | "civil_society" | "academic" | "user_supplied" | "unknown";
+    reliabilityHint: "official" | "primary" | "secondary" | "contested" | "unknown";
+    retrievedAt?: string;
+    originalSnippet?: string;
+    translatedSnippet?: string;
+    translationStatus?: "not_needed" | "translated" | "needs_review" | "uncertain";
+    evidenceState: "source_needed" | "partial" | "contested" | "supported" | "context_missing" | "outdated";
+  }>;
+  openGaps: string[];
+  reviewState: "review_required" | "approved" | "rejected";
+};
+```
+
+Regeln:
+
+- Keine Fake-Quellen.
+- Keine erfundenen Treffer.
+- Keine Quelle wird durch Uebersetzung ersetzt.
+- Originalquelle und Originalsprache bleiben erhalten.
+- Quellensicherheit wird als Hinweis/Status gezeigt, nicht als KI-Wahrheitssiegel.
+
+## Grundsatz 7: Language Bridge statt klassischer i18n-Abkuerzung
+
+UI-Sprache, Originalsprache, Arbeitssprache, Ausgabesprache und Quellensprache sind getrennt zu behandeln.
+
+Kanonische Ebenen:
+
+- Original
+- Uebersetzung
+- Zusammenfassung
+- Voxy-Einordnung
+- Quellenlage
+- offene Fragen
+- Unsicherheit
+
+Regeln:
+
+- Original bleibt immer erhalten.
+- Uebersetzung wird markiert.
+- Zusammenfassung ersetzt nie Original oder Quelle.
+- Zitate, Positionen und kulturelle Nuancen werden nicht still normalisiert.
+- Unsichere Uebersetzung wird sichtbar markiert.
+- RTL-Unterstuetzung, insbesondere Arabisch, gehoert zum Contract.
+
+## Grundsatz 8: Cross-lingual Matching nur als Vorschlag
+
+Cross-lingual Matching darf Themen, Claims und Dubletten vorschlagen, aber nicht automatisch mergen.
+
+Regeln:
+
+- Tuerkischer Beitrag kann deutsches Thema erkennen.
+- Arabische Antwort kann deutsch gelesen werden.
+- Schwedische oder franzoesische Quelle kann in deutscher Lesesprache zusammengefasst werden.
+- Gleiche oder aehnliche Claims werden als moegliche Dublette markiert.
+- Merge/Zuordnung erfolgt review-first.
+- Minderheitenperspektiven duerfen nicht durch Normalisierung verschwinden.
+
+## Grundsatz 9: Trust-Layer statt harter KI-Faktenrichter
+
+Oeffentlich soll eDebatte nicht als Wahrheitsrichter auftreten.
+
+Zielstatus fuer Aussagen:
+
+- `source_needed`
+- `source_present`
+- `context_missing`
+- `contested`
+- `partially_supported`
+- `supported`
+- `normative_position`
+- `jurisdiction_unclear`
+- `translation_uncertain`
+- `outdated`
+
+Public Copy:
+
+- Quellenlage
+- Beleglage
+- Kontextpruefung
+- Gegenposition
+- Unsicherheit
+- offene Punkte
+
+Nicht als finale Wahrheit behaupten:
+
+- KI-Faktencheck abgeschlossen
+- wahr/falsch ohne Pruefpfad
+- Factcheck-Seal ohne echten Review und Quellenpfad
+
+## Grundsatz 10: Nicht Newsmaschine, nicht Content-Schleuder
+
+Feeds, Social und Voxy dienen Debattenstand, Quellenlage, Verstaendigung und Beteiligung.
+
+Nicht Ziel:
+
+- endlose Newsfeed-Startseite
+- Trend-Content-Spam
+- Social-Media-Maschine ohne Quellenlage
+- Voxy-Video aus Trenddruck ohne Dossier-/Review-Kontext
+
+Ziel:
+
+- Relevante Signale erkennen
+- Quellenlage anreichern
+- Debattenstand verbessern
+- geeignete Beteiligungsform vorschlagen
+- reviewfaehige Outputs vorbereiten
+
+## Grundsatz 11: Provider-Neutralitaet plattformweit
+
+Nicht nur Voxy Video, sondern alle externen Integrationen muessen austauschbar bleiben.
+
+Provider-Klassen:
+
+- `LLMProvider`
+- `TranslationProvider`
+- `SearchProvider`
+- `FactcheckProvider`
+- `VoiceProvider`
+- `AvatarProvider`
+- `RenderProvider`
+- `PublishProvider`
+- `StorageProvider`
+
+Regeln:
+
+- Kein Feature-Code bindet direkt an einen Anbieter.
+- Provider-Ausfall fuehrt zu sichtbarem Fehlerstatus, nicht stillem Erfolg.
+- Kosten-/Nutzungstruth muss fuer kostenrelevante Schritte vorbereitet sein.
+- Externe Tools sind Adapter, nicht Produktkern.
+
+## Grundsatz 12: Kosten- und Provider-Preflight
+
+Auto-Enrichment ist erlaubt, aber kostenrelevante Schritte brauchen Preflight.
+
+Preflight muss zeigen:
+
+- welcher Schritt gestartet wird
+- welcher Provider genutzt wird
+- ob Kosten/Limits betroffen sind
+- ob Review/Approval notwendig ist
+- ob Fallback moeglich ist
+- ob Output oeffentlich werden kann oder nur Draft bleibt
+
+Besonders relevant fuer:
+
+- DeepSearch
+- mehrsprachige Uebersetzung in groesserem Volumen
+- Voxy Voice
+- Avatar/Talking Head
+- Rendering
+- Social-/Publishing-Exports
+- grosse Evidence/Feed-Laeufe
+
+## Grundsatz 13: Recovery, Retry und Audit als Automationspflicht
+
+Jeder automatische Vorbereitungsschritt braucht:
+
+- Status
+- Fehlergrund
+- Retry-Moeglichkeit
+- manuelle Korrektur
+- Audit Trail
+- keine stillen Fehler
+- keine doppelten Runtime-Records ohne Merge-/Review-Entscheid
+
+Dies gilt fuer:
+
+- Create/Analyze
+- Dossier-Handoff
+- Feed-Enrichment
+- Translation
+- Source Pack
+- Poll-Vorschlag
+- Social Draft
+- Voxy Script
+- Render Job
+- Publishing Draft
+
+## Grundsatz 14: User-Lifecycle — kein Beitrag ins Nichts
+
+Jeder Beitrag braucht nachvollziehbare Rueckmeldung.
+
+User-facing Lifecycle:
+
+```text
+Eingegangen
+-> eingeordnet
+-> Thema/Debatte gefunden oder neu vorbereitet
+-> Aussagen/Fragen erkannt
+-> Quellenlage ergaenzt oder offen markiert
+-> Formatvorschlag erstellt
+-> Review-ready
+-> Publish-ready / Activation-ready
+-> aktiviert/veroeffentlicht oder mit Grund zurueckgestellt
+-> Ergebnis/Auswertung verfuegbar
+```
+
+Akzeptanzkriterium:
+
+- User sieht, was aus seinem Beitrag wurde.
+- User sieht, wer/was als naechstes pruefen muss.
+- User sieht, ob sein Beitrag oeffentlich wurde, angehaengt wurde oder noch Klaerung braucht.
+
+## Grundsatz 15: Voxy Persona Guardrails
+
+Voxy ist Moderator und Brueckenbauer, nicht Richter, Amt oder politische Autoritaet.
+
+Regeln:
+
+- Voxy ist klar als Avatar/Mascot gekennzeichnet.
+- Kein Eindruck, Voxy sei eine echte Person.
+- Voxy spricht keine amtliche Wahrheit.
+- Voxy ordnet ein, zeigt Quellenlage, macht Unsicherheit sichtbar.
+- Voxy darf keine politische Zuspitzung ungeprueft als Fakt darstellen.
+- Stimme, Avatar, Assets und Brand-Regeln werden versioniert.
+- Rechte/Lizenzen von Stimme/Avatar/Assets muessen dokumentiert bleiben.
+
+## Operative Codex-Reihenfolge ab morgen
+
+### Codex 1 — Canonical OpenTasks Sweep
+
+Task-ID:
+
+`V3-CANONICAL-LANGUAGE-BRIDGE-RUNTIME-BACKLOG-01`
+
+Ziel:
+
+- `docs/E150/OpenTasks.md` mit einem neuen operativen V3-Block ergaenzen.
+- Diese Datei als kanonischen Beleg referenzieren.
+- Keine Runtime-Implementierung.
+- Keine Status-Hochstufung in `ProductionReadinessMatrix.md`, ausser als docs-only/verankert.
+
+OpenTasks-Block soll mindestens enthalten:
+
+1. `V3-AUTO-PREPARE-PUBLISH-READY-GUARD-01`
+2. `V3-CANONICAL-PREPARATION-STATUS-CONTRACT-01`
+3. `V3-LANGUAGE-BRIDGE-TRUST-FORMAT-CONTRACT-01`
+4. `V3-EVIDENCE-SOURCE-PACK-CONTRACT-01`
+5. `V3-ROLE-SPECIFIC-REVIEW-CONTRACT-01`
+6. `V3-USER-CONTRIBUTION-LIFECYCLE-01`
+7. `V3-DOWNSTREAM-RUNTIME-HANDOFF-PERSISTENCE-01`
+8. `V3-PARTICIPATION-POLL-HANDOFF-PERSISTENCE-01`
+9. `V3-UNIFIED-REVIEW-QUEUE-01`
+10. `V3-DOSSIER-WORKSPACE-REVIEW-SURFACE-01`
+11. `V3-MULTILINGUAL-STATEMENTS-COMMENTS-THREADS-01`
+12. `V3-MULTILINGUAL-EVIDENCE-TRUST-01`
+13. `V3-CROSS-LINGUAL-TOPIC-CLAIM-CLUSTERING-01`
+14. `V3-DOSSIER-SOCIAL-OUTPUT-DRAFTS-01`
+15. `V3-VOXY-VIDEO-BRIEFING-FLOW-MASTER-01`
+
+### Codex 2 — Contract Types + Tests
+
+Erst nach Codex 1.
+
+Ziel:
+
+- shared Contract fuer `CanonicalPreparationStatus` und Publish-Guard anlegen.
+- Contract-Tests fuer `autoPublish=false`, `reviewRequired=true`, `publish_ready !== published`.
+- Keine Public-Action vor passendem Review.
+
+### Codex 3 — Language Bridge / Trust / Format Recommendation
+
+Ziel:
+
+- Language Bridge Contract operationalisieren.
+- Trust-Layer Status statt finalem Faktenrichter.
+- Format Recommendation review-first und publish-safe.
+
+### Codex 4 — Evidence/Source Pack
+
+Ziel:
+
+- gemeinsames SourcePack-Modell vorbereiten.
+- Feed, Dossier, Claim, Social und Voxy spaeter darauf ausrichten.
+
+### Codex 5 — Downstream Runtime Handoff
+
+Ziel:
+
+- Dossier-Runtime-Draft sauber in Graph-/Anlassraum-/Participation-Folgepfade tragen.
+- Weiterhin kein Auto-Publish, kein Auto-Graph-Write, kein Auto-DeepSearch.
+
+### Codex 6 — Review Queue / Dossier Workspace
+
+Ziel:
+
+- Unified Review Queue als zentrale Arbeitsflaeche.
+- Dossier Workspace mit Claims, Gegenpositionen, Quellen, Fragen, Poll-/Social-/Voxy-Kandidaten.
+
+### Codex 7 — Voxy Video Architecture + Types
+
+Ziel:
+
+- Issue #310 in `docs/E150/V3_VOXY_VIDEO_BRIEFING_FLOW_2026-07-06.md` ueberfuehren.
+- `apps/web/src/features/voxyVideo/` vorbereiten.
+- Types, Statusmodell, Provider-Interfaces und Contract-Tests anlegen.
+- Keine Provider-Implementierung, kein Rendering, kein Publishing.
+
+## Codex-Prompt fuer morgen: erster Slice
+
+```text
+Du arbeitest im Repo VOGADMINRGF/edebatte-org.
+
+Ziel: Fuehre einen docs-only Canonical OpenTasks Sweep fuer V3 durch.
+
+Ausgangslage:
+- docs/E150/OpenTasks.md ist der operative SSOT.
+- docs/E150/V3_CANONICAL_LANGUAGE_BRIDGE_RUNTIME_BACKLOG_2026-07-06.md enthaelt die neu kanonisierten Produktregeln.
+- Issue #310 ist der Voxy Video Briefing Flow Mastertask.
+
+Aufgabe:
+1. Ergaenze docs/E150/OpenTasks.md um einen neuen operativen V3-Block fuer die naechsten Slices.
+2. Nimm mindestens diese Tasks auf:
+   - V3-AUTO-PREPARE-PUBLISH-READY-GUARD-01
+   - V3-CANONICAL-PREPARATION-STATUS-CONTRACT-01
+   - V3-LANGUAGE-BRIDGE-TRUST-FORMAT-CONTRACT-01
+   - V3-EVIDENCE-SOURCE-PACK-CONTRACT-01
+   - V3-ROLE-SPECIFIC-REVIEW-CONTRACT-01
+   - V3-USER-CONTRIBUTION-LIFECYCLE-01
+   - V3-DOWNSTREAM-RUNTIME-HANDOFF-PERSISTENCE-01
+   - V3-PARTICIPATION-POLL-HANDOFF-PERSISTENCE-01
+   - V3-UNIFIED-REVIEW-QUEUE-01
+   - V3-DOSSIER-WORKSPACE-REVIEW-SURFACE-01
+   - V3-MULTILINGUAL-STATEMENTS-COMMENTS-THREADS-01
+   - V3-MULTILINGUAL-EVIDENCE-TRUST-01
+   - V3-CROSS-LINGUAL-TOPIC-CLAIM-CLUSTERING-01
+   - V3-DOSSIER-SOCIAL-OUTPUT-DRAFTS-01
+   - V3-VOXY-VIDEO-BRIEFING-FLOW-MASTER-01
+3. Fuehre fuer jeden Task Status, Priority, Depends on, Scope, Goal, Acceptance Criteria, Decision open und Evidence/Notes auf.
+4. Halte fest: Auto-Prepare ja, Auto-Publish nein.
+5. Halte fest: publish_ready ist nicht published.
+6. Halte fest: One-click Publish/Activate erst nach passendem Review/Approval.
+7. Halte fest: externe Provider bleiben Adapter, nicht Produktkern.
+8. Keine Runtime-Implementierung, keine Status-Hochstufung, keine Produktlogik.
+9. Aktualisiere docs/E150/ProductionReadinessMatrix.md nur falls dort ein docs-only Verweis sinnvoll ist; keine falsche Readiness behaupten.
+10. Ergaenze oder aktualisiere Tests nur, falls bestehende Docs-/Guardrail-Tests zwingend einen neuen Verweis brauchen.
+
+Validierung:
+- git diff --check
+- falls keine Codeaenderung: keine unnoetigen Build-/Typecheck-Laeufe
+- falls Tests angepasst werden: gezielte relevante Tests laufen lassen
+
+Ergebnis:
+- PR mit knapper Summary
+- klare Folgeempfehlung fuer den naechsten Contract-Type-Slice
+```
+
+## Heute bewusst nicht anfassen
+
+- Keine direkte Aenderung an `OpenTasks.md` ohne vollstaendigen Kontextpatch.
+- Keine Runtime-/Code-Implementierung.
+- Keine Tests ohne Code-/Contract-Aenderung.
+- Keine `ProductionReadinessMatrix`-Hochstufung.
+- Kein Merge von Voxy/Provider/Render/Publish-Logik.
+
+Heute reicht: diese Doku manifestieren, Issue #310 ergaenzen, PR oeffnen.

--- a/docs/E150/V3_CODEX_AUTOPILOT_PROMPT_2026-07-06.md
+++ b/docs/E150/V3_CODEX_AUTOPILOT_PROMPT_2026-07-06.md
@@ -1,0 +1,257 @@
+# V3 Codex Autopilot Master Prompt
+
+Stand: 2026-07-06
+
+## Zweck
+
+Diese Datei ist der vorbereitete One-Prompt fuer einen effizienten Codex-Lauf.
+
+Ziel ist nicht, Checks oder Review zu umgehen, sondern Codex mit einem einzigen Startprompt so zu fuehren, dass er die notwendigen V3-Schritte selbst sequenziert, nur relevante Checks ausfuehrt, sauber commitet und bei echten Blockern stoppt.
+
+## Wann verwenden
+
+Nach Merge von PR `#311` bzw. nachdem folgende Datei auf `main` vorhanden ist:
+
+`docs/E150/V3_CANONICAL_LANGUAGE_BRIDGE_RUNTIME_BACKLOG_2026-07-06.md`
+
+## Empfohlener Branch
+
+```bash
+git checkout main
+git pull --ff-only
+git checkout -b pr/v3-canonical-runtime-autopilot-01
+```
+
+## Codex Autopilot Prompt
+
+```text
+Du arbeitest im Repo VOGADMINRGF/edebatte-org.
+
+Ziel:
+Fuehre einen gefuehrten V3-Autopilot-Lauf durch, der die kanonischen Produktregeln aus docs/E150/V3_CANONICAL_LANGUAGE_BRIDGE_RUNTIME_BACKLOG_2026-07-06.md in OpenTasks, Contracts und erste sichere Tests ueberfuehrt.
+
+Wichtig:
+- Arbeite sequenziell innerhalb dieses einen Prompts.
+- Erstelle keine unkontrollierte Mega-Implementierung.
+- Nutze kleine interne Phasen mit separaten Commits.
+- Stoppe bei echten Produktentscheidungen, unklarer Persistenz, fehlender Runtime-Wahrheit oder roten Checks, die du nicht sicher beheben kannst.
+- Erfinde keine Runtime, keine Quellen, keine Provider, keine externen Automationen und keine Readiness.
+- Kein Auto-Publish.
+- Auto-Prepare / Publish-ready / One-click-after-review ist der Zielkompromiss.
+
+Kanonische Referenzen:
+- docs/E150/OpenTasks.md ist der operative SSOT.
+- docs/E150/V3_CANONICAL_LANGUAGE_BRIDGE_RUNTIME_BACKLOG_2026-07-06.md ist die neue V3-Kanonik fuer diesen Lauf.
+- docs/E150/ProductionReadinessMatrix.md nur dann aktualisieren, wenn du docs-only Status/Verweis ehrlich ergaenzen kannst. Keine Hoherstufung ohne gebaute Runtime.
+- GitHub Issue #310 bleibt Voxy Video Briefing Flow Mastertask.
+
+Arbeitsmodus:
+Fuehre die folgenden Phasen nacheinander aus. Nach jeder Phase:
+1. Pruefe `git diff --check`.
+2. Fuehre nur relevante Tests/Checks aus.
+3. Erstelle einen Commit, wenn die Phase sauber abgeschlossen ist.
+4. Dokumentiere im Commit oder PR-Body, was bewusst nicht umgesetzt wurde.
+
+Phase 1 — OpenTasks Canonical Sweep
+Aufgabe:
+- Ergaenze docs/E150/OpenTasks.md um einen kompakten operativen V3-Block.
+- Referenziere docs/E150/V3_CANONICAL_LANGUAGE_BRIDGE_RUNTIME_BACKLOG_2026-07-06.md als Evidence.
+- Nimm mindestens diese Tasks auf:
+  - V3-AUTO-PREPARE-PUBLISH-READY-GUARD-01
+  - V3-CANONICAL-PREPARATION-STATUS-CONTRACT-01
+  - V3-LANGUAGE-BRIDGE-TRUST-FORMAT-CONTRACT-01
+  - V3-EVIDENCE-SOURCE-PACK-CONTRACT-01
+  - V3-ROLE-SPECIFIC-REVIEW-CONTRACT-01
+  - V3-USER-CONTRIBUTION-LIFECYCLE-01
+  - V3-DOWNSTREAM-RUNTIME-HANDOFF-PERSISTENCE-01
+  - V3-PARTICIPATION-POLL-HANDOFF-PERSISTENCE-01
+  - V3-UNIFIED-REVIEW-QUEUE-01
+  - V3-DOSSIER-WORKSPACE-REVIEW-SURFACE-01
+  - V3-MULTILINGUAL-STATEMENTS-COMMENTS-THREADS-01
+  - V3-MULTILINGUAL-EVIDENCE-TRUST-01
+  - V3-CROSS-LINGUAL-TOPIC-CLAIM-CLUSTERING-01
+  - V3-DOSSIER-SOCIAL-OUTPUT-DRAFTS-01
+  - V3-VOXY-VIDEO-BRIEFING-FLOW-MASTER-01
+- Jeder Task braucht: Status, Priority, Depends on, Scope, Goal, Acceptance Criteria, Decision open, Evidence/Notes.
+- Keine Runtime-Implementierung.
+
+Akzeptanz:
+- OpenTasks hat eine klare naechste Queue.
+- Auto-Prepare ja / Auto-Publish nein ist sichtbar.
+- `publish_ready` ist nicht `published`.
+- One-click Publish/Activate erst nach Review/Approval.
+- Externe Provider bleiben Adapter, nicht Produktkern.
+
+Phase 2 — Canonical Preparation Status Contract
+Aufgabe:
+- Suche bestehende Status-/Publish-/Review-Contracts.
+- Lege nur dann einen neuen shared Contract an, wenn es repo-architektonisch sauber passt.
+- Ziel ist ein kleiner Contract fuer:
+  - `draft`
+  - `needs_clarification`
+  - `review_ready`
+  - `publish_ready`
+  - `scheduled_after_review`
+  - `active_or_published`
+  - `archived`
+  - `failed`
+- Ergaenze Guardrail-Flags:
+  - `autoPublish = false`
+  - `reviewRequired = true`
+  - `publicOutputAllowed = false` bis Approval
+  - `publishActionEnabled = false` bis Approval
+  - `externalSocialApiTriggered = false`
+- Ergaenze Contract-Tests.
+
+Akzeptanz:
+- Tests sichern: publish_ready !== published.
+- Tests sichern: ohne Approval keine Public Action.
+- Keine bestehende Runtime wird umgebaut.
+- Keine oeffentliche Route wird automatisch aktiviert.
+
+Phase 3 — Language Bridge / Trust / Format Recommendation Contract
+Aufgabe:
+- Baue auf vorhandenen Language-Context-Contracts auf.
+- Kein Cross-lingual Grossumbau.
+- Lege, falls passend, kleine shared Types/Helpers fuer folgende Ebenen an:
+  - Original
+  - Uebersetzung
+  - Zusammenfassung
+  - Voxy-Einordnung
+  - Quellenlage
+  - offene Fragen
+  - Unsicherheit
+- Lege Trust-/Evidence-State-Typen an oder harmonisiere vorhandene:
+  - source_needed
+  - source_present
+  - context_missing
+  - contested
+  - partially_supported
+  - supported
+  - normative_position
+  - jurisdiction_unclear
+  - translation_uncertain
+  - outdated
+- Lege Format-Recommendation-Typen an:
+  - clarify
+  - debate_and_arguments
+  - comment_thread
+  - poll
+  - live_question
+  - mitmachraum
+  - statement_review
+  - source_review
+- Alles review-first, kein Auto-Publish.
+- Tests fuer Trust-Layer und Format-Recommendation ergaenzen.
+
+Akzeptanz:
+- Uebersetzung ersetzt Original nicht.
+- Zusammenfassung ersetzt Quelle nicht.
+- Formatvorschlag bleibt Vorschlag.
+- ReviewRequired bleibt true.
+
+Phase 4 — Evidence / Source Pack Contract
+Aufgabe:
+- Suche bestehende Source-/Evidence-/Feed-/Factcheck-Contracts.
+- Lege einen kleinen gemeinsamen SourcePack-Contract an oder dokumentiere bewusst, warum nur ein Adapter-/Bridge-Contract sinnvoll ist.
+- Pflichtfelder sollen mindestens abbilden:
+  - Originalquelle
+  - Originalsprache
+  - Quellentyp
+  - Region
+  - Abruf-/Standdatum, falls vorhanden
+  - reliabilityHint
+  - primary/official/media/civilSociety hints
+  - originalSnippet
+  - translatedSnippet
+  - translationStatus
+  - evidenceState
+  - openGaps
+  - reviewState
+- Keine externen Quellen suchen.
+- Keine Fake-Quellen.
+- Keine DeepSearch starten.
+
+Akzeptanz:
+- Tests sichern fehlende Quellen als `source_needed` oder vergleichbaren ehrlichen Status.
+- SourcePack kann spaeter von Dossier, Social und Voxy genutzt werden.
+
+Phase 5 — Voxy Video Architecture Docs Alignment
+Aufgabe:
+- Lege `docs/E150/V3_VOXY_VIDEO_BRIEFING_FLOW_2026-07-06.md` an oder aktualisiere eine vorhandene passende Datei.
+- Nutze Issue #310 als Inhalt/Evidence.
+- Halte fest:
+  - eDebatte besitzt Workflow, Datenmodell, Review, Branding, Quellenlogik und Publishing Queue.
+  - Externe Tools sind nur Provider/Adapter.
+  - Auto-Prepare ja, Auto-Publish nein.
+  - Voxy ist Avatar/Mascot, nicht echte Person, nicht Amt, nicht Wahrheitsrichter.
+  - Rendering/Provider-Implementierung ist bewusst nicht Teil dieses Slices.
+- Optional: Falls repo-architektonisch passend, bereite `apps/web/src/features/voxyVideo/` nur mit reinen Types/Contracts und Tests vor. Keine Provider-Integration, kein Rendering, kein Publishing.
+
+Akzeptanz:
+- Voxy Video ist als E150-Kanonik dokumentiert.
+- Keine externe Tool-Abhaengigkeit wird fest verdrahtet.
+- Kein Video-Rendering oder Publishing wird aktiviert.
+
+Phase 6 — Final Docs / Matrix / PR Body
+Aufgabe:
+- Aktualisiere docs/E150/ProductionReadinessMatrix.md nur, wenn ein ehrlicher docs-only/contract-only Verweis noetig ist.
+- Keine `operational_basic`, `endstate_ready` oder `production_ready` Hochstufung fuer neu angelegte Contracts.
+- Ergaenze PR-Body mit:
+  - Phasenliste
+  - geaenderte Dateien
+  - ausgefuehrte Checks
+  - bewusst nicht umgesetzt
+  - naechste empfohlene PRs, falls noch offen
+
+Stop-Regeln:
+Stoppe sofort und liefere eine klare Blocker-Zusammenfassung, wenn:
+- OpenTasks-Struktur unklar ist und du Gefahr laeufst, den SSOT zu beschaedigen.
+- bestehende Contracts widerspruechlich sind.
+- Tests rot bleiben und nicht lokal/sicher behebbar sind.
+- du eine Produktentscheidung brauchst.
+- eine Runtime-/Persistenzbehauptung noetig waere, die nicht belegbar ist.
+
+Was ausdruecklich nicht Ziel ist:
+- kein Auto-Publish
+- keine automatische oeffentliche Aktivierung
+- kein Social API Posting
+- kein Voxy Rendering
+- kein Avatar-/Voice-Provider
+- kein DeepSearch-Autostart
+- keine Cross-lingual Matching Engine
+- keine Migration aller Inhalte
+- keine neue Produktparallelwelt
+- keine Status-Hochstufung ohne gebaute Runtime
+
+Mindest-Checks:
+- immer: git diff --check
+- bei Docs-only: keine unnoetigen Build-/Typecheck-Laeufe
+- bei TS/Tests: relevante vitest-Tests fuer die geaenderten Contracts
+- bei App-Code: pnpm -C apps/web run typecheck und pnpm -C apps/web run lint, falls betroffen
+
+Am Ende:
+- Erstelle einen PR gegen main.
+- PR-Titel: `feat(v3): add canonical preparation and language bridge contracts`
+- PR-Body mit Summary, Scope, Checks, bewusst nicht umgesetzt, Folgepfade.
+```
+
+## Empfehlung fuer Kontingent-schonendes Vorgehen
+
+Ein einzelner Autopilot-Prompt ist moeglich, aber er sollte Codex intern zu kleinen Phasen und Commits zwingen.
+
+Nicht empfehlen:
+
+- ein einziger riesiger ungepruefter Commit
+- Checks komplett auslassen
+- OpenTasks, Contracts, Runtime, Voxy und Provider alles gleichzeitig ohne Stop-Regeln
+
+Empfohlen:
+
+- ein Prompt
+- ein Branch
+- ein PR
+- mehrere interne Commits
+- relevante Checks pro Phase
+- harte Stop-Regeln
+- keine Runtime-Erfindungen


### PR DESCRIPTION
## Summary
- adds a canonical E150 V3 backlog document for language bridge, trust layer, auto-prepare/publish-ready, review roles, source packs, provider neutrality, Voxy guardrails and tomorrow's Codex sequence
- adds completion/readiness meta-guardrails so V3 work distinguishes docs_only, contract_only, preview_only, operational_basic and endstate_ready instead of treating visibility as done
- adds a Codex Autopilot master prompt for a one-prompt, one-branch, one-PR workflow with internal phases, relevant checks and hard stop rules
- keeps `OpenTasks.md` untouched for a targeted Codex sweep instead of a risky large manual SSOT edit
- links the Voxy Video Flow direction to the broader V3 guardrails via Issue #310 comment

## Scope
- docs-only canonical planning artifacts
- no runtime/code changes
- no readiness status upgrade
- no OpenTasks mutation yet

## Added docs
- `docs/E150/V3_CANONICAL_LANGUAGE_BRIDGE_RUNTIME_BACKLOG_2026-07-06.md`
- `docs/E150/V3_CANONICAL_COMPLETION_READINESS_GUARDRAILS_2026-07-06.md`
- `docs/E150/V3_CODEX_AUTOPILOT_PROMPT_2026-07-06.md`

## Suggested next Codex step
`V3-CANONICAL-LANGUAGE-BRIDGE-RUNTIME-BACKLOG-01`

Goal: update `docs/E150/OpenTasks.md` with a compact operative V3 queue referencing the canonical documents, then proceed to contract types/tests.

## Explicit non-goals
- no Auto-Publish
- no public activation
- no provider integration
- no rendering/publishing runtime
- no ProductionReadiness upgrade
- no OpenTasks edit in this PR