### PR TITLE
feat(agentic): add personal Voxy first-login companion runtime

### DIFF
--- a/apps/web/src/app/account/PersonalVoxyFirstLoginCompanion.tsx
+++ b/apps/web/src/app/account/PersonalVoxyFirstLoginCompanion.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+
+type CompanionMode = "passive" | "relevant_only" | "periodic_overview" | "active_companion";
+
+type SavedCompanionProfile = {
+  mode: CompanionMode;
+  region: string;
+  interests: string[];
+  savedAt: string;
+};
+
+const STORAGE_KEY = "edebatte.personal-voxy.first-login.v1";
+
+const MODES: Array<{ id: CompanionMode; title: string; description: string }> = [
+  {
+    id: "passive",
+    title: "Nur auf Anfrage",
+    description: "Voxy bleibt im Hintergrund und reagiert nur, wenn du ihn öffnest.",
+  },
+  {
+    id: "relevant_only",
+    title: "Relevante Hinweise",
+    description: "Nur Hinweise mit klarem Bezug zu deiner Region oder deinen Themen.",
+  },
+  {
+    id: "periodic_overview",
+    title: "Regelmäßiger Überblick",
+    description: "Ein ruhiger Überblick über neue Themen und Beteiligungsmöglichkeiten.",
+  },
+  {
+    id: "active_companion",
+    title: "Aktiv begleiten",
+    description: "Voxy schlägt Zusammenhänge, Beteiligungen und nächste Schritte vor.",
+  },
+];
+
+const INTERESTS = [
+  "Nachbarschaft",
+  "Mobilität",
+  "Bildung",
+  "Gesundheit",
+  "Stadtentwicklung",
+  "Klima & Umwelt",
+  "Soziales",
+  "Digitalisierung",
+];
+
+const DAILY_IMPULSES = [
+  "Was ist dir heute im gesellschaftlichen Miteinander aufgefallen?",
+  "Was könnte aus deiner Sicht dahinterstecken?",
+  "Welche Veränderung oder Wirkung wäre dir dabei wichtig?",
+];
+
+function readSavedProfile(): SavedCompanionProfile | null {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<SavedCompanionProfile>;
+    if (!parsed.mode || !Array.isArray(parsed.interests)) return null;
+    return {
+      mode: parsed.mode,
+      region: typeof parsed.region === "string" ? parsed.region : "",
+      interests: parsed.interests.filter((value): value is string => typeof value === "string"),
+      savedAt: typeof parsed.savedAt === "string" ? parsed.savedAt : new Date().toISOString(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function PersonalVoxyFirstLoginCompanion({ welcomeNotice = false }: { welcomeNotice?: boolean }) {
+  const [mode, setMode] = useState<CompanionMode>("relevant_only");
+  const [region, setRegion] = useState("");
+  const [interests, setInterests] = useState<string[]>([]);
+  const [consent, setConsent] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [expanded, setExpanded] = useState(welcomeNotice);
+
+  useEffect(() => {
+    const stored = readSavedProfile();
+    if (!stored) return;
+    setMode(stored.mode);
+    setRegion(stored.region);
+    setInterests(stored.interests);
+    setConsent(true);
+    setSaved(true);
+  }, []);
+
+  const selectedMode = useMemo(() => MODES.find((item) => item.id === mode) ?? MODES[1], [mode]);
+
+  function toggleInterest(interest: string) {
+    setSaved(false);
+    setInterests((current) =>
+      current.includes(interest)
+        ? current.filter((item) => item !== interest)
+        : [...current, interest],
+    );
+  }
+
+  function saveProfile() {
+    if (!consent) return;
+    const profile: SavedCompanionProfile = {
+      mode,
+      region: region.trim(),
+      interests,
+      savedAt: new Date().toISOString(),
+    };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(profile));
+    setSaved(true);
+  }
+
+  function resetProfile() {
+    window.localStorage.removeItem(STORAGE_KEY);
+    setMode("relevant_only");
+    setRegion("");
+    setInterests([]);
+    setConsent(false);
+    setSaved(false);
+  }
+
+  return (
+    <section
+      aria-labelledby="personal-voxy-heading"
+      className="overflow-hidden rounded-[28px] border border-sky-400/20 bg-gradient-to-br from-slate-950 via-slate-950 to-sky-950/50 shadow-[0_24px_80px_rgba(2,132,199,0.12)]"
+    >
+      <div className="grid gap-0 lg:grid-cols-[minmax(0,1.25fr)_minmax(280px,0.75fr)]">
+        <div className="space-y-5 p-5 md:p-7">
+          <div className="flex items-start gap-4">
+            <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl border border-sky-300/30 bg-sky-400/10 text-xl font-black text-sky-300 shadow-inner">
+              V
+            </div>
+            <div className="min-w-0 space-y-2">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-sky-400">
+                Dein persönlicher Voxy
+              </p>
+              <h2 id="personal-voxy-heading" className="text-xl font-semibold text-white md:text-2xl">
+                Schön, dass du da bist.
+              </h2>
+              <p className="max-w-2xl text-sm leading-6 text-slate-300">
+                Ich begleite dich durch eDebatte, erkläre Zusammenhänge und zeige dir passende
+                Beteiligungsmöglichkeiten. Du entscheidest, wie aktiv ich sein darf und was ich mir merke.
+              </p>
+            </div>
+          </div>
+
+          {!expanded ? (
+            <div className="flex flex-wrap gap-3">
+              <button
+                type="button"
+                onClick={() => setExpanded(true)}
+                className="rounded-full bg-sky-400 px-5 py-2.5 text-sm font-semibold text-slate-950 transition hover:bg-sky-300"
+              >
+                Voxy einrichten
+              </button>
+              <Link
+                href="/create"
+                className="rounded-full border border-white/15 px-5 py-2.5 text-sm font-semibold text-white transition hover:border-sky-300/50 hover:bg-white/5"
+              >
+                Direkt etwas einbringen
+              </Link>
+            </div>
+          ) : (
+            <div className="space-y-6">
+              <fieldset className="space-y-3">
+                <legend className="text-sm font-semibold text-white">Wie soll Voxy dich begleiten?</legend>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {MODES.map((item) => {
+                    const active = item.id === mode;
+                    return (
+                      <button
+                        key={item.id}
+                        type="button"
+                        onClick={() => {
+                          setMode(item.id);
+                          setSaved(false);
+                        }}
+                        aria-pressed={active}
+                        className={`rounded-2xl border p-3 text-left transition ${
+                          active
+                            ? "border-sky-300/70 bg-sky-400/10"
+                            : "border-white/10 bg-white/[0.03] hover:border-white/20"
+                        }`}
+                      >
+                        <span className="block text-sm font-semibold text-white">{item.title}</span>
+                        <span className="mt-1 block text-xs leading-5 text-slate-400">{item.description}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </fieldset>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <label className="space-y-2">
+                  <span className="text-sm font-semibold text-white">Deine Region</span>
+                  <input
+                    value={region}
+                    onChange={(event) => {
+                      setRegion(event.target.value);
+                      setSaved(false);
+                    }}
+                    placeholder="z. B. Rahnsdorf, Berlin"
+                    className="w-full rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-sm text-white outline-none placeholder:text-slate-600 focus:border-sky-300/70"
+                  />
+                </label>
+                <div className="space-y-2">
+                  <p className="text-sm font-semibold text-white">Themen, die dich interessieren</p>
+                  <div className="flex flex-wrap gap-2">
+                    {INTERESTS.map((interest) => {
+                      const active = interests.includes(interest);
+                      return (
+                        <button
+                          key={interest}
+                          type="button"
+                          onClick={() => toggleInterest(interest)}
+                          aria-pressed={active}
+                          className={`rounded-full border px-3 py-1.5 text-xs transition ${
+                            active
+                              ? "border-sky-300/60 bg-sky-400/15 text-sky-100"
+                              : "border-white/10 text-slate-300 hover:border-white/25"
+                          }`}
+                        >
+                          {interest}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+
+              <label className="flex items-start gap-3 rounded-2xl border border-white/10 bg-black/15 p-3 text-xs leading-5 text-slate-300">
+                <input
+                  type="checkbox"
+                  checked={consent}
+                  onChange={(event) => {
+                    setConsent(event.target.checked);
+                    setSaved(false);
+                  }}
+                  className="mt-1 h-4 w-4 rounded border-white/20 bg-transparent"
+                />
+                <span>
+                  Voxy darf diese Auswahl ausschließlich in diesem Browser speichern. Du kannst sie jederzeit
+                  ändern oder vollständig zurücksetzen. Es entsteht keine automatische Veröffentlichung und keine
+                  politische Einstufung.
+                </span>
+              </label>
+
+              <div className="flex flex-wrap items-center gap-3">
+                <button
+                  type="button"
+                  disabled={!consent}
+                  onClick={saveProfile}
+                  className="rounded-full bg-sky-400 px-5 py-2.5 text-sm font-semibold text-slate-950 transition enabled:hover:bg-sky-300 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  Begleitung speichern
+                </button>
+                <button
+                  type="button"
+                  onClick={resetProfile}
+                  className="rounded-full border border-white/10 px-4 py-2.5 text-sm text-slate-300 transition hover:border-white/25 hover:text-white"
+                >
+                  Zurücksetzen
+                </button>
+                <span className="text-xs text-slate-400" aria-live="polite">
+                  {saved ? `Gespeichert · ${selectedMode.title}` : "Noch nicht gespeichert"}
+                </span>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <aside className="border-t border-white/10 bg-black/20 p-5 lg:border-l lg:border-t-0 md:p-7">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-sky-400">
+            Was bewegt dich heute?
+          </p>
+          <h3 className="mt-2 text-lg font-semibold text-white">Drei kurze Impulse</h3>
+          <p className="mt-2 text-xs leading-5 text-slate-400">
+            Nicht um dich einzuordnen, sondern damit Voxy dein Thema und deine Argumentation besser versteht.
+          </p>
+          <ol className="mt-5 space-y-3">
+            {DAILY_IMPULSES.map((impulse, index) => (
+              <li key={impulse} className="flex gap-3 rounded-2xl border border-white/10 bg-white/[0.03] p-3">
+                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-sky-400/10 text-xs font-bold text-sky-300">
+                  {index + 1}
+                </span>
+                <span className="text-sm leading-5 text-slate-200">{impulse}</span>
+              </li>
+            ))}
+          </ol>
+          <div className="mt-5 grid gap-2">
+            <Link
+              href="/create?entryIntent=observation&entryMode=guided"
+              className="rounded-2xl bg-white px-4 py-3 text-center text-sm font-semibold text-slate-950 transition hover:bg-sky-100"
+            >
+              Einen Gedanken teilen
+            </Link>
+            <Link
+              href="/themen"
+              className="rounded-2xl border border-white/10 px-4 py-3 text-center text-sm font-semibold text-white transition hover:border-sky-300/50 hover:bg-white/5"
+            >
+              Aktuelle Themen ansehen
+            </Link>
+          </div>
+          <p className="mt-4 text-[11px] leading-5 text-slate-500">
+            Regionale Live-Recherche und automatische Themenwache werden erst nach ausdrücklicher Freigabe als
+            eigener Runtime-Schritt aktiviert. Bis dahin bleibt Voxy transparent und review-first.
+          </p>
+        </aside>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/account/page.tsx
+++ b/apps/web/src/app/account/page.tsx
@@ -1,6 +1,7 @@
 // file: app/account/page.tsx
 import { redirect } from "next/navigation";
 import { AccountClient } from "./AccountClient";
+import { PersonalVoxyFirstLoginCompanion } from "./PersonalVoxyFirstLoginCompanion";
 import { getAccountOverview } from "@features/account/service";
 import { readSession } from "@/utils/session";
 import { PRODUCTION_ENTRY_COPY } from "@/features/access/productionEntryContract";
@@ -63,6 +64,8 @@ export default async function AccountPage({ searchParams }: Props) {
             {buildVoxyExperienceShellHint("account")} {buildAgenticCivicE2EAccountHint()}
           </p>
         </header>
+
+        <PersonalVoxyFirstLoginCompanion welcomeNotice={welcomeNotice} />
 
         <AccountClient
           initialData={overview}

--- a/apps/web/tests/personal-voxy-first-login-companion.runtime.test.tsx
+++ b/apps/web/tests/personal-voxy-first-login-companion.runtime.test.tsx
@@ -20,7 +20,7 @@ describe("personal Voxy first-login companion runtime", () => {
     expect(html).toContain("Was könnte aus deiner Sicht dahinterstecken?");
     expect(html).toContain("ausschließlich in diesem Browser speichern");
     expect(html).toContain("keine politische Einstufung");
-    expect(html).toContain("Keine automatische Veröffentlichung");
+    expect(html).toContain("keine automatische Veröffentlichung");
     expect(html).toContain("Einen Gedanken teilen");
     expect(html).toContain("Aktuelle Themen ansehen");
   });

--- a/apps/web/tests/personal-voxy-first-login-companion.runtime.test.tsx
+++ b/apps/web/tests/personal-voxy-first-login-companion.runtime.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { PersonalVoxyFirstLoginCompanion } from "@/app/account/PersonalVoxyFirstLoginCompanion";
+
+describe("personal Voxy first-login companion runtime", () => {
+  it("renders the personal welcome, consent boundary and civic impulses", () => {
+    const html = renderToStaticMarkup(
+      <PersonalVoxyFirstLoginCompanion welcomeNotice />,
+    );
+
+    expect(html).toContain("Dein persönlicher Voxy");
+    expect(html).toContain("Schön, dass du da bist");
+    expect(html).toContain("Wie soll Voxy dich begleiten?");
+    expect(html).toContain("Nur auf Anfrage");
+    expect(html).toContain("Relevante Hinweise");
+    expect(html).toContain("Regelmäßiger Überblick");
+    expect(html).toContain("Aktiv begleiten");
+    expect(html).toContain("Was bewegt dich heute?");
+    expect(html).toContain("Drei kurze Impulse");
+    expect(html).toContain("Was könnte aus deiner Sicht dahinterstecken?");
+    expect(html).toContain("ausschließlich in diesem Browser speichern");
+    expect(html).toContain("keine politische Einstufung");
+    expect(html).toContain("Keine automatische Veröffentlichung");
+    expect(html).toContain("Einen Gedanken teilen");
+    expect(html).toContain("Aktuelle Themen ansehen");
+  });
+
+  it("keeps the default account view lightweight until Voxy is opened", () => {
+    const html = renderToStaticMarkup(
+      <PersonalVoxyFirstLoginCompanion welcomeNotice={false} />,
+    );
+
+    expect(html).toContain("Voxy einrichten");
+    expect(html).toContain("Direkt etwas einbringen");
+    expect(html).not.toContain("Wie soll Voxy dich begleiten?");
+  });
+});

--- a/docs/E150/V3_PERSONAL_VOXY_FIRST_LOGIN_COMPANION_RUNTIME_2026-07-15.md
+++ b/docs/E150/V3_PERSONAL_VOXY_FIRST_LOGIN_COMPANION_RUNTIME_2026-07-15.md
@@ -1,0 +1,67 @@
+# V3 Personal Voxy First Login Companion Runtime
+
+Status: implementation slice
+Date: 2026-07-15
+Task: `V3-PERSONAL-VOXY-FIRST-LOGIN-COMPANION-RUNTIME-01`
+
+## Ziel
+
+Die vorbereitete Personal-Voxy-Architektur wird auf `/account` erstmals als echte, nutzbare B2C-Begleitoberfläche sichtbar. Der Nutzer wird persönlich begrüßt, kann den gewünschten Begleitmodus auswählen, Region und Themen festlegen und die drei freiwilligen Civic Impulses sehen.
+
+## Umgesetzt
+
+- persönliche Voxy-Begrüßung auf `/account`;
+- aufgeklappte Einrichtung bei `?welcome=1|true|yes`;
+- kompakter Einstieg für bestehende Nutzer;
+- Begleitmodi:
+  - nur auf Anfrage;
+  - relevante Hinweise;
+  - regelmäßiger Überblick;
+  - aktiv begleiten;
+- Region und Themeninteressen;
+- expliziter Browser-Speicher-Consent;
+- vollständiges Zurücksetzen;
+- drei tägliche Impulse zur Wahrnehmung, Einordnung und gewünschten Wirkung;
+- direkte Übergänge zu `/create` und `/themen`;
+- kein Voxy-Bild-Asset im neuen Surface, damit fehlerhafte oder fehlende globale Styles kein ungebremstes Vollbild-Rendering verursachen.
+
+## Persistenzgrenze
+
+Der Slice nutzt ausschließlich `localStorage` nach einer expliziten Checkbox. Er aktiviert noch keinen serverseitigen Profilstore, keine politische Profilbildung, keine externe Weitergabe, keine Benachrichtigung und keine regionale Live-Recherche.
+
+## Guardrails
+
+- kein Auto-Publish;
+- kein Voting im Namen des Nutzers;
+- keine versteckte politische Einstufung;
+- keine serverseitige Profilpersistenz;
+- keine Provider- oder Modellaufrufe;
+- keine Agenten-Parallelarchitektur;
+- keine Fake-Themen oder Fake-Beteiligungen;
+- regionale Live-Recherche bleibt transparent als noch nicht aktiv gekennzeichnet.
+
+## Geänderte Dateien
+
+- `apps/web/src/app/account/PersonalVoxyFirstLoginCompanion.tsx`
+- `apps/web/src/app/account/page.tsx`
+- `apps/web/tests/personal-voxy-first-login-companion.runtime.test.tsx`
+
+## Manueller Smoke
+
+1. anmelden;
+2. `/account?welcome=1` öffnen;
+3. Begrüßung und ausgeklappte Einrichtung prüfen;
+4. Modus, Region und Interessen auswählen;
+5. ohne Consent prüfen, dass Speichern deaktiviert bleibt;
+6. Consent setzen und speichern;
+7. Seite neu laden und Browser-Persistenz prüfen;
+8. Zurücksetzen und vollständige Löschung prüfen;
+9. Links zu `/create` und `/themen` prüfen.
+
+## Nächste Runtime-Slices
+
+1. serverseitiger, widerrufbarer Personal-Voxy-Profilstore;
+2. echter regionaler Civic Radar mit Quellen- und Abrufzeit;
+3. dialogischer Impuls-Flow mit Nutzerbestätigung;
+4. gemeinsamer persistenter Agent-Run-Kernel;
+5. echter B2C-Vertikalpilot bis Dossier und Beteiligungsformat.


### PR DESCRIPTION
## Ziel

Aktiviert den ersten echten B2C-Personal-Voxy-Vertikalslice auf `/account`, statt nur Agenten-Contracts und Readiness-Hinweise zu zeigen.

## Umgesetzt

- persönliche Begrüßung: `Dein persönlicher Voxy` / `Schön, dass du da bist`
- aufgeklappte Einrichtung bei `/account?welcome=1|true|yes`
- kompakter Einstieg für bestehende Nutzer
- Begleitmodi:
  - Nur auf Anfrage
  - Relevante Hinweise
  - Regelmäßiger Überblick
  - Aktiv begleiten
- Region und Themeninteressen
- expliziter Consent vor Browser-Persistenz
- vollständiges Zurücksetzen
- `Was bewegt dich heute?` mit drei freiwilligen Civic Impulsen
- direkte Übergänge zu `/create` und `/themen`
- neue fokussierte Runtime-Contract-Tests

## Persistenz- und Runtime-Grenzen

- Speicherung nur im Browser via `localStorage` und nur nach explizitem Opt-in
- noch kein serverseitiger Profilstore
- noch keine regionale Live-Recherche
- keine Provider-/Modellaufrufe
- keine Benachrichtigungen
- keine versteckte politische Profilierung
- kein Auto-Publish
- kein Voting für Nutzer
- keine parallele Agentenarchitektur

## UX-Entscheidung

Der neue Slice verwendet bewusst kein großes Voxy-Bild-Asset. Damit bleibt die Begrüßungsoberfläche auch bei Asset-/Style-Problemen kontrolliert und kann nicht erneut durch ein ungebremst skaliertes Voxy-Bild überlagert werden.

## Geänderte Dateien

- `apps/web/src/app/account/PersonalVoxyFirstLoginCompanion.tsx`
- `apps/web/src/app/account/page.tsx`
- `apps/web/tests/personal-voxy-first-login-companion.runtime.test.tsx`
- `docs/E150/V3_PERSONAL_VOXY_FIRST_LOGIN_COMPANION_RUNTIME_2026-07-15.md`

## Validierung

Connector-seitig wurde kein lokaler Testlauf ausgeführt. Vor Merge bitte ausführen:

```bash
pnpm -C apps/web exec vitest run tests/personal-voxy-first-login-companion.runtime.test.tsx tests/account-resume-workbench.contract.test.tsx
pnpm -C apps/web run lint
pnpm -C apps/web run build
```

## Manueller Smoke

1. anmelden
2. `/account?welcome=1` öffnen
3. Modus, Region und Interessen auswählen
4. prüfen, dass Speichern ohne Consent deaktiviert bleibt
5. Consent setzen und speichern
6. Seite neu laden und Browser-Persistenz prüfen
7. zurücksetzen
8. Links zu `/create` und `/themen` prüfen

## Nächster Schritt

- serverseitiger widerrufbarer Profilstore
- echter regionaler Civic Radar
- dialogische Civic Impulses
- persistenter gemeinsamer Agent-Run-Kernel
