### PR TITLE
Restore account and contact journey guardrails

### DIFF
--- a/apps/web/src/app/account/AccountClient.tsx
+++ b/apps/web/src/app/account/AccountClient.tsx
@@ -1670,7 +1670,7 @@ function CompactProfileHubSection({
   };
 
   return (
-    <section className="space-y-3 pb-[calc(env(safe-area-inset-bottom)+5.2rem)] md:pb-4">
+    <section id="interessen" className="space-y-3 pb-[calc(env(safe-area-inset-bottom)+5.2rem)] md:pb-4">
       <article className="overflow-hidden rounded-3xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-3.5 shadow-[0_16px_48px_rgba(15,23,42,0.08)] sm:p-5">
         <div className="flex items-start justify-between gap-2.5">
           <div className="flex min-w-0 items-center gap-3">

--- a/apps/web/src/app/kontakt/KontaktForm.tsx
+++ b/apps/web/src/app/kontakt/KontaktForm.tsx
@@ -162,6 +162,13 @@ export default function KontaktForm({ sent, error, challenge }: Props) {
       <p className="mt-1 text-center text-xs text-[rgb(var(--muted))]">
         {t("Wir routen dein Anliegen intern an die passende Stelle.", "lead")}
       </p>
+      <p className="mt-2 text-center text-xs text-[rgb(var(--muted))]">
+        Vertraulicher Hinweis? Nutze das{" "}
+        <Link href="/community/contributions" className="font-semibold text-[rgb(var(--fg))] underline underline-offset-4">
+          Hinweisformular
+        </Link>
+        . Hinweise werden intern geprüft und nicht automatisch an eine hostende Organisation weitergegeben.
+      </p>
       {sent && (
         <div className="mt-3 rounded-xl border border-emerald-100 bg-emerald-50/80 px-4 py-3 text-sm text-emerald-800">
           {t(
@@ -219,7 +226,7 @@ export default function KontaktForm({ sent, error, challenge }: Props) {
             <option value="juristisch">{t("Juristische / rechtliche Anfrage", "category.legal")}</option>
             <option value="presse">{t("Presse- / Interviewanfrage", "category.press")}</option>
             <option value="medien">{t("Medien / Kooperation", "category.media")}</option>
-            <option value="partei">{t("Verantwortliche Person aus Fraktion/Mandat/Organisation", "category.party")}</option>
+            <option value="partei">{t("Verantwortliche Person aus Mandat/Organisation", "category.party")}</option>
             <option value="bewerbung">{t("Bewerbung / Mitarbeit", "category.apply")}</option>
             <option value="sonstiges">{t("Sonstiges Anliegen", "category.other")}</option>
           </select>

--- a/apps/web/tests/member-system-journey-handoff.contract.test.ts
+++ b/apps/web/tests/member-system-journey-handoff.contract.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolvePostRegistrationRedirect } from "@/features/auth/roleExperienceContract";
+
+function read(relativePath: string) {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8");
+}
+
+describe("member system journey handoff contract", () => {
+  it("keeps account quick transitions to themes/swipes/pricing visible", () => {
+    const accountPage = read("src/app/account/page.tsx");
+    const accountClient = read("src/app/account/AccountClient.tsx");
+
+    expect(accountPage).toContain("<AccountClient");
+    expect(accountClient).toContain("Interessen");
+    expect(accountClient).toContain("/swipes");
+    expect(accountClient).toContain("/pricing");
+    expect(accountClient).toContain('id="interessen"');
+  });
+
+  it("keeps contact-to-confidential-hint handoff explicit", () => {
+    const kontaktForm = read("src/app/kontakt/KontaktForm.tsx");
+
+    expect(kontaktForm).toContain('href="/community/contributions"');
+    expect(kontaktForm).toContain("Vertraulicher Hinweis?");
+    expect(kontaktForm).toContain(
+      "nicht automatisch an eine hostende Organisation weitergegeben",
+    );
+  });
+
+  it("keeps post-registration redirect deterministic for public/member handoff", () => {
+    expect(resolvePostRegistrationRedirect({ roleId: "citizens" })).toBe("/swipes?welcome=1");
+    expect(
+      resolvePostRegistrationRedirect({
+        requestedRedirect: "/themen?focus=verkehr",
+        roleId: "citizens",
+      }),
+    ).toBe("/themen?focus=verkehr");
+    expect(
+      resolvePostRegistrationRedirect({
+        requestedRedirect: "https://example.org/evil",
+        roleId: "citizens",
+      }),
+    ).toBe("/swipes?welcome=1");
+  });
+});

--- a/apps/web/tests/public-journey-wording-guardrails.contract.test.ts
+++ b/apps/web/tests/public-journey-wording-guardrails.contract.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const CORE_PUBLIC_JOURNEY_FILES = [
+  "src/app/start/LandingStart.tsx",
+  "src/app/(components)/SiteHeader.tsx",
+  "src/components/mobile/MobileAppShellChrome.tsx",
+  "src/app/themen/page.tsx",
+  "src/app/swipes/SwipesClient.tsx",
+  "src/components/dossier/DossierViewer.tsx",
+  "src/app/stream/page.tsx",
+  "src/app/pricing/page.tsx",
+  "src/app/register/identity/page.tsx",
+  "src/app/account/page.tsx",
+  "src/app/account/AccountClient.tsx",
+  "src/app/community/contributions/page.tsx",
+  "src/app/kontakt/KontaktForm.tsx",
+  "src/features/create/createSurfaceConfig.ts",
+] as const;
+
+const PUBLIC_UI_LEGACY_PATTERNS: ReadonlyArray<{ label: string; pattern: RegExp }> = [
+  { label: "Beteiligungstool", pattern: /\bBeteiligungstool\b/ },
+  { label: "Parteienbuch", pattern: /\bParteienbuch\b/ },
+  { label: "Lager", pattern: /\bLager\b/ },
+  { label: "Eventualitäten", pattern: /\bEventualitäten\b/ },
+  { label: "Evidenz", pattern: /\bEvidenz\b/ },
+  { label: "Legitimitätsübersicht", pattern: /\bLegitimitätsübersicht\b/ },
+  { label: "Einordnungsfluss", pattern: /\bEinordnungsfluss\b/ },
+];
+
+describe("public journey wording guardrails", () => {
+  it("keeps legacy terms out of core public/member journey UI files", () => {
+    const joined = CORE_PUBLIC_JOURNEY_FILES.map((file) =>
+      readFileSync(resolve(process.cwd(), file), "utf8"),
+    ).join("\n");
+
+    PUBLIC_UI_LEGACY_PATTERNS.forEach(({ label, pattern }) => {
+      expect(joined, `legacy public UI wording found: ${label}`).not.toMatch(pattern);
+    });
+  });
+});


### PR DESCRIPTION
## Ziel

Verwertbare Account-/Kontakt-/Journey-Änderungen aus einem alten Stash gezielt auf den aktuellen Stand übertragen, ohne die moderne Account-Architektur zurückzusetzen.

## Änderungen

- stabilen `#interessen`-Anchor im aktuellen Account-Hub ergänzt
- Kontaktseite mit explizitem Verweis auf das vertrauliche Hinweisformular verbunden
- klarstellt, dass Hinweise intern geprüft und nicht automatisch an hostende Organisationen weitergegeben werden
- Member-Journey-Contract an die heutige AccountClient-Architektur angepasst
- öffentlicher Wording-Guardrail ergänzt
- keine Rückkehr zur alten Account-Page-Navigation
- keine alten UX-Audit-Dokumente übernommen

## Validierung

- Member-System-Journey-Handoff-Contract
- Public-Journey-Wording-Guardrail
- Lint
- Typecheck
- `git diff --check`
