### PR TITLE
Restore reviewed mandate feedback actions

### DIFF
--- a/apps/web/src/app/api/editorial/feedback/route.ts
+++ b/apps/web/src/app/api/editorial/feedback/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { insertEditorialFeedback, listEditorialFeedback } from "@/lib/db/editorialFeedbackRepo";
 import { z } from "zod";
 import { rateLimitFromRequest, rateLimitHeaders } from "@/utils/rateLimitHelpers";
+import { resolveEditorialFeedbackReviewStatus } from "@/lib/editorial/status";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -13,6 +14,8 @@ const FEEDBACK_GET_RATE = { limit: 120, windowMs: 60_000 };
 
 const ShortText = z.string().trim().min(1).max(600);
 const ClaimText = z.string().trim().min(1).max(800);
+const MandateTitle = z.string().trim().min(1).max(120);
+const MandateDescription = z.string().trim().min(1).max(800);
 const FactVerdict = z.enum(["LIKELY_TRUE", "LIKELY_FALSE", "MIXED", "UNDETERMINED"]);
 const SourceUrl = z.string().trim().min(1).max(600);
 const FeedbackOrigin = z.enum(["community", "editorial", "user", "ai"]);
@@ -81,6 +84,38 @@ const FeedbackActionSchema = z.discriminatedUnion("type", [
       note: ShortText.optional(),
     })
     .strict(),
