### PR TITLE
Restore factcheck route classification hardening

### DIFF
--- a/apps/web/src/app/api/factcheck/result/[contributionId]/route.ts
+++ b/apps/web/src/app/api/factcheck/result/[contributionId]/route.ts
@@ -7,6 +7,10 @@ import { resolveSealedFactcheckStatusView } from "@features/ai/e150/factcheckSta
 import { resolveAiRouteClassification } from "@features/ai/e150/routeClassification";
 import { resolveRequestScopeContext } from "@/lib/server/auth/requestScope";
 
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+
 const ParamsSchema = z.object({ contributionId: z.string().min(1) });
 
 async function resolveParams(p: any): Promise<{ contributionId: string }> {
@@ -27,7 +31,16 @@ export async function GET(
   const job = (await getFactcheckWorkflowRepo().listByContributionId(contributionId))[0] ?? null;
   if (!job) {
     return NextResponse.json(
-      { ok: false, reason: "No job found for contributionId", results: [] },
+      {
+        ok: false,
+        reason: "No job found for contributionId",
+        results: [],
+        meta: {
+          lane: "sealed_factcheck",
+          journeyProfile: "sealed_factcheck",
+          routeClassification,
+        },
+      },
       { status: 404 },
     );
   }

--- a/apps/web/src/app/api/quality/clarify/route.ts
+++ b/apps/web/src/app/api/quality/clarify/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { resolveAiRouteClassification } from "@features/ai/e150/routeClassification";
 
 // ——— Simple LRU mit TTL, um Tippen-Spitzen abzupuffern ————————————————
 type CacheRec = { value:any; exp:number };
@@ -71,14 +72,25 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function POST(req:NextRequest){
+  const routeClassification = resolveAiRouteClassification("/api/quality/clarify");
   const t0=Date.now();
   const b = await req.json().catch(()=> ({}));
   const text = String(b?.text ?? "").trim();
-  if(!text) return NextResponse.json({ ok:true, tookMs:0, hints:{} },{status:200});
+  if(!text) {
+    return NextResponse.json(
+      { ok:true, tookMs:0, hints:{}, meta: { routeClassification } },
+      {status:200},
+    );
+  }
 
   const ck = "clarify:"+text.slice(0,512);
   const cached = getK(ck);
-  if(cached) return NextResponse.json({ ok:true, cached:true, tookMs: 0, hints: cached }, {status:200});
+  if(cached) {
+    return NextResponse.json(
+      { ok:true, cached:true, tookMs: 0, hints: cached, meta: { routeClassification } },
+      {status:200},
+    );
+  }
 
   const base = heuristic(text);
 
@@ -91,5 +103,8 @@ export async function POST(req:NextRequest){
 
   const merged = { ...base, ...(refined||{}) };
   setK(ck, merged);
-  return NextResponse.json({ ok:true, tookMs: Date.now()-t0, hints: merged }, {status:200});
+  return NextResponse.json(
+    { ok:true, tookMs: Date.now()-t0, hints: merged, meta: { routeClassification } },
+    {status:200},
+  );
 }

--- a/apps/web/tests/e150-route-classification.contract.test.ts
+++ b/apps/web/tests/e150-route-classification.contract.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { resolveAiRouteClassification } from "@features/ai/e150/routeClassification";
+import { LEGACY_DIRECT_PROVIDER_ROUTES } from "@/features/ai/orchestrationRouteContract";
 
 describe("e150 route classification", () => {
   it("marks canonical analyze route as canonical", () => {
@@ -28,5 +29,17 @@ describe("e150 route classification", () => {
     expect(diag.canonical).toBe(false);
     expect(diag.routeProfile).toBe("diagnostic");
     expect(diag.directProviderPath).toBe(true);
+  });
+
+  it("keeps legacy direct-provider route catalog aligned with e150 route classification", () => {
+    for (const route of LEGACY_DIRECT_PROVIDER_ROUTES) {
+      const classification = resolveAiRouteClassification(route);
+      expect(classification.routePath).toBe(route);
+      expect(classification.canonical).toBe(false);
+      expect(classification.notCanonical).toBe(true);
+      expect(classification.legacyExceptionPath).toBe(true);
+      expect(classification.directProviderPath).toBe(true);
+      expect(classification.routeProfile).not.toBe("unknown");
+    }
   });
 });

--- a/apps/web/tests/factcheck-result.route.contract.test.ts
+++ b/apps/web/tests/factcheck-result.route.contract.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const routeSource = readFileSync(
+  new URL(
+    "../src/app/api/factcheck/result/[contributionId]/route.ts",
+    import.meta.url,
+  ),
+  "utf8",
+);
+
+describe("factcheck result route contract", () => {
+  it("keeps the canonical workflow repository and access controls", () => {
+    expect(routeSource).toContain('export const runtime = "nodejs";');
+    expect(routeSource).toContain(
+      'export const dynamic = "force-dynamic";',
+    );
+
+    expect(routeSource).toContain("getFactcheckWorkflowRepo");
+    expect(routeSource).toContain("listByContributionId");
+    expect(routeSource).toContain("resolveRequestScopeContext");
+    expect(routeSource).toContain("canViewFactcheckRecord");
+
+    expect(routeSource).not.toContain("factcheckJobsCol");
+    expect(routeSource).not.toContain(".find(");
+  });
+
+  it("exposes route classification without weakening result privacy", () => {
+    expect(routeSource).toContain("resolveAiRouteClassification");
+    expect(routeSource).toContain(
+      'reason: "No job found for contributionId"',
+    );
+    expect(routeSource).toContain(
+      'code: "FORBIDDEN"',
+    );
+    expect(routeSource).toContain(
+      'lane: "sealed_factcheck"',
+    );
+    expect(routeSource).toContain(
+      'journeyProfile: "sealed_factcheck"',
+    );
+
+    const classificationReferences =
+      routeSource.match(/routeClassification/g) ?? [];
+
+    expect(classificationReferences.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("keeps conservative workflow and verification fields", () => {
+    expect(routeSource).toContain("resolveSealedFactcheckStatusView");
+    expect(routeSource).toContain("factcheckStatusLabel");
+    expect(routeSource).toContain("truthStatus");
+    expect(routeSource).toContain("sourceSupport");
+    expect(routeSource).toContain("sourceStatus");
+    expect(routeSource).toContain("sealGranted");
+    expect(routeSource).toContain("publicSealVisible");
+  });
+});

--- a/apps/web/tests/quality-clarify.route.contract.test.ts
+++ b/apps/web/tests/quality-clarify.route.contract.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+
+import { POST as clarifyPOST } from "@/app/api/quality/clarify/route";
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/quality/clarify", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/quality/clarify route contract", () => {
+  it("returns route classification meta and marks path as not canonical legacy exception", async () => {
+    const previousKey = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "";
+    try {
+      const res = await clarifyPOST(makeRequest({ text: "Bitte den Claim klarer formulieren." }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body?.ok).toBe(true);
+      expect(body?.meta?.routeClassification?.routePath).toBe("/api/quality/clarify");
+      expect(body?.meta?.routeClassification?.canonical).toBe(false);
+      expect(body?.meta?.routeClassification?.legacyExceptionPath).toBe(true);
+      expect(body?.meta?.routeClassification?.directProviderPath).toBe(true);
+    } finally {
+      process.env.OPENAI_API_KEY = previousKey;
+    }
+  });
+});

--- a/features/ai/e150/routeClassification.ts
+++ b/features/ai/e150/routeClassification.ts
@@ -64,11 +64,23 @@ export function resolveAiRouteClassification(routePath: string): AiRouteClassifi
   if (normalized === "/api/contributions/refine") {
     return exception(normalized, "legacy_exception", "direct_provider_refine_path");
   }
+  if (normalized === "/api/contributions/analyze/save") {
+    return exception(normalized, "legacy_exception", "direct_provider_analyze_save_path");
+  }
   if (normalized === "/api/quality/polish") {
     return exception(normalized, "legacy_exception", "direct_provider_polish_path");
   }
+  if (normalized === "/api/quality/clarify") {
+    return exception(normalized, "legacy_exception", "direct_provider_clarify_path");
+  }
+  if (normalized === "/api/news/survey-topics") {
+    return exception(normalized, "legacy_exception", "direct_provider_news_survey_path");
+  }
   if (normalized === "/api/diag/gpt" || normalized === "/api/_diag/gpt") {
     return exception(normalized, "diagnostic", "diagnostic_direct_provider_path");
+  }
+  if (normalized === "/api/admin/ai/orchestrator-smoke") {
+    return exception(normalized, "diagnostic", "diagnostic_orchestrator_smoke_path");
   }
   return {
     routePath: normalized,


### PR DESCRIPTION
## Ziel

Verwertbare Factcheck-/Quality-Hardening-Änderungen aus einem alten Stash auf die aktuelle Runtime übertragen, ohne veraltete Datenbank- oder Zugriffspfade wieder einzuführen.

## Änderungen

- zusätzliche E150-Route-Klassifikationen ergänzt
- `/api/quality/clarify` um konsistente Route-Classification-Metadaten erweitert
- Factcheck-Result-Route auf `nodejs` und `force-dynamic` festgelegt
- Route-Classification auch im 404-Meta sichtbar
- heutiges Factcheck-Workflow-Repository und Zugriffsschutz vollständig beibehalten
- kein Rückfall auf direkten Collection-Zugriff
- gezielte Route- und Classification-Contracts ergänzt

## Validierung

- drei fokussierte Contract-Testdateien
- Lint
- Typecheck
- `git diff --check`
