### PR TITLE
fix: isolate dossier demo runtime from real dossier flows

### DIFF
--- a/apps/web/src/app/account/AccountClient.tsx
+++ b/apps/web/src/app/account/AccountClient.tsx
@@ -19,6 +19,7 @@ import {
 import type { AccountFeatureInterestKey } from "@features/account/types";
 import { TOPIC_CHOICES, type TopicKey } from "@features/interests/topics";
 import { buildCommunityHref } from "@/features/community/deepLinkContract";
+import { buildCanonicalDossierHref } from "@/components/dossier/runtimeTruth";
 import type { LocalizedContentRecord } from "@/features/i18n/contentTranslations";
 import type { UserRole } from "@/types/user";
 import type { EngagementLevel } from "@features/user/engagement";
@@ -491,7 +492,12 @@ const ACCOUNT_HUB_TABS: Array<{ key: AccountHubTab; label: string; icon: IconTyp
 const MOBILE_CORE_ACTIONS: Array<{ key: "swipes" | "create" | "dossier" | "profile"; label: string; icon: IconType; href?: string }> = [
   { key: "swipes", label: "Swipes", icon: FiSliders, href: "/swipes" },
   { key: "create", label: "Anlass", icon: FiEdit2, href: "/create" },
-  { key: "dossier", label: "Dossier", icon: FiPackage, href: "/dossier/demo" },
+  {
+    key: "dossier",
+    label: "Dossier",
+    icon: FiPackage,
+    href: buildCanonicalDossierHref(null, { allowIndexFallback: true }) ?? "/dossier",
+  },
   { key: "profile", label: "Profil", icon: FiUser },
 ];
 
@@ -3071,7 +3077,11 @@ function CompactProfileHubSection({
                       Dossier öffnen
                     </Link>
                   ) : (
-                    <Link href="/dossier/demo" className={`${secondaryLightButtonClass} w-full`} onClick={() => setSocialDetail(null)}>
+                    <Link
+                      href={buildCanonicalDossierHref(null, { allowIndexFallback: true }) ?? "/dossier"}
+                      className={`${secondaryLightButtonClass} w-full`}
+                      onClick={() => setSocialDetail(null)}
+                    >
                       Dossier öffnen
                     </Link>
                   )}

--- a/apps/web/src/app/api/demo/vote/route.ts
+++ b/apps/web/src/app/api/demo/vote/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from "next/server";
 import demoDossier from "@features/dossier/data/demoDossier";
+import { shouldAllowDemoDossierFallback } from "@/features/runtimeDataGuardrails";
 
 export const runtime = "nodejs";
 
-type Body = { dossierId?: string; optionId?: string };
+type Body = { dossierId?: string; optionId?: string; runtimeContext?: string };
 
 function getBaseMajority() {
   const note = demoDossier.analyze.notes?.find((n) => n.id === "note-inputs");
@@ -46,9 +47,27 @@ function nudgeMajority(majority: { id: string; pct: number }[], optionId: string
 
 export async function POST(req: Request) {
   const body = (await req.json().catch(() => ({}))) as Body;
+  const dossierId = body.dossierId?.trim();
   const optionId = body.optionId?.trim();
+  const runtimeContext = body.runtimeContext?.trim();
+
+  if (!dossierId) {
+    return NextResponse.json({ ok: false, error: "dossierId_missing" }, { status: 400 });
+  }
+
   if (!optionId) {
     return NextResponse.json({ ok: false, error: "optionId_missing" }, { status: 400 });
+  }
+
+  if (runtimeContext !== "demo" || !shouldAllowDemoDossierFallback(dossierId)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "demo_context_required",
+        message: "Diese Route ist nur für explizite Demo-Dossiers freigeschaltet.",
+      },
+      { status: 403 },
+    );
   }
 
   const base = getBaseMajority();
@@ -57,7 +76,7 @@ export async function POST(req: Request) {
   return NextResponse.json(
     {
       ok: true,
-      dossierId: body.dossierId ?? demoDossier.meta.id,
+      dossierId,
       updatedAt: new Date().toISOString(),
       totalVotes: (getBaseMajority().length ? 284 : 0) + 1,
       majorityDemo,

--- a/apps/web/src/app/api/dossier/[id]/vote/route.ts
+++ b/apps/web/src/app/api/dossier/[id]/vote/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { shouldAllowDemoDossierFallback } from "@/features/runtimeDataGuardrails";
+
+type RouteContext = {
+  params: Promise<{ id: string }>;
+};
+
+type VoteBody = {
+  optionId?: string;
+};
+
+function readId(value: string | null | undefined) {
+  const trimmed = String(value ?? "").trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export async function POST(req: Request, context: RouteContext) {
+  const { id } = await context.params;
+  const dossierId = readId(id);
+  const body = (await req.json().catch(() => ({}))) as VoteBody;
+  const optionId = readId(body.optionId);
+
+  if (!dossierId) {
+    return NextResponse.json({ ok: false, error: "dossierId_missing" }, { status: 400 });
+  }
+
+  if (!optionId) {
+    return NextResponse.json({ ok: false, error: "optionId_missing" }, { status: 400 });
+  }
+
+  if (shouldAllowDemoDossierFallback(dossierId)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "use_demo_vote_route",
+        message: "Demo-Abstimmungen müssen über die explizite Demo-Route laufen.",
+      },
+      { status: 400 },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      ok: false,
+      error: "vote_runtime_unavailable",
+      message: "Die Abstimmungsruntime für dieses Dossier ist aktuell nicht verfügbar.",
+      dossierId,
+      retryable: true,
+    },
+    { status: 503 },
+  );
+}

--- a/apps/web/src/app/beitraege/[id]/page.tsx
+++ b/apps/web/src/app/beitraege/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import demoDossier from "@features/dossier/data/demoDossier";
 import { getPresentation } from "@/components/dossier/presentation";
+import { buildCanonicalDossierHref } from "@/components/dossier/runtimeTruth";
 
 function formatDate(value: string) {
   const d = new Date(value);
@@ -14,6 +15,7 @@ export default async function ContributionDetailPage({ params }: { params: Promi
   const { contributions, traceability } = getPresentation(demoDossier);
   const contribution = contributions.find((entry) => entry.id === id);
   if (!contribution) return notFound();
+  const dossierHref = buildCanonicalDossierHref(demoDossier.meta.id) ?? "/dossier";
 
   const statementTitleById = new Map(
     demoDossier.analyze.claims.map((claim) => [claim.id, claim.title ?? claim.id]),
@@ -23,7 +25,7 @@ export default async function ContributionDetailPage({ params }: { params: Promi
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgb(248,250,252)_0%,rgb(241,245,249)_45%,rgb(226,232,240)_100%)] dark:bg-[radial-gradient(circle_at_top,rgb(15,23,42)_0%,rgb(2,6,23)_45%,rgb(2,6,23)_100%)]">
       <div className="mx-auto w-full max-w-3xl px-6 py-12">
-        <Link href="/dossier/demo" className="text-xs text-[rgb(var(--muted))] underline">
+        <Link href={dossierHref} className="text-xs text-[rgb(var(--muted))] underline">
           Zurück zum Dossier
         </Link>
         <div className="mt-6 space-y-4 rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-6">
@@ -47,7 +49,11 @@ export default async function ContributionDetailPage({ params }: { params: Promi
                 {statementIds.map((statementId) => (
                   <li key={statementId}>
                     <Link
-                      href={`/dossier/demo#stmt-${statementId}`}
+                      href={
+                        buildCanonicalDossierHref(demoDossier.meta.id, {
+                          anchor: `stmt-${statementId}`,
+                        }) ?? dossierHref
+                      }
                       className="text-[rgb(var(--fg))] underline"
                     >
                       {statementTitleById.get(statementId) ?? statementId}

--- a/apps/web/src/app/create/CreateClient.tsx
+++ b/apps/web/src/app/create/CreateClient.tsx
@@ -90,6 +90,7 @@ import {
   type CreateLinkIntentOptionId,
   type CreateLinkIntakeDetection,
 } from "@/features/create/linkIntake";
+import { buildCanonicalDossierHref } from "@/components/dossier/runtimeTruth";
 import {
   buildCreateAttachmentMaterialItems,
   resolveMaterialRouting,
@@ -2703,7 +2704,10 @@ export default function CreateClient({
           </div>
 
           <div className="mt-3 flex flex-wrap gap-2">
-            <Link href="/dossier/demo" className="btn-secondary text-xs">
+            <Link
+              href={buildCanonicalDossierHref(null, { allowIndexFallback: true }) ?? "/dossier"}
+              className="btn-secondary text-xs"
+            >
               Thema öffnen
             </Link>
             <Link href="/swipes" className="btn-secondary text-xs">

--- a/apps/web/src/app/streams/[id]/page.tsx
+++ b/apps/web/src/app/streams/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import demoDossier from "@features/dossier/data/demoDossier";
 import { getPresentation } from "@/components/dossier/presentation";
+import { buildCanonicalDossierHref } from "@/components/dossier/runtimeTruth";
 
 function formatDate(value: string) {
   const d = new Date(value);
@@ -14,6 +15,7 @@ export default async function StreamDetailPage({ params }: { params: Promise<{ i
   const { streams, traceability } = getPresentation(demoDossier);
   const stream = streams.find((entry) => entry.id === id);
   if (!stream) return notFound();
+  const dossierHref = buildCanonicalDossierHref(demoDossier.meta.id) ?? "/dossier";
 
   const statementTitleById = new Map(
     demoDossier.analyze.claims.map((claim) => [claim.id, claim.title ?? claim.id]),
@@ -23,7 +25,7 @@ export default async function StreamDetailPage({ params }: { params: Promise<{ i
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgb(248,250,252)_0%,rgb(241,245,249)_45%,rgb(226,232,240)_100%)] dark:bg-[radial-gradient(circle_at_top,rgb(15,23,42)_0%,rgb(2,6,23)_45%,rgb(2,6,23)_100%)]">
       <div className="mx-auto w-full max-w-3xl px-6 py-12">
-        <Link href="/dossier/demo" className="text-xs text-[rgb(var(--muted))] underline">
+        <Link href={dossierHref} className="text-xs text-[rgb(var(--muted))] underline">
           Zurück zum Dossier
         </Link>
         <div className="mt-6 space-y-4 rounded-2xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-6">
@@ -39,7 +41,11 @@ export default async function StreamDetailPage({ params }: { params: Promise<{ i
                 {statementIds.map((statementId) => (
                   <li key={statementId}>
                     <Link
-                      href={`/dossier/demo#stmt-${statementId}`}
+                      href={
+                        buildCanonicalDossierHref(demoDossier.meta.id, {
+                          anchor: `stmt-${statementId}`,
+                        }) ?? dossierHref
+                      }
                       className="text-[rgb(var(--fg))] underline"
                     >
                       {statementTitleById.get(statementId) ?? statementId}

--- a/apps/web/src/app/streams/page.tsx
+++ b/apps/web/src/app/streams/page.tsx
@@ -1,6 +1,11 @@
 import Link from "next/link";
+import demoDossier from "@features/dossier/data/demoDossier";
+import { buildCanonicalDossierHref } from "@/components/dossier/runtimeTruth";
 
 export default function StreamsIndexPage() {
+  const demoStreamsHref =
+    buildCanonicalDossierHref(demoDossier.meta.id, { anchor: "streams" }) ?? "/dossier";
+
   return (
     <main className="mx-auto w-full max-w-4xl px-6 py-12 text-[rgb(var(--fg))]">
       <div className="space-y-3">
@@ -13,7 +18,7 @@ export default function StreamsIndexPage() {
           Dossier verknüpft.
         </p>
         <div className="flex flex-wrap gap-2">
-          <Link href="/dossier/demo#streams" className="btn btn-ghost text-xs">
+          <Link href={demoStreamsHref} className="btn btn-ghost text-xs">
             Zum Demo-Dossier
           </Link>
         </div>

--- a/apps/web/src/app/studio/page.tsx
+++ b/apps/web/src/app/studio/page.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
+import { buildCanonicalDossierHref } from "@/components/dossier/runtimeTruth";
 
 const PRODUCT_AREAS = [
   {
-    href: "/dossier/demo",
+    href: buildCanonicalDossierHref(null, { allowIndexFallback: true }) ?? "/dossier",
     title: "Dossier",
     lead: "Akte, Evidenz, offene Fragen und Entscheidungsraum.",
   },

--- a/apps/web/src/components/dossier/DossierViewer.tsx
+++ b/apps/web/src/components/dossier/DossierViewer.tsx
@@ -430,7 +430,16 @@ export function DossierViewer({
   const presentationBundle = useMemo(() => getPresentation(dossier), [dossier]);
   const { presentation, streams, contributions, voteOptions, majorityDemo, traceability, openQuestions } =
     presentationBundle;
-  const { selectedOptionId, savedOptionId, savedAt, setSelectedOptionId, saveSelection, saveNotice } =
+  const {
+    selectedOptionId,
+    savedOptionId,
+    savedAt,
+    setSelectedOptionId,
+    saveSelection,
+    saveNotice,
+    saveError,
+    savePending,
+  } =
     useDecisionState(meta.id, {
       onMajorityUpdate: (payload) => {
         if (payload.majorityDemo?.length) setMajorityLive(payload.majorityDemo);
@@ -1587,6 +1596,8 @@ export function DossierViewer({
               void saveSelection();
             }}
             saveNotice={saveNotice}
+            saveError={saveError}
+            savePending={savePending}
             savedAt={savedAt}
             canVote={isCitizen}
             roleLabel={roleLabel}

--- a/apps/web/src/components/dossier/ExportPanel.tsx
+++ b/apps/web/src/components/dossier/ExportPanel.tsx
@@ -1,4 +1,5 @@
 import { DOSSIER_EXPORT_SHARE_PUBLICATION_NOTES } from "@/features/review/dossierExportShareTruth";
+import { buildCanonicalDossierEmbedSnippet } from "./runtimeTruth";
 
 type ExportPanelProps = {
   dossierId: string;
@@ -10,7 +11,8 @@ export function ExportPanel({ dossierId, exportBase }: ExportPanelProps) {
   const jsonHref = `${base}?format=json`;
   const csvHref = `${base}?format=csv`;
   const embedSnippet =
-    `<iframe src="/dossier/demo" title="Dossier Embed" style="width:100%;height:720px;border:0;"></iframe>`;
+    buildCanonicalDossierEmbedSnippet(dossierId) ??
+    "Einbettung ist erst verfügbar, sobald ein kanonisches Dossier bereitsteht.";
 
   return (
     <section className="vog-card p-5 space-y-3">

--- a/apps/web/src/components/dossier/VotePanel.tsx
+++ b/apps/web/src/components/dossier/VotePanel.tsx
@@ -9,6 +9,8 @@ type VotePanelProps = {
   onSelect: (optionId: string) => void;
   onSave: () => void;
   saveNotice: boolean;
+  saveError?: string | null;
+  savePending?: boolean;
   savedAt?: string | null;
   canVote?: boolean;
   roleLabel?: string;
@@ -31,6 +33,8 @@ export function VotePanel({
   onSelect,
   onSave,
   saveNotice,
+  saveError,
+  savePending = false,
   savedAt,
   canVote = true,
   roleLabel,
@@ -83,9 +87,15 @@ export function VotePanel({
         type="button"
         className="btn btn-primary w-full"
         onClick={onSave}
-        disabled={!canVote || !selectedOptionId || selectedOptionId === savedOptionId}
+        disabled={!canVote || !selectedOptionId || selectedOptionId === savedOptionId || savePending}
       >
-        {isSaved ? "✔ Stimme gespeichert" : "Stimme speichern"}
+        {savePending
+          ? "Stimme wird gespeichert…"
+          : saveError
+            ? "Erneut versuchen"
+            : isSaved
+              ? "✔ Stimme gespeichert"
+              : "Stimme speichern"}
       </button>
 
       {!canVote ? (
@@ -100,6 +110,11 @@ export function VotePanel({
           <span className="text-[rgb(var(--fg))]">✓</span>
           <span className="ml-1">Stimme gespeichert · Danke</span>
           {savedAt ? <span className="ml-1">({formatDateTime(savedAt)})</span> : null}
+        </div>
+      ) : null}
+      {saveError ? (
+        <div className="rounded-xl border border-rose-300/70 bg-rose-500/10 px-3 py-2 text-[11px] text-rose-900">
+          {saveError}
         </div>
       ) : null}
       {isSaved ? (

--- a/apps/web/src/components/dossier/runtimeTruth.ts
+++ b/apps/web/src/components/dossier/runtimeTruth.ts
@@ -1,0 +1,174 @@
+import { shouldAllowDemoDossierFallback } from "@/features/runtimeDataGuardrails";
+
+type StorageLike = Pick<Storage, "setItem">;
+
+export type DossierVoteRuntimeMode = "demo" | "runtime";
+
+export type DossierVoteRuntime = {
+  mode: DossierVoteRuntimeMode;
+  endpoint: string | null;
+  usesLocalPersistence: boolean;
+  unavailableMessage: string;
+};
+
+export type DossierVotePersistResult =
+  | {
+      ok: true;
+      savedAt: string;
+      payload: Record<string, unknown>;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+function normalizeText(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeAnchor(value: unknown): string | null {
+  const anchor = normalizeText(value);
+  if (!anchor) return null;
+  return anchor.replace(/^#/, "");
+}
+
+export function buildCanonicalDossierHref(
+  dossierId: unknown,
+  options?: {
+    anchor?: string | null;
+    allowIndexFallback?: boolean;
+  },
+) {
+  const normalizedId = normalizeText(dossierId);
+  const normalizedAnchor = normalizeAnchor(options?.anchor);
+  const anchorSuffix = normalizedAnchor ? `#${encodeURIComponent(normalizedAnchor)}` : "";
+
+  if (normalizedId) {
+    return `/dossier/${encodeURIComponent(normalizedId)}${anchorSuffix}`;
+  }
+
+  if (options?.allowIndexFallback) {
+    return `/dossier${anchorSuffix}`;
+  }
+
+  return null;
+}
+
+export function buildCanonicalDossierEmbedSnippet(dossierId: unknown) {
+  const href = buildCanonicalDossierHref(dossierId);
+  if (!href) return null;
+  return `<iframe src="${href}" title="Dossier Embed" style="width:100%;height:720px;border:0;"></iframe>`;
+}
+
+export function resolveDossierVoteRuntime(
+  dossierId: unknown,
+  explicitMode?: DossierVoteRuntimeMode,
+): DossierVoteRuntime {
+  const normalizedId = normalizeText(dossierId);
+  const mode =
+    explicitMode ??
+    (shouldAllowDemoDossierFallback(normalizedId) ? "demo" : "runtime");
+
+  if (!normalizedId) {
+    return {
+      mode,
+      endpoint: null,
+      usesLocalPersistence: false,
+      unavailableMessage:
+        mode === "demo"
+          ? "Demo-Abstimmung nur mit explizitem Demo-Dossier verfügbar."
+          : "Für dieses Dossier ist keine sichere Abstimmungsroute verfügbar.",
+    };
+  }
+
+  return {
+    mode,
+    endpoint:
+      mode === "demo"
+        ? "/api/demo/vote"
+        : `/api/dossier/${encodeURIComponent(normalizedId)}/vote`,
+    usesLocalPersistence: mode === "demo",
+    unavailableMessage:
+      mode === "demo"
+        ? "Demo-Abstimmung derzeit nicht verfügbar."
+        : "Die Abstimmungsruntime für dieses Dossier ist aktuell nicht verfügbar.",
+  };
+}
+
+function extractVoteErrorMessage(
+  payload: Record<string, unknown> | null,
+  runtime: DossierVoteRuntime,
+) {
+  const message = normalizeText(payload?.message) ?? normalizeText(payload?.error);
+  return message ?? runtime.unavailableMessage;
+}
+
+export async function persistDossierVoteSelection(params: {
+  dossierId: string;
+  optionId: string;
+  runtime: DossierVoteRuntime;
+  fetchImpl: typeof fetch;
+  now?: () => string;
+  storage?: StorageLike | null;
+  storageKey?: string;
+  timeKey?: string;
+}): Promise<DossierVotePersistResult> {
+  if (!params.runtime.endpoint) {
+    return {
+      ok: false,
+      error: params.runtime.unavailableMessage,
+    };
+  }
+
+  const body =
+    params.runtime.mode === "demo"
+      ? {
+          dossierId: params.dossierId,
+          optionId: params.optionId,
+          runtimeContext: "demo",
+        }
+      : {
+          optionId: params.optionId,
+        };
+
+  try {
+    const response = await params.fetchImpl(params.runtime.endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const payload = (await response.json().catch(() => null)) as Record<string, unknown> | null;
+
+    if (!response.ok || !payload?.ok) {
+      return {
+        ok: false,
+        error: extractVoteErrorMessage(payload, params.runtime),
+      };
+    }
+
+    const savedAt = normalizeText(payload.updatedAt) ?? params.now?.() ?? new Date().toISOString();
+
+    if (
+      params.runtime.usesLocalPersistence &&
+      params.storage &&
+      params.storageKey &&
+      params.timeKey
+    ) {
+      params.storage.setItem(params.storageKey, params.optionId);
+      params.storage.setItem(params.timeKey, savedAt);
+    }
+
+    return {
+      ok: true,
+      savedAt,
+      payload,
+    };
+  } catch {
+    return {
+      ok: false,
+      error: params.runtime.unavailableMessage,
+    };
+  }
+}

--- a/apps/web/src/components/dossier/useDecisionState.ts
+++ b/apps/web/src/components/dossier/useDecisionState.ts
@@ -1,6 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import {
+  type DossierVoteRuntimeMode,
+  persistDossierVoteSelection,
+  resolveDossierVoteRuntime,
+} from "./runtimeTruth";
 
 type DecisionState = {
   selectedOptionId: string | null;
@@ -9,6 +14,8 @@ type DecisionState = {
   setSelectedOptionId: (id: string | null) => void;
   saveSelection: () => Promise<void>;
   saveNotice: boolean;
+  saveError: string | null;
+  savePending: boolean;
 };
 
 type MajorityUpdatePayload = {
@@ -19,6 +26,7 @@ type MajorityUpdatePayload = {
 
 type DecisionStateOptions = {
   onMajorityUpdate?: (payload: MajorityUpdatePayload) => void;
+  runtimeMode?: DossierVoteRuntimeMode;
 };
 
 export function useDecisionState(dossierId: string, options?: DecisionStateOptions): DecisionState {
@@ -28,9 +36,15 @@ export function useDecisionState(dossierId: string, options?: DecisionStateOptio
   const [savedOptionId, setSavedOptionId] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<string | null>(null);
   const [saveNotice, setSaveNotice] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [savePending, setSavePending] = useState(false);
+  const runtime = useMemo(
+    () => resolveDossierVoteRuntime(dossierId, options?.runtimeMode),
+    [dossierId, options?.runtimeMode],
+  );
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
+    if (typeof window === "undefined" || !runtime.usesLocalPersistence) return;
     const stored = window.localStorage.getItem(storageKey);
     const storedAt = window.localStorage.getItem(timeKey);
     if (stored) {
@@ -38,32 +52,48 @@ export function useDecisionState(dossierId: string, options?: DecisionStateOptio
       setSavedOptionId(stored);
     }
     if (storedAt) setSavedAt(storedAt);
-  }, [storageKey, timeKey]);
+  }, [runtime.usesLocalPersistence, storageKey, timeKey]);
 
   const saveSelection = async () => {
     if (!selectedOptionId || typeof window === "undefined") return;
-    window.localStorage.setItem(storageKey, selectedOptionId);
-    const timestamp = new Date().toISOString();
-    window.localStorage.setItem(timeKey, timestamp);
+    setSaveError(null);
+    setSaveNotice(false);
+    setSavePending(true);
+
+    const result = await persistDossierVoteSelection({
+      dossierId,
+      optionId: selectedOptionId,
+      runtime,
+      fetchImpl: fetch,
+      storage: runtime.usesLocalPersistence ? window.localStorage : null,
+      storageKey,
+      timeKey,
+    });
+
+    setSavePending(false);
+
+    if (result.ok === false) {
+      setSaveError(result.error);
+      return;
+    }
+
     setSavedOptionId(selectedOptionId);
-    setSavedAt(timestamp);
+    setSavedAt(result.savedAt);
     setSaveNotice(true);
     window.setTimeout(() => setSaveNotice(false), 2200);
-
-    try {
-      const response = await fetch("/api/demo/vote", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ dossierId, optionId: selectedOptionId }),
-      });
-      const data = (await response.json()) as { ok?: boolean } & MajorityUpdatePayload;
-      if (data?.ok) options?.onMajorityUpdate?.(data);
-    } catch {
-      // Demo-only: silently ignore
-    }
+    options?.onMajorityUpdate?.(result.payload as MajorityUpdatePayload);
   };
 
-  return { selectedOptionId, savedOptionId, savedAt, setSelectedOptionId, saveSelection, saveNotice };
+  return {
+    selectedOptionId,
+    savedOptionId,
+    savedAt,
+    setSelectedOptionId,
+    saveSelection,
+    saveNotice,
+    saveError,
+    savePending,
+  };
 }
 
 export default useDecisionState;

--- a/apps/web/src/features/runtimeDataGuardrails.ts
+++ b/apps/web/src/features/runtimeDataGuardrails.ts
@@ -40,7 +40,12 @@ export function isRegionDraftDossierId(value: string | null | undefined): boolea
 
 export function isExplicitDemoDossierId(value: string | null | undefined): boolean {
   const normalized = String(value || "").trim().toLowerCase();
-  return normalized === "demo" || normalized === "demo-dossier" || normalized === "dossier_demo_mobility_berlin";
+  return (
+    normalized === "demo" ||
+    normalized === "demo-dossier" ||
+    normalized === "dossier_demo_mobility_berlin" ||
+    normalized === "demo-innencity-2026"
+  );
 }
 
 export function shouldAllowDemoDossierFallback(dossierId: string | null | undefined): boolean {

--- a/apps/web/tests/dossier-demo-link-isolation.test.ts
+++ b/apps/web/tests/dossier-demo-link-isolation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+function readSource(relPath: string) {
+  return readFileSync(path.join(process.cwd(), "src", relPath), "utf8");
+}
+
+describe("dossier demo link isolation", () => {
+  it("removes hardcoded /dossier/demo links from the affected runtime surfaces", () => {
+    const sources = [
+      readSource("components/dossier/ExportPanel.tsx"),
+      readSource("app/studio/page.tsx"),
+      readSource("app/create/CreateClient.tsx"),
+      readSource("app/account/AccountClient.tsx"),
+      readSource("app/streams/page.tsx"),
+      readSource("app/streams/[id]/page.tsx"),
+      readSource("app/beitraege/[id]/page.tsx"),
+    ];
+
+    for (const source of sources) {
+      expect(source).not.toContain("/dossier/demo");
+    }
+  });
+
+  it("uses canonical dossier helpers instead of inventing ids for runtime links", () => {
+    const exportPanel = readSource("components/dossier/ExportPanel.tsx");
+    const studioPage = readSource("app/studio/page.tsx");
+    const createClient = readSource("app/create/CreateClient.tsx");
+    const accountClient = readSource("app/account/AccountClient.tsx");
+    const streamsPage = readSource("app/streams/page.tsx");
+    const streamDetailPage = readSource("app/streams/[id]/page.tsx");
+    const contributionPage = readSource("app/beitraege/[id]/page.tsx");
+
+    expect(exportPanel).toContain("buildCanonicalDossierEmbedSnippet(dossierId)");
+    expect(studioPage).toContain("allowIndexFallback: true");
+    expect(createClient).toContain("allowIndexFallback: true");
+    expect(accountClient).toContain("allowIndexFallback: true");
+    expect(streamsPage).toContain("demoDossier.meta.id");
+    expect(streamDetailPage).toContain("demoDossier.meta.id");
+    expect(contributionPage).toContain("demoDossier.meta.id");
+  });
+});

--- a/apps/web/tests/dossier-vote-route-isolation.test.ts
+++ b/apps/web/tests/dossier-vote-route-isolation.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+import { POST as postDemoVote } from "@/app/api/demo/vote/route";
+import { POST as postDossierVote } from "@/app/api/dossier/[id]/vote/route";
+
+describe("dossier vote route isolation", () => {
+  it("accepts explicit demo votes only inside the demo runtime context", async () => {
+    const response = await postDemoVote(
+      new NextRequest("http://localhost/api/demo/vote", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          dossierId: "demo-innencity-2026",
+          optionId: "option-a",
+          runtimeContext: "demo",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      dossierId: "demo-innencity-2026",
+    });
+  });
+
+  it("rejects demo vote calls without an explicit demo dossier id", async () => {
+    const response = await postDemoVote(
+      new NextRequest("http://localhost/api/demo/vote", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          optionId: "option-a",
+          runtimeContext: "demo",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "dossierId_missing",
+    });
+  });
+
+  it("rejects real dossiers on the demo vote route", async () => {
+    const response = await postDemoVote(
+      new NextRequest("http://localhost/api/demo/vote", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          dossierId: "dossier-42",
+          optionId: "option-a",
+          runtimeContext: "demo",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "demo_context_required",
+    });
+  });
+
+  it("fails closed for real dossier votes while preserving retry information", async () => {
+    const response = await postDossierVote(
+      new NextRequest("http://localhost/api/dossier/dossier-42/vote", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ optionId: "option-b" }),
+      }),
+      { params: Promise.resolve({ id: "dossier-42" }) },
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "vote_runtime_unavailable",
+      dossierId: "dossier-42",
+      retryable: true,
+    });
+  });
+
+  it("keeps explicit demo dossiers off the real vote route", async () => {
+    const response = await postDossierVote(
+      new NextRequest("http://localhost/api/dossier/demo-innencity-2026/vote", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ optionId: "option-b" }),
+      }),
+      { params: Promise.resolve({ id: "demo-innencity-2026" }) },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: "use_demo_vote_route",
+    });
+  });
+});

--- a/apps/web/tests/dossier-vote-runtime-truth.test.tsx
+++ b/apps/web/tests/dossier-vote-runtime-truth.test.tsx
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import VotePanel from "@/components/dossier/VotePanel";
+import {
+  buildCanonicalDossierEmbedSnippet,
+  buildCanonicalDossierHref,
+  persistDossierVoteSelection,
+  resolveDossierVoteRuntime,
+} from "@/components/dossier/runtimeTruth";
+
+describe("dossier vote runtime truth", () => {
+  it("builds canonical dossier links and embeds without forcing the demo dossier", () => {
+    expect(buildCanonicalDossierHref("demo-innencity-2026", { anchor: "streams" })).toBe(
+      "/dossier/demo-innencity-2026#streams",
+    );
+    expect(buildCanonicalDossierHref(null, { allowIndexFallback: true })).toBe("/dossier");
+    expect(buildCanonicalDossierEmbedSnippet("dossier-42")).toContain('src="/dossier/dossier-42"');
+    expect(buildCanonicalDossierEmbedSnippet("")).toBeNull();
+  });
+
+  it("keeps explicit demo dossiers on the demo vote route and real dossiers on the runtime route", () => {
+    expect(resolveDossierVoteRuntime("demo-innencity-2026")).toMatchObject({
+      mode: "demo",
+      endpoint: "/api/demo/vote",
+      usesLocalPersistence: true,
+    });
+    expect(resolveDossierVoteRuntime("dossier-42")).toMatchObject({
+      mode: "runtime",
+      endpoint: "/api/dossier/dossier-42/vote",
+      usesLocalPersistence: false,
+    });
+  });
+
+  it("persists demo votes only after an explicit demo save succeeds", async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input).toBe("/api/demo/vote");
+      expect(JSON.parse(String(init?.body))).toMatchObject({
+        dossierId: "demo-innencity-2026",
+        optionId: "opt-a",
+        runtimeContext: "demo",
+      });
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          updatedAt: "2026-07-20T10:00:00.000Z",
+          majorityDemo: [{ id: "opt-a", pct: 51 }],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+    const storage = { setItem: vi.fn() };
+
+    const result = await persistDossierVoteSelection({
+      dossierId: "demo-innencity-2026",
+      optionId: "opt-a",
+      runtime: resolveDossierVoteRuntime("demo-innencity-2026"),
+      fetchImpl,
+      storage,
+      storageKey: "vote",
+      timeKey: "voteAt",
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      savedAt: "2026-07-20T10:00:00.000Z",
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(storage.setItem).toHaveBeenNthCalledWith(1, "vote", "opt-a");
+    expect(storage.setItem).toHaveBeenNthCalledWith(2, "voteAt", "2026-07-20T10:00:00.000Z");
+  });
+
+  it("does not fake a successful local vote for a real dossier when the runtime fails", async () => {
+    const fetchImpl = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          ok: false,
+          error: "vote_runtime_unavailable",
+          message: "Die Abstimmungsruntime für dieses Dossier ist aktuell nicht verfügbar.",
+        }),
+        { status: 503, headers: { "content-type": "application/json" } },
+      );
+    });
+    const storage = { setItem: vi.fn() };
+
+    const result = await persistDossierVoteSelection({
+      dossierId: "dossier-42",
+      optionId: "opt-b",
+      runtime: resolveDossierVoteRuntime("dossier-42"),
+      fetchImpl,
+      storage,
+      storageKey: "vote",
+      timeKey: "voteAt",
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(storage.setItem).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      ok: false,
+      error: "Die Abstimmungsruntime für dieses Dossier ist aktuell nicht verfügbar.",
+    });
+  });
+
+  it("shows retry feedback instead of a success-only state after a failed vote", () => {
+    const html = renderToStaticMarkup(
+      <VotePanel
+        options={[{ id: "opt-a", label: "Option A" }]}
+        selectedOptionId="opt-a"
+        savedOptionId={null}
+        onSelect={() => {}}
+        onSave={() => {}}
+        saveNotice={false}
+        saveError="Die Abstimmung konnte nicht gespeichert werden."
+      />,
+    );
+
+    expect(html).toContain("Erneut versuchen");
+    expect(html).toContain("Die Abstimmung konnte nicht gespeichert werden.");
+    expect(html).not.toContain("✔ Stimme gespeichert");
+  });
+});

--- a/apps/web/tests/runtime-data-guardrails.test.ts
+++ b/apps/web/tests/runtime-data-guardrails.test.ts
@@ -11,6 +11,7 @@ describe("runtime data guardrails", () => {
   it("keeps demo fallback restricted to explicit demo dossier ids", () => {
     expect(isExplicitDemoDossierId("demo")).toBe(true);
     expect(isExplicitDemoDossierId("dossier_demo_mobility_berlin")).toBe(true);
+    expect(isExplicitDemoDossierId("demo-innencity-2026")).toBe(true);
     expect(shouldAllowDemoDossierFallback("dossier-draft-abc")).toBe(false);
     expect(shouldAllowDemoDossierFallback("berlin-reinickendorf-review")).toBe(false);
   });


### PR DESCRIPTION
## Summary
- isolate dossier vote runtime truth so real dossiers no longer call the demo vote route or fake local success
- replace hardcoded /dossier/demo links in the affected Account/Create/Studio/Streams/Beiträge/ExportPanel surfaces with canonical dossier routing
- add focused regression tests for demo vote isolation, real-dossier fail-closed behavior, canonical dossier links, and retry/error visibility

## Validation
- git diff --check
- pnpm -C apps/web exec vitest run tests/dossier-vote-runtime-truth.test.tsx tests/dossier-vote-route-isolation.test.ts tests/dossier-demo-link-isolation.test.ts tests/runtime-data-guardrails.test.ts tests/dossier-route.runtime-guard.test.ts
- pnpm -C apps/web run lint
- pnpm -C apps/web run typecheck
- pnpm -C apps/web run build

## Notes
- existing unrelated pricing/docs worktree changes were left untouched
- no merge or auto-merge performed