+  z
+    .object({
+      type: z.literal("mandate_update_submit"),
+      title: MandateTitle,
+      description: MandateDescription,
+      sources: z.array(SourceUrl).max(5).optional(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("mandate_risk_submit"),
+      title: MandateTitle,
+      description: MandateDescription,
+      sources: z.array(SourceUrl).max(5).optional(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("mandate_responsibility_submit"),
+      title: MandateTitle,
+      description: MandateDescription,
+      sources: z.array(SourceUrl).max(5).optional(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("mandate_impact_submit"),
+      title: MandateTitle,
+      description: MandateDescription,
+      sources: z.array(SourceUrl).max(5).optional(),
+    })
+    .strict(),
 ]);
 
 const FeedbackSchema = z
@@ -137,11 +172,9 @@ export async function POST(req: NextRequest) {
     }
 
     const ts = parsed.data.ts ?? new Date().toISOString();
-    const reviewStatus =
-      parsed.data.action.type === "manual_factcheck_submit" ||
-      parsed.data.action.type === "manual_factcheck_update"
-        ? "pending"
-        : undefined;
+    const reviewStatus = resolveEditorialFeedbackReviewStatus(
+      parsed.data.action.type,
+    );
     const { id } = await insertEditorialFeedback({
       ts,
       context: parsed.data.context,

--- a/apps/web/src/lib/editorial/status.ts
+++ b/apps/web/src/lib/editorial/status.ts
@@ -9,16 +9,33 @@ export type EditorialStatusInput = {
 
 const STATUS_LABELS: Record<EditorialStatus, string> = {
   pending: "offen",
-  approved: "geprueft",
+  approved: "geprüft",
   rejected: "abgelehnt",
   needs_review: "umstritten",
   unknown: "unbekannt",
 };
 
-const APPROVED = new Set(["approved", "geprueft", "freigegeben", "ok", "review_ok"]);
+const APPROVED = new Set(["approved", "geprueft", "geprüft", "freigegeben", "ok", "review_ok"]);
 const REJECTED = new Set(["rejected", "abgelehnt"]);
 const PENDING = new Set(["pending", "queued", "in-review", "review", "offen", "ausstehend", "unbestaetigt", "fehlt"]);
 const NEEDS_REVIEW = new Set(["umstritten", "needs_review"]);
+
+const REVIEW_REQUIRED_ACTION_TYPES = new Set([
+  "manual_factcheck_submit",
+  "manual_factcheck_update",
+  "mandate_update_submit",
+  "mandate_risk_submit",
+  "mandate_responsibility_submit",
+  "mandate_impact_submit",
+]);
+
+export function resolveEditorialFeedbackReviewStatus(
+  actionType: string,
+): "pending" | undefined {
+  const normalized = actionType.trim().toLowerCase();
+  return REVIEW_REQUIRED_ACTION_TYPES.has(normalized) ? "pending" : undefined;
+}
+
 
 export function resolveEditorialStatus(input: EditorialStatusInput): EditorialStatus {
   if (input.redaktionFreigabe === true) return "approved";

--- a/apps/web/tests/editorial-feedback-mandate.contract.test.ts
+++ b/apps/web/tests/editorial-feedback-mandate.contract.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  formatEditorialStatus,
+  resolveEditorialFeedbackReviewStatus,
+  resolveEditorialStatus,
+} from "../src/lib/editorial/status";
+
+const routeSource = readFileSync(
+  new URL("../src/app/api/editorial/feedback/route.ts", import.meta.url),
+  "utf8",
+);
+
+describe("editorial feedback mandate contract", () => {
+  it("accepts bounded mandate feedback categories", () => {
+    const actionTypes = [
+      "mandate_update_submit",
+      "mandate_risk_submit",
+      "mandate_responsibility_submit",
+      "mandate_impact_submit",
+    ];
+
+    for (const actionType of actionTypes) {
+      expect(routeSource).toContain(`z.literal("${actionType}")`);
+    }
+
+    expect(routeSource).toContain(
+      "const MandateTitle = z.string().trim().min(1).max(120);",
+    );
+    expect(routeSource).toContain(
+      "const MandateDescription = z.string().trim().min(1).max(800);",
+    );
+
+    const boundedSourceLists =
+      routeSource.match(
+        /sources: z\.array\(SourceUrl\)\.max\(5\)\.optional\(\)/g,
+      ) ?? [];
+
+    expect(boundedSourceLists).toHaveLength(4);
+  });
+
+  it("sends mandate and factcheck submissions into human review", () => {
+    const reviewRequiredActions = [
+      "manual_factcheck_submit",
+      "manual_factcheck_update",
+      "mandate_update_submit",
+      "mandate_risk_submit",
+      "mandate_responsibility_submit",
+      "mandate_impact_submit",
+    ];
+
+    for (const actionType of reviewRequiredActions) {
+      expect(resolveEditorialFeedbackReviewStatus(actionType)).toBe(
+        "pending",
+      );
+    }
+
+    expect(resolveEditorialFeedbackReviewStatus("confirm_flag")).toBeUndefined();
+  });
+
+  it("uses the proper German approved label and accepts both spellings", () => {
+    expect(resolveEditorialStatus({ reviewStatus: "geprueft" })).toBe(
+      "approved",
+    );
+    expect(resolveEditorialStatus({ reviewStatus: "geprüft" })).toBe(
+      "approved",
+    );
+
+    expect(formatEditorialStatus({ reviewStatus: "approved" })).toEqual({
+      status: "approved",
+      label: "geprüft",
+    });
+  });
+});


### PR DESCRIPTION
## Ziel

Den alten Editorial-Stash gezielt und ohne veraltete Nebenänderungen wiederherstellen.

## Änderungen

- vier strukturierte Mandatsmeldungen ergänzt:
  - Update
  - Risiko
  - Verantwortung
  - Auswirkung
- Titel, Beschreibung und Quellenanzahl begrenzt
- Mandatsmeldungen ausdrücklich als `pending` in die menschliche Prüfung geführt
- deutsche Statusanzeige auf „geprüft“ korrigiert
- beide Eingabeformen `geprueft` und `geprüft` bleiben kompatibel
- gezielter Contract-Test ergänzt
- kein Auto-Publish und keine automatische Freigabe

## Validierung

- gezielter Editorial-Contract-Test
- Lint
- Typecheck
- `git diff --check`